### PR TITLE
Enhance Refresh action to allow SSID and password updation

### DIFF
--- a/src/framework/ow_constants.h
+++ b/src/framework/ow_constants.h
@@ -226,8 +226,7 @@ namespace OpenWifi::RESTAPI::Errors {
 		1102, "Provisioning service not available yet."
 	};
 	static const struct msg SSIDInvalidPassword {
-		1103, "Invalid password length. Must be 8 characters or greater, and a maximum of 32 "
-			  "characters."
+		1103, "Invalid password length. Must be between 8 and 32 characters without spaces."
 	};
 	static const struct msg InvalidStartingIPAddress {
 		1104, "Invalid starting/ending IP address."
@@ -432,7 +431,9 @@ namespace OpenWifi::RESTAPI::Errors {
     static const struct msg InvalidRadiusServer { 1191, "Invalid Radius Server." };
 
 	static const struct msg InvalidRRMAction { 1192, "Invalid RRM Action." };
-
+	static const struct msg SSIDInvalidName{
+		1193, "Invalid SSID. Allowed characters: 1 to 32 chars (letters, digits, dot, underscore, hyphen, space.)"};
+	static const struct msg ConfigNotFound { 1194, "Configuration not available for this device." };
     static const struct msg SimulationDoesNotExist {
         7000, "Simulation Instance ID does not exist."
     };

--- a/src/sdks/SDK_gw.h
+++ b/src/sdks/SDK_gw.h
@@ -16,12 +16,12 @@ namespace OpenWifi::SDK::GW {
 					 bool KeepRedirector);
 		void Upgrade(RESTAPIHandler *client, const std::string &Mac, uint64_t When,
 					 const std::string &ImageName, bool KeepRedirector);
-		void Refresh(RESTAPIHandler *client, const std::string &Mac, uint64_t When);
 		void PerformCommand(RESTAPIHandler *client, const std::string &Command,
 							const std::string &EndPoint, Poco::JSON::Object &CommandRequest);
 		bool Configure(RESTAPIHandler *client, const std::string &Mac,
 					   Poco::JSON::Object::Ptr &Configuration, Poco::JSON::Object::Ptr &Response);
-
+		Poco::Net::HTTPResponse::HTTPStatus SetConfig(RESTAPIHandler *client, const std::string &SerialNumber,
+				   const Poco::JSON::Object::Ptr &Body, std::string &status);
 		bool SetVenue(RESTAPIHandler *client, const std::string &SerialNumber,
 					  const std::string &uuid);
 		bool GetLastStats(RESTAPIHandler *client, const std::string &Mac,

--- a/src/storage/storage_subscriber_info.cpp
+++ b/src/storage/storage_subscriber_info.cpp
@@ -62,7 +62,7 @@ namespace OpenWifi {
 		int ap_num = 1;
 		for (const auto &i : Devices.subscriberDevices) {
 			SubObjects::AccessPoint AP;
-			AP.macAddress = i.realMacAddress;
+			AP.macAddress = i.serialNumber;
 			AP.serialNumber = i.serialNumber;
 			AP.deviceType = i.deviceType;
 			AP.id = i.info.id;


### PR DESCRIPTION
[#2 ]
**Problem Fixed**
Previously, the Refresh action did not allow subscribers to update Wi-Fi credentials. SSID and password changes could only be made manually through the Provisioning-UI, requiring operator intervention.

**Key Changes:-**
  **RESTAPI_action_handler.cpp**
   - Added logic to accept optional `ssid` and `password` parameters from the Refresh request.
   - Validates SSID and password format before applying.
   
  **ow_constants.h**
   - Introduced constants for new parameter handling.
   
  **SDK_gw.cpp / SDK_gw.h**
   - Extended gateway SDK functions to apply configuration updates with SSID/password overrides.
   
**Outcome**
   - If no overrides are provided, Refresh continues to work without altering device configuration.
   - If SSID or password overrides are provided, they are updated safely in the device configuration and pushed in device.
   
Kindly review the changes and let me know if any modifications are needed.
   