### PR TITLE
Add venue creation + monitoring on GET /subscriber

### DIFF
--- a/src/ConfigMaker.cpp
+++ b/src/ConfigMaker.cpp
@@ -503,7 +503,7 @@ namespace OpenWifi {
 					"Could not find Subscriber device in provisioning for {}", i.serialNumber));
 			}
 			SDK::GW::Device::SetSubscriber(nullptr, i.serialNumber, SI.id);
-			SDK::Prov::Subscriber::UpdateSubscriber(nullptr, SI.id, i.serialNumber, false);
+			SDK::Prov::Subscriber::SetSubscriber(nullptr, SI.id, i.serialNumber, false);
 		}
 		SI.modified = Utils::Now();
 		return StorageService()->SubInfoDB().UpdateRecord("id", id_, SI);

--- a/src/RESTAPI/RESTAPI_subscriber_devices_handler.cpp
+++ b/src/RESTAPI/RESTAPI_subscriber_devices_handler.cpp
@@ -110,7 +110,7 @@ namespace OpenWifi {
 		ProvObjects::SubscriberDeviceList devices;
 		devices.subscriberDevices.push_back(dev);
 
-		StorageService()->SubInfoDB().CreateDefaultSubscriberInfo(UserInfo_, ctx.SubscriberInfo, devices);
+		StorageService()->SubInfoDB().BuildDefaultSubscriberInfo(UserInfo_, ctx.SubscriberInfo, devices);
 
 		ConfigMaker InitialConfig(Logger(), ctx.SubscriberInfo.id);
 		if (!SDK::Prov::Subscriber::GetDevice(this, ctx.SubscriberInfo.accessPoints.list[0].macAddress, ctx.SubDevice)) {
@@ -202,7 +202,7 @@ namespace OpenWifi {
 			return false;
 		}
 
-		if (!SDK::Prov::Subscriber::UpdateSubscriber(this, UserInfo_.userinfo.id, ctx.Mac, false)) {
+		if (!SDK::Prov::Subscriber::SetSubscriber(this, UserInfo_.userinfo.id, ctx.Mac, false)) {
 			Logger().error(fmt::format("Couldn't link device: {} to subscriber: {} in inventory.", ctx.Mac, UserInfo_.userinfo.id));
 			InternalError(RESTAPI::Errors::RecordNotUpdated);
 			return false;

--- a/src/RESTAPI/RESTAPI_subscriber_handler.h
+++ b/src/RESTAPI/RESTAPI_subscriber_handler.h
@@ -1,3 +1,8 @@
+/*
+ * SPDX-License-Identifier: AGPL-3.0 OR LicenseRef-Commercial
+ * Copyright (c) 2025 Infernet Systems Pvt Ltd
+ * Portions copyright (c) Telecom Infra Project (TIP), BSD-3-Clause
+ */
 //
 // Created by stephane bourque on 2021-11-07.
 //
@@ -7,6 +12,14 @@
 #include "framework/RESTAPI_Handler.h"
 
 namespace OpenWifi {
+	namespace SubObjects {
+		struct SubscriberInfo;
+	}
+	namespace ProvObjects {
+		struct SubscriberDeviceList;
+		struct SubscriberDevice;
+	}
+
 	class RESTAPI_subscriber_handler : public RESTAPIHandler {
 	  public:
 		RESTAPI_subscriber_handler(const RESTAPIHandler::BindingMap &bindings, Poco::Logger &L,
@@ -14,7 +27,6 @@ namespace OpenWifi {
 								   bool Internal)
 			: RESTAPIHandler(bindings, L,
 							 std::vector<std::string>{Poco::Net::HTTPRequest::HTTP_GET,
-													  Poco::Net::HTTPRequest::HTTP_PUT,
 													  Poco::Net::HTTPRequest::HTTP_DELETE,
 													  Poco::Net::HTTPRequest::HTTP_OPTIONS},
 							 Server, TransactionId, Internal, true, false,
@@ -24,9 +36,21 @@ namespace OpenWifi {
 
 		void DoGet() final;
 		void DoPost() final{};
-		void DoPut() final;
+		void DoPut() final {};
 		void DoDelete() final;
 
 	  private:
+		bool ValidateUserInfo();
+		bool LoadSubscriberInfo(SubObjects::SubscriberInfo &subInfo);
+		bool LoadProvisioningDevices(ProvObjects::SubscriberDeviceList &devices);
+		bool PrepareSubInfoObject(SubObjects::SubscriberInfo &subInfo,
+								  const ProvObjects::SubscriberDeviceList &devices);
+		bool PrepareDefaultConfig(SubObjects::SubscriberInfo &subInfo,
+									ProvObjects::SubscriberDevice &subDevice);
+		bool LinkSubscriberDevice(const SubObjects::SubscriberInfo &subInfo,
+											const ProvObjects::SubscriberDevice &subDevice);
+		bool CreateDbEntry(SubObjects::SubscriberInfo &subInfo);
+		bool ProvisionSubscriber(SubObjects::SubscriberInfo &subInfo);
+		bool DeletePostSubscriber();
 	};
 } // namespace OpenWifi

--- a/src/RESTObjects/RESTAPI_SubObjects.cpp
+++ b/src/RESTObjects/RESTAPI_SubObjects.cpp
@@ -1,3 +1,8 @@
+/*
+ * SPDX-License-Identifier: AGPL-3.0 OR LicenseRef-Commercial
+ * Copyright (c) 2025 Infernet Systems Pvt Ltd
+ * Portions copyright (c) Telecom Infra Project (TIP), BSD-3-Clause
+ */
 //
 // Created by stephane bourque on 2021-10-27.
 //

--- a/src/framework/OpenAPIRequests.cpp
+++ b/src/framework/OpenAPIRequests.cpp
@@ -1,3 +1,8 @@
+/*
+ * SPDX-License-Identifier: AGPL-3.0 OR LicenseRef-Commercial
+ * Copyright (c) 2025 Infernet Systems Pvt Ltd
+ * Portions copyright (c) Telecom Infra Project (TIP), BSD-3-Clause
+ */
 //
 // Created by stephane bourque on 2022-10-25.
 //
@@ -52,9 +57,10 @@ namespace OpenWifi {
 
 					Poco::Net::HTTPResponse Response;
 					std::istream &is = Session.receiveResponse(Response);
-					if (Response.getStatus() == Poco::Net::HTTPResponse::HTTP_OK) {
+					try {
 						Poco::JSON::Parser P;
 						ResponseObject = P.parse(is).extract<Poco::JSON::Object::Ptr>();
+					} catch (...) {
 					}
 					return Response.getStatus();
 				} else {
@@ -65,9 +71,10 @@ namespace OpenWifi {
 
 					Poco::Net::HTTPResponse Response;
 					std::istream &is = Session.receiveResponse(Response);
-					if (Response.getStatus() == Poco::Net::HTTPResponse::HTTP_OK) {
+					try {
 						Poco::JSON::Parser P;
 						ResponseObject = P.parse(is).extract<Poco::JSON::Object::Ptr>();
+					} catch (...) {
 					}
 					return Response.getStatus();
 				}

--- a/src/sdks/SDK_prov.h
+++ b/src/sdks/SDK_prov.h
@@ -10,6 +10,8 @@
 
 #pragma once
 
+#include <optional>
+
 #include "RESTObjects/RESTAPI_ProvObjects.h"
 #include "framework/RESTAPI_Handler.h"
 
@@ -38,8 +40,10 @@ namespace OpenWifi::SDK::Prov {
 
 	namespace Subscriber {
 		bool GetDevices(RESTAPIHandler *client, const std::string &SubscriberId,
-						const std::string &OperatorId, ProvObjects::SubscriberDeviceList &devList);
-		bool UpdateSubscriber(RESTAPIHandler *client, const std::string &SubscriberId,
+						const std::string &OperatorId, ProvObjects::SubscriberDeviceList &devList,
+						Poco::Net::HTTPServerResponse::HTTPStatus &CallStatus,
+						Poco::JSON::Object::Ptr &CallResponse);
+		bool SetSubscriber(RESTAPIHandler *client, const std::string &SubscriberId,
 									 const std::string &SerialNumber, bool removeSubscriber = false);
 		Poco::JSON::Object::Ptr BuildMeshConfig(const Poco::JSON::Object::Ptr &configuration);
 		bool CreateSubDeviceInfo(RESTAPIHandler *client, const ProvObjects::InventoryTag &inventoryTag, const SecurityObjects::UserInfo &userInfo,
@@ -49,6 +53,14 @@ namespace OpenWifi::SDK::Prov {
 		bool GetDevice(RESTAPIHandler *client, const std::string &SerialNumber,
 					   ProvObjects::SubscriberDevice &D);
 		bool DeleteProvSubscriberDevice(RESTAPIHandler *client, const std::string &SerialNumber);
+		bool DeleteProvisionSubscriber(RESTAPIHandler *client, const std::string &subscriberId,
+									   Poco::Net::HTTPServerResponse::HTTPStatus &callStatus);
+		bool ProvisionSubscriber(RESTAPIHandler *client, const std::string &subscriberId,
+								 bool enableMonitoring, const std::optional<uint64_t> &retention,
+								 const std::optional<uint64_t> &interval,
+								 const std::optional<bool> &monitorSubVenues,
+								 Poco::Net::HTTPServerResponse::HTTPStatus &callStatus,
+								 Poco::JSON::Object::Ptr &callResponse);
 	} // namespace Subscriber
 
 	namespace Signup {

--- a/src/storage/storage_subscriber_info.cpp
+++ b/src/storage/storage_subscriber_info.cpp
@@ -37,7 +37,7 @@ namespace OpenWifi {
 									   Poco::Logger &L)
 		: DB(T, "subscriberinfo", SubInfoDBDB_Fields, SubInfoDBDB_Fields_Indexes, P, L, "sui") {}
 
-	void SubscriberInfoDB::CreateDefaultSubscriberInfo(
+	void SubscriberInfoDB::BuildDefaultSubscriberInfo(
 		const SecurityObjects::UserInfoAndPolicy &UI, SubObjects::SubscriberInfo &SI,
 		const ProvObjects::SubscriberDeviceList &Devices) {
 		auto Now = Utils::Now();

--- a/src/storage/storage_subscriber_info.h
+++ b/src/storage/storage_subscriber_info.h
@@ -1,3 +1,8 @@
+/*
+ * SPDX-License-Identifier: AGPL-3.0 OR LicenseRef-Commercial
+ * Copyright (c) 2025 Infernet Systems Pvt Ltd
+ * Portions copyright (c) Telecom Infra Project (TIP), BSD-3-Clause
+ */
 //
 // Created by stephane bourque on 2021-11-29.
 //
@@ -20,7 +25,7 @@ namespace OpenWifi {
 	  public:
 		SubscriberInfoDB(OpenWifi::DBType T, Poco::Data::SessionPool &P, Poco::Logger &L);
 		virtual ~SubscriberInfoDB(){};
-		void CreateDefaultSubscriberInfo(const SecurityObjects::UserInfoAndPolicy &UI,
+		void BuildDefaultSubscriberInfo(const SecurityObjects::UserInfoAndPolicy &UI,
 										 SubObjects::SubscriberInfo &SI,
 										 const ProvObjects::SubscriberDeviceList &Devices);
 		void AddAccessPoint(SubObjects::SubscriberInfo &SI, const std::string &macAddress,


### PR DESCRIPTION
Start monitoring on the first GET /subscriber by provisioning the subscriber, and refactor the subscriber flow into smaller, error-aware steps.

Changes

1. rename
  CreateDefaultSubscriberInfo -> BuildDefaultSubscriberInfo
  UpdateSubscriber -> SetSubscriber

2. refactor
  GET /subscriber flow into smaller helper functions

3. add
  Provisioning call on GET /subscriber to start monitoring
  Provisioning delete call on subscriber delete

4. improve
  Safer JSON parsing in OpenAPI requests