### PR TITLE
Add support for POST /signup and DELETE /subscriber APIs

### DIFF
--- a/src/ConfigMaker.cpp
+++ b/src/ConfigMaker.cpp
@@ -1,3 +1,9 @@
+/*
+ * SPDX-License-Identifier: AGPL-3.0 OR LicenseRef-Commercial
+ * Copyright (c) 2025 Infernet Systems Pvt Ltd
+ * Portions copyright (c) Telecom Infra Project (TIP), BSD-3-Clause
+ */
+
 //
 // Created by stephane bourque on 2021-12-13.
 //
@@ -376,6 +382,7 @@ namespace OpenWifi {
 					"Could not find Subscriber device in provisioning for {}", i.serialNumber));
 			}
 			SDK::GW::Device::SetSubscriber(nullptr, i.serialNumber, SI.id);
+			SDK::Prov::Subscriber::UpdateSubscriber(nullptr, SI.id, i.serialNumber, false);
 		}
 		SI.modified = Utils::Now();
 		return StorageService()->SubInfoDB().UpdateRecord("id", id_, SI);

--- a/src/RESTAPI/RESTAPI_signup_handler.cpp
+++ b/src/RESTAPI/RESTAPI_signup_handler.cpp
@@ -1,3 +1,9 @@
+/*
+ * SPDX-License-Identifier: AGPL-3.0 OR LicenseRef-Commercial
+ * Copyright (c) 2025 Infernet Systems Pvt Ltd
+ * Portions copyright (c) Telecom Infra Project (TIP), BSD-3-Clause
+ */
+
 //
 // Created by stephane bourque on 2022-02-20.
 //
@@ -14,6 +20,7 @@ namespace OpenWifi {
 		Poco::toLowerInPlace(UserName);
 		Poco::trimInPlace(UserName);
 
+		// Serial number is actually the MAC address of the device
 		auto SerialNumber = GetParameter("macAddress");
 		Poco::toLowerInPlace(SerialNumber);
 		Poco::trimInPlace(SerialNumber);
@@ -21,6 +28,8 @@ namespace OpenWifi {
 		auto registrationId = GetParameter("registrationId");
 		Poco::toLowerInPlace(registrationId);
 		Poco::trimInPlace(registrationId);
+
+		Logger().information(fmt::format("Signup request is coming for email: {} macAddress: {} registrationId: {}", UserName,SerialNumber, registrationId));
 
 		if (!Utils::ValidSerialNumber(SerialNumber)) {
 			return BadRequest(RESTAPI::Errors::InvalidSerialNumber);
@@ -37,20 +46,4 @@ namespace OpenWifi {
 		return API_Proxy(Logger(), Request, Response, uSERVICE_PROVISIONING.c_str(),
 						 "/api/v1/signup", 60000);
 	}
-
-	void RESTAPI_signup_handler::DoPut() {
-		return API_Proxy(Logger(), Request, Response, uSERVICE_PROVISIONING.c_str(),
-						 "/api/v1/signup", 60000);
-	}
-
-	void RESTAPI_signup_handler::DoGet() {
-		return API_Proxy(Logger(), Request, Response, uSERVICE_PROVISIONING.c_str(),
-						 "/api/v1/signup", 60000);
-	}
-
-	void RESTAPI_signup_handler::DoDelete() {
-		return API_Proxy(Logger(), Request, Response, uSERVICE_PROVISIONING.c_str(),
-						 "/api/v1/signup", 60000);
-	}
-
 } // namespace OpenWifi

--- a/src/RESTAPI/RESTAPI_signup_handler.h
+++ b/src/RESTAPI/RESTAPI_signup_handler.h
@@ -1,3 +1,9 @@
+/*
+ * SPDX-License-Identifier: AGPL-3.0 OR LicenseRef-Commercial
+ * Copyright (c) 2025 Infernet Systems Pvt Ltd
+ * Portions copyright (c) Telecom Infra Project (TIP), BSD-3-Clause
+ */
+
 //
 // Created by stephane bourque on 2022-02-20.
 //
@@ -14,26 +20,15 @@ namespace OpenWifi {
 							   bool Internal)
 			: RESTAPIHandler(bindings, L,
 							 std::vector<std::string>{Poco::Net::HTTPRequest::HTTP_POST,
-													  Poco::Net::HTTPRequest::HTTP_OPTIONS,
-													  Poco::Net::HTTPRequest::HTTP_PUT,
-													  Poco::Net::HTTPRequest::HTTP_GET,
-													  Poco::Net::HTTPRequest::HTTP_DELETE},
+													  Poco::Net::HTTPRequest::HTTP_OPTIONS},
 							 Server, TransactionId, Internal, false, true) {}
 
 		static auto PathName() { return std::list<std::string>{"/api/v1/signup"}; };
 
-		/*        inline bool RoleIsAuthorized(std::string & Reason) {
-					if(UserInfo_.userinfo.userRole != SecurityObjects::USER_ROLE::SUBSCRIBER) {
-						Reason = "User must be a subscriber";
-						return false;
-					}
-					return true;
-				}
-		*/
-		void DoGet() final;
+		void DoGet() final {};
 		void DoPost() final;
-		void DoPut() final;
-		void DoDelete() final;
+		void DoPut() final {};
+		void DoDelete() final {};
 
 	  private:
 	};

--- a/src/framework/ow_constants.h
+++ b/src/framework/ow_constants.h
@@ -89,7 +89,7 @@ namespace OpenWifi::RESTAPI::Errors {
 	static const struct msg ConfigurationMustExist { 1017, "Configuration must exist." };
 	static const struct msg MissingOrInvalidParameters { 1018, "Invalid or missing parameters." };
 	static const struct msg UnknownSerialNumber { 1019, "Unknown Serial Number." };
-	static const struct msg InvalidSerialNumber { 1020, "Invalid Serial Number." };
+	static const struct msg InvalidSerialNumber { 1020, "Invalid Serial Number or MAC address" };
 	static const struct msg SerialNumberExists { 1021, "Serial Number already exists." };
 	static const struct msg ValidNonRootUUID { 1022, "Must be a non-root, and valid UUID." };
 	static const struct msg VenueMustExist { 1023, "Venue does not exist." };
@@ -584,7 +584,7 @@ namespace OpenWifi::RESTAPI::Protocol {
 
 namespace OpenWifi::uCentralProtocol {
 
-	const int SERIAL_NUMBER_LENGTH = 30;
+	const int SERIAL_NUMBER_LENGTH = 12;
 
 	// vocabulary used in the PROTOCOL.md file
 	static const char *JSONRPC = "jsonrpc";

--- a/src/framework/utils.cpp
+++ b/src/framework/utils.cpp
@@ -1,3 +1,9 @@
+/*
+ * SPDX-License-Identifier: AGPL-3.0 OR LicenseRef-Commercial
+ * Copyright (c) 2025 Infernet Systems Pvt Ltd
+ * Portions copyright (c) Telecom Infra Project (TIP), BSD-3-Clause
+ */
+
 //
 // Created by stephane bourque on 2022-10-25.
 //
@@ -32,7 +38,7 @@ namespace OpenWifi::Utils {
 	}
 
 	[[nodiscard]] bool ValidSerialNumber(const std::string &Serial) {
-		return ((Serial.size() < uCentralProtocol::SERIAL_NUMBER_LENGTH) &&
+		return ((Serial.size() == uCentralProtocol::SERIAL_NUMBER_LENGTH) &&
 				std::all_of(Serial.begin(), Serial.end(), [](auto i) { return std::isxdigit(i); }));
 	}
 

--- a/src/sdks/SDK_gw.cpp
+++ b/src/sdks/SDK_gw.cpp
@@ -178,6 +178,8 @@ namespace OpenWifi::SDK::GW {
 			auto ResponseStatus =
 				R.Do(CallResponse, client ? client->UserInfo_.webtoken.access_token_ : "");
 			if (ResponseStatus == Poco::Net::HTTPResponse::HTTP_OK) {
+				Poco::Logger::get("SDK_gw").information(fmt::format(
+					"SetSubscriber: Successfully set subscriber [{}] for device {}.", SerialNumber, uuid));
 				return true;
 			}
 			return false;

--- a/src/sdks/SDK_prov.h
+++ b/src/sdks/SDK_prov.h
@@ -1,3 +1,9 @@
+/*
+ * SPDX-License-Identifier: AGPL-3.0 OR LicenseRef-Commercial
+ * Copyright (c) 2025 Infernet Systems Pvt Ltd
+ * Portions copyright (c) Telecom Infra Project (TIP), BSD-3-Clause
+ */
+
 //
 // Created by stephane bourque on 2022-01-11.
 //
@@ -31,8 +37,8 @@ namespace OpenWifi::SDK::Prov {
 	namespace Subscriber {
 		bool GetDevices(RESTAPIHandler *client, const std::string &SubscriberId,
 						const std::string &OperatorId, ProvObjects::SubscriberDeviceList &devList);
-		bool ReturnDeviceToInventory(RESTAPIHandler *client, const std::string &SubscriberId,
-									 const std::string &SerialNumber);
+		bool UpdateSubscriber(RESTAPIHandler *client, const std::string &SubscriberId,
+									 const std::string &SerialNumber, bool removeSubscriber = false);
 		bool SetDevice(RESTAPIHandler *client, const ProvObjects::SubscriberDevice &D);
 		bool GetDevice(RESTAPIHandler *client, const std::string &SerialNumber,
 					   ProvObjects::SubscriberDevice &D);


### PR DESCRIPTION
[#1] [USERPORTAL][SIGNUP] Add support for POST /signup and DELETE /subscriber APIs

Fix Type: Feature

Root Cause:
- The OWSUB component did not previously support subscriber creation or deletion through API endpoints.

Solution:
Implemented API handlers for:
- POST /signup — to register a new subscriber via device MAC and registration ID
- DELETE /subscriber — to remove an existing subscriber entry


```
POST /api/v1/signup
{
"email": "
"macAddress": "
"registrationId": "
}
Description: This endpoint is used by a device to register a new subscriber account.
It associates the user’s email address, device MAC address, and registration operator ID to create a new account and initiate email verification.
The email address is used as the user name.
The macAddress is the MAC address of the device.
The registrationId is the registration operator name (e.g. airtel-up-west-201304).

Flow of signup request:

- The request is received by the User Portal API server.
- The API server validates the email, macAddress, and registrationId parameters.
- The request is forwarded to the Provisioning (OWPROV) microservice.
- OWPROV performs the following checks:
   -- If the MAC address is new — it creates a new user record linked to the provided email and registration operator.
   -- If the MAC address already exists — it returns an error indicating that the device is already registered.
- OWPROV sends a POST /api/v1/signup request to the Security (OWSEC) service to create the subscriber account.
- OWSEC creates the subscriber record with status waiting-for-email-verification and sends a verification email to the user.
- OWPROV returns the response to the User Portal API server.
- The API server returns the response to the device.

When the user verifies their email, OWSEC updates the account status to signup completed and prompts the user to set a password.



Error Handling:
- 200 OK: The signup request was successful, and the user account has been created. The response includes a message indicating that a verification email has been sent.
- 400 Bad Request: The request is malformed or missing required fields (email, macAddress, registrationId).
```

```
DELETE /subscriber

	Description:
	- Delete all devices associated with the subscriber in owprov.
	- Delete the subscriber in owsec.
	- Note that the actual devices are not deleted, just unlinked from the subscriber.

	Flow of delete susbrciber api end-to-end:
	- owsub receives DELETE /subscriber request.
	- owsub retrieves subscriber info from SubInfoDB using user ID.
	- For each access point linked to the subscriber:
		- If the access point has a serial number:
		- Sends PUT /inventory?removeSubscriber=true to owprov.
		    - owprov checks if the subscriber matches the one in the inventory record.
		    - Delete the device default configuration
		    - Clear the subscriber field in the inventory record
		    - Change the devClass field to ANY
		    - Sends a POST /configure to owgw  with empty subscriber
	- DELETE /subscrber owsec to delete the subscriber information from database
	- Deletes the subscriber record OWSUB db
	- Returns appropriate HTTP response based on the operation's success or failure.

	Device state:
		- The device remains connected and still communicating with owgw,
		- but the subscriber account is fully removed from owprov and owsec.
```