### PR TITLE
Add support for configuring SSID and password

### DIFF
--- a/src/RESTAPI/RESTAPI_action_handler.cpp
+++ b/src/RESTAPI/RESTAPI_action_handler.cpp
@@ -1,3 +1,9 @@
+/*
+ * SPDX-License-Identifier: AGPL-3.0 OR LicenseRef-Commercial
+ * Copyright (c) 2025 Infernet Systems Pvt Ltd
+ * Portions copyright (c) Telecom Infra Project (TIP), BSD-3-Clause
+ */
+
 //
 // Created by stephane bourque on 2021-11-30.
 //
@@ -53,12 +59,22 @@ namespace OpenWifi {
 													keepRedirector);
 				} else if (Command == "factory") {
 					return SDK::GW::Device::Factory(this, i.serialNumber, When, keepRedirector);
-				} else if (Command == "refresh") {
-					ConfigMaker InitialConfig(Logger(), UserInfo_.userinfo.id);
-					if (InitialConfig.Prepare())
-						return OK();
-					else
-						return InternalError(RESTAPI::Errors::SubConfigNotRefreshed);
+				} else if (Command == "configure") {
+					std::string status{};
+					auto Response = SDK::GW::Device::SetConfig(this, i.serialNumber, Body, status);
+					if (Response != Poco::Net::HTTPServerResponse::HTTP_OK) {
+						if (status == "MissingOrInvalidParameters") {
+							return BadRequest(RESTAPI::Errors::MissingOrInvalidParameters,"Required Parameters are missing.");
+						} else if (status == "DeviceNotConnected") {
+							return BadRequest(RESTAPI::Errors::DeviceNotConnected);
+						} else if (status == "SSIDInvalidName") {
+							return BadRequest(RESTAPI::Errors::SSIDInvalidName);
+						} else if (status == "SSIDInvalidPassword") {
+							return BadRequest(RESTAPI::Errors::SSIDInvalidPassword);
+						}
+						return BadRequest(RESTAPI::Errors::InternalError, status);
+					}
+					return OK();
 				} else {
 					return BadRequest(RESTAPI::Errors::MissingOrInvalidParameters);
 				}

--- a/src/framework/ow_constants.h
+++ b/src/framework/ow_constants.h
@@ -1,3 +1,9 @@
+/*
+ * SPDX-License-Identifier: AGPL-3.0 OR LicenseRef-Commercial
+ * Copyright (c) 2025 Infernet Systems Pvt Ltd
+ * Portions copyright (c) Telecom Infra Project (TIP), BSD-3-Clause
+ */
+
 //
 // Created by stephane bourque on 2022-02-21.
 //
@@ -226,8 +232,7 @@ namespace OpenWifi::RESTAPI::Errors {
 		1102, "Provisioning service not available yet."
 	};
 	static const struct msg SSIDInvalidPassword {
-		1103, "Invalid password length. Must be 8 characters or greater, and a maximum of 32 "
-			  "characters."
+		1103, "Invalid password length. Must be between 8 and 32 characters without spaces."
 	};
 	static const struct msg InvalidStartingIPAddress {
 		1104, "Invalid starting/ending IP address."
@@ -432,7 +437,8 @@ namespace OpenWifi::RESTAPI::Errors {
     static const struct msg InvalidRadiusServer { 1191, "Invalid Radius Server." };
 
 	static const struct msg InvalidRRMAction { 1192, "Invalid RRM Action." };
-
+	static const struct msg SSIDInvalidName{
+		1193, "Invalid SSID. Allowed characters: 1 to 32 chars (letters, digits, dot, underscore, hyphen, space.)"};
     static const struct msg SimulationDoesNotExist {
         7000, "Simulation Instance ID does not exist."
     };

--- a/src/sdks/SDK_gw.h
+++ b/src/sdks/SDK_gw.h
@@ -1,3 +1,9 @@
+/*
+ * SPDX-License-Identifier: AGPL-3.0 OR LicenseRef-Commercial
+ * Copyright (c) 2025 Infernet Systems Pvt Ltd
+ * Portions copyright (c) Telecom Infra Project (TIP), BSD-3-Clause
+ */
+
 //
 // Created by stephane bourque on 2022-01-11.
 //
@@ -16,12 +22,12 @@ namespace OpenWifi::SDK::GW {
 					 bool KeepRedirector);
 		void Upgrade(RESTAPIHandler *client, const std::string &Mac, uint64_t When,
 					 const std::string &ImageName, bool KeepRedirector);
-		void Refresh(RESTAPIHandler *client, const std::string &Mac, uint64_t When);
 		void PerformCommand(RESTAPIHandler *client, const std::string &Command,
 							const std::string &EndPoint, Poco::JSON::Object &CommandRequest);
 		bool Configure(RESTAPIHandler *client, const std::string &Mac,
 					   Poco::JSON::Object::Ptr &Configuration, Poco::JSON::Object::Ptr &Response);
-
+		Poco::Net::HTTPResponse::HTTPStatus SetConfig(RESTAPIHandler *client, const std::string &SerialNumber,
+				   const Poco::JSON::Object::Ptr &Body, std::string &status);
 		bool SetVenue(RESTAPIHandler *client, const std::string &SerialNumber,
 					  const std::string &uuid);
 		bool GetLastStats(RESTAPIHandler *client, const std::string &Mac,

--- a/src/storage/storage_subscriber_info.cpp
+++ b/src/storage/storage_subscriber_info.cpp
@@ -1,3 +1,9 @@
+/*
+ * SPDX-License-Identifier: AGPL-3.0 OR LicenseRef-Commercial
+ * Copyright (c) 2025 Infernet Systems Pvt Ltd
+ * Portions copyright (c) Telecom Infra Project (TIP), BSD-3-Clause
+ */
+
 //
 // Created by stephane bourque on 2021-11-29.
 //
@@ -62,7 +68,7 @@ namespace OpenWifi {
 		int ap_num = 1;
 		for (const auto &i : Devices.subscriberDevices) {
 			SubObjects::AccessPoint AP;
-			AP.macAddress = i.realMacAddress;
+			AP.macAddress = i.serialNumber;
 			AP.serialNumber = i.serialNumber;
 			AP.deviceType = i.deviceType;
 			AP.id = i.info.id;


### PR DESCRIPTION
[#2] [USERPORTAL][CONFIGURE] Add support for configuring SSID and password
Fix Type: Feature
Root Cause:
  The 'configure' command was not supported, and there was no functionality
  to set the SSID or password for a network.

Solutions:
  Implemented support for the 'configure' action to allow users to modify
  the SSID and password settings.