### PR TITLE
Fixed values for correct default config generation in owsub /subscriber

### DIFF
--- a/src/ConfigMaker.cpp
+++ b/src/ConfigMaker.cpp
@@ -89,6 +89,10 @@ namespace OpenWifi {
                   ]
                 },
                 "health": {
+                  "dns-remote": true,
+                  "dns-local": true,
+                  "dhcp-remote": false,
+                  "dhcp-local": true,
                   "interval": 60
                 },
                 "statistics": {
@@ -125,8 +129,7 @@ namespace OpenWifi {
                     "location": "universe"
                 },
                 "ssh": {
-                    "authorized-keys": [],
-                    "password-authentication": false,
+                    "password-authentication": true,
                     "port": 22
                 }
             }
@@ -153,6 +156,13 @@ namespace OpenWifi {
 				AllBands.emplace_back(ConvertBand(rr.band));
 
 			nlohmann::json UpstreamPort, DownstreamPort;
+			auto addPortDefaults = [](nlohmann::json &Port) { // used a lambda func to avoid code duplication
+				Port["vlan-tag"] = "auto";
+				Port["reverse-path"] = false;
+				Port["isolate"] = false;
+				Port["learning"] = true;
+				Port["multicast"] = true;
+			};
 			if (i.internetConnection.type == "manual") {
 				UpstreamInterface["addressing"] = "static";
 				UpstreamInterface["subnet"] = i.internetConnection.subnetMask;
@@ -164,6 +174,7 @@ namespace OpenWifi {
 			} else if (i.internetConnection.type == "pppoe") {
 				nlohmann::json Port;
 				Port["select-ports"].push_back("WAN*");
+				addPortDefaults(Port);
 				UpstreamInterface["ethernet"].push_back(Port);
 				UpstreamInterface["broad-band"]["protocol"] = "pppoe";
 				UpstreamInterface["broad-band"]["user-name"] = i.internetConnection.username;
@@ -176,6 +187,7 @@ namespace OpenWifi {
 				Port["select-ports"].push_back("WAN*");
 				if (i.deviceMode.type == "bridge")
 					Port["select-ports"].push_back("LAN*");
+				addPortDefaults(Port);
 				UpstreamInterface["ethernet"].push_back(Port);
 				UpstreamInterface["ipv4"]["addressing"] = "dynamic";
 				if (i.internetConnection.ipV6Support)
@@ -185,9 +197,12 @@ namespace OpenWifi {
 			if (i.deviceMode.type == "bridge") {
 				UpstreamPort["select-ports"].push_back("LAN*");
 				UpstreamPort["select-ports"].push_back("WAN*");
+				addPortDefaults(UpstreamPort);
 			} else if (i.deviceMode.type == "manual") {
-				UpstreamPort.push_back("WAN*");
-				DownstreamPort.push_back("LAN*");
+				UpstreamPort["select-ports"].push_back("WAN*"); // puts WAN in select-ports for UpstreamPort object
+				DownstreamPort["select-ports"].push_back("LAN*");
+				addPortDefaults(UpstreamPort);
+				addPortDefaults(DownstreamPort);
 				DownstreamInterface["name"] = "LAN";
 				DownstreamInterface["role"] = "downstream";
 				DownstreamInterface["services"].push_back("lldp");
@@ -198,6 +213,8 @@ namespace OpenWifi {
 				CreateDHCPInfo(i.deviceMode.subnet, i.deviceMode.startIP, i.deviceMode.endIP,
 							   FirstIPInRange, HowMany);
 				DownstreamInterface["ipv4"]["subnet"] = i.deviceMode.subnet;
+				DownstreamInterface["ipv4"]["send-hostname"] = false;
+				DownstreamInterface["ipv4"]["gateway"] = "192.168.1.1";
 				DownstreamInterface["ipv4"]["dhcp"]["lease-first"] = FirstIPInRange;
 				DownstreamInterface["ipv4"]["dhcp"]["lease-count"] = HowMany;
 				DownstreamInterface["ipv4"]["dhcp"]["lease-time"] =
@@ -205,6 +222,8 @@ namespace OpenWifi {
 			} else if (i.deviceMode.type == "nat") {
 				UpstreamPort["select-ports"].push_back("WAN*");
 				DownstreamPort["select-ports"].push_back("LAN*");
+				addPortDefaults(UpstreamPort);
+				addPortDefaults(DownstreamPort);
 				DownstreamInterface["name"] = "LAN";
 				DownstreamInterface["role"] = "downstream";
 				DownstreamInterface["services"].push_back("lldp");
@@ -215,6 +234,8 @@ namespace OpenWifi {
 				CreateDHCPInfo(i.deviceMode.subnet, i.deviceMode.startIP, i.deviceMode.endIP,
 							   FirstIPInRange, HowMany);
 				DownstreamInterface["ipv4"]["subnet"] = i.deviceMode.subnet;
+				DownstreamInterface["ipv4"]["send-hostname"] = false;
+				DownstreamInterface["ipv4"]["gateway"] = "192.168.1.1";
 				DownstreamInterface["ipv4"]["dhcp"]["lease-first"] = FirstIPInRange;
 				DownstreamInterface["ipv4"]["dhcp"]["lease-count"] = HowMany;
 				DownstreamInterface["ipv4"]["dhcp"]["lease-time"] =
@@ -231,6 +252,12 @@ namespace OpenWifi {
 					ssid["wifi-bands"] = ConvertBands(j.bands);
 				}
 				ssid["bss-mode"] = "ap";
+				ssid["tip-information-element"] = true;
+				ssid["dtim-period"] = 2;
+				ssid["fils-discovery-interval"] = 20;
+				ssid["maximum-clients"] = 64;
+				ssid["services"] = nlohmann::json::array();
+				ssid["hidden-ssid"] = false;
 				if (j.encryption == "wpa1-personal") {
 					ssid["encryption"]["proto"] = "psk";
 					ssid["encryption"]["ieee80211w"] = "disabled";
@@ -248,7 +275,9 @@ namespace OpenWifi {
 					ssid["encryption"]["ieee80211w"] = "disabled";
 				}
 				ssid["encryption"]["key"] = j.password;
+				ssid["encryption"]["key-caching"] = true;
 				if (j.type == "main") {
+					ssid["isolate-clients"] = false;
 					main_ssids.push_back(ssid);
 				} else {
 					hasGuest = true;
@@ -264,9 +293,11 @@ namespace OpenWifi {
 
 			nlohmann::json UpStreamEthernet, DownStreamEthernet;
 			if (!UpstreamPort.empty()) {
+				addPortDefaults(UpstreamPort);
 				UpStreamEthernet.push_back(UpstreamPort);
 			}
 			if (!DownstreamPort.empty()) {
+				addPortDefaults(DownstreamPort);
 				DownStreamEthernet.push_back(DownstreamPort);
 			}
 
@@ -317,26 +348,21 @@ namespace OpenWifi {
 					radio["allow-dfs"] = true;
 				if (!k.mimo.empty())
 					radio["mimo"] = k.mimo;
-				radio["legacy-rates"] = k.legacyRates;
 				radio["beacon-interval"] = k.beaconInterval;
-				radio["dtim-period"] = k.dtimPeriod;
 				radio["maximum-clients"] = k.maximumClients;
 				radio["rates"]["beacon"] = k.rates.beacon;
 				radio["rates"]["multicast"] = k.rates.multicast;
-				radio["he-settings"]["multiple-bssid"] = k.he.multipleBSSID;
-				radio["he-settings"]["ema"] = k.he.ema;
-				radio["he-settings"]["bss-color"] = k.he.bssColor;
 				radios.push_back(radio);
 			}
 
 			ProvObjects::DeviceConfigurationElement Metrics{.name = "metrics",
 															.description = "default metrics",
-															.weight = 0,
+															.weight = 1,
 															.configuration = to_string(metrics)};
 
 			ProvObjects::DeviceConfigurationElement Services{.name = "services",
 															 .description = "default services",
-															 .weight = 0,
+															 .weight = 1,
 															 .configuration = to_string(services)};
 
 			nlohmann::json InterfaceSection;
@@ -344,14 +370,14 @@ namespace OpenWifi {
 			ProvObjects::DeviceConfigurationElement InterfacesList{
 				.name = "interfaces",
 				.description = "default interfaces",
-				.weight = 0,
+				.weight = 1,
 				.configuration = to_string(InterfaceSection)};
 
 			nlohmann::json RadiosSection;
 			RadiosSection["radios"] = radios;
 			ProvObjects::DeviceConfigurationElement RadiosList{.name = "radios",
 															   .description = "default radios",
-															   .weight = 0,
+															   .weight = 1,
 															   .configuration =
 																   to_string(RadiosSection)};
 

--- a/src/storage/storage_subscriber_info.cpp
+++ b/src/storage/storage_subscriber_info.cpp
@@ -82,7 +82,7 @@ namespace OpenWifi {
 			WN.type = "main";
 			WN.name = "OpenWifi-" + AP.macAddress.substr(6);
 			WN.password = Poco::toUpper(AP.macAddress);
-			WN.encryption = "wpa2-personal";
+			WN.encryption = "wpa1-personal";
 			if (AP.deviceType == "linksys_ea8300") {
 				WN.bands.emplace_back("2G");
 				WN.bands.emplace_back("5GL");
@@ -104,13 +104,8 @@ namespace OpenWifi {
 				RI.channel = 0;
 				RI.country = i.locale;
 				RI.maximumClients = 64;
-				RI.legacyRates = false;
-				RI.he.bssColor = 1;
-				RI.he.ema = false;
-				RI.he.multipleBSSID = false;
 				RI.beaconInterval = 100;
-				RI.dtimPeriod = 2;
-				RI.allowDFS = false;
+				RI.allowDFS = true;
 				RI.mimo = "";
 				RI.txpower = 24;
 				if (b == "2G") {


### PR DESCRIPTION
[#4 ]
### Problem Fixed:-

GET /subscriber was generating a default config with missing/wrong values and unsupported fields compared to Provisioning-UI. This PR aligns owsub’s generated config with UI so it validates cleanly and pushes correct values to devices.

**Key Changes**

Change the various values present in the ConfigMaker.cpp and remove the extra radio fields from storage_subscriber_info.cpp to ensure owsub sends correct configuration to the device:-

- **Metrics** → Health: added dns-remote:true, dns-local:true, dhcp-remote:false, dhcp-local:true.
- **Services** → SSH: set "password-authentication": true; removed "authorized-keys":[ ].
- **SSIDs**: added UI supported values (dtim-period:2, fils-discovery-interval:20, maximum-clients:64) .
- **Interfaces** → Ethernet: fixed structure to always include defaults (vlan-tag:auto, reverse-path:false, isolate:false, learning:true, multicast:true).
- **Radios**: Removed unsupported fields (legacy-rates, radio-level dtim-period, he-settings); kept only UI-accepted values.
- **Section weights**: Changed value from 0 → 1 for metrics, services, interfaces, and radios.

**Current Behaviour**

When GET/subscriber api is called after a new subscriber verifies his e-mail address, a new configuration is created which contains correct and valid fields supported by the Provisioning-UI and is also sent to the connected device.

<img width="1111" height="880" alt="image" src="https://github.com/user-attachments/assets/fdd1cff8-3944-4e6e-a41a-de13f2629a8e" />

<img width="1919" height="747" alt="image" src="https://github.com/user-attachments/assets/a6d23f97-3f7d-46de-ab65-fef1f9309a2e" />

<img width="955" height="896" alt="image" src="https://github.com/user-attachments/assets/f2d350a2-16ea-4df2-a7c6-618c4ab78634" />


****Kindly review the changes and let me know if any modifications are needed.****