### PR TITLE
Fix incorrect error message when device is busy during login

### DIFF
--- a/src/RESTAPI/RESTAPI_subscriber_handler.cpp
+++ b/src/RESTAPI/RESTAPI_subscriber_handler.cpp
@@ -75,7 +75,7 @@ namespace OpenWifi {
 			fmt::format("{}: Fetching Current configuration from controller", UserInfo_.userinfo.email));
 		if (subInfo.accessPoints.list.empty()) {
 			Logger().error("Subscriber access points list is empty.");
-			InternalError(RESTAPI::Errors::ConfigBlockInvalid);
+			InternalError(RESTAPI::Errors::SubNoDeviceActivated);
 			return false;
 		}
 
@@ -101,7 +101,7 @@ namespace OpenWifi {
 		if (!SDK::Prov::Subscriber::UpdateSubscriberDevice(nullptr, subDevice)) {
 			Logger().error(
 				fmt::format("Failed to persist provisioning config for {}.", subDevice.serialNumber));
-			InternalError(RESTAPI::Errors::ConfigBlockInvalid);
+			InternalError(RESTAPI::Errors::ApplyConfigFailed);
 			return false;
 		}
 		if (!SDK::GW::Device::SetSubscriber(nullptr, subDevice.serialNumber, subInfo.id)) {

--- a/src/framework/ow_constants.h
+++ b/src/framework/ow_constants.h
@@ -229,7 +229,7 @@ namespace OpenWifi::RESTAPI::Errors {
 	static const struct msg DefConfigNameExists { 1099, "Configuration name already exists." };
 
 	static const struct msg SubNoDeviceActivated { 1100, "No devices activated yet." };
-	static const struct msg SubConfigNotRefreshed { 1101, "Configuration could not be refreshed." };
+	static const struct msg ApplyConfigFailed {1101, "Failed to apply configuration to device."};
 
 	static const struct msg ProvServiceNotAvailable {
 		1102, "Provisioning service not available yet."
@@ -443,10 +443,9 @@ namespace OpenWifi::RESTAPI::Errors {
 	static const struct msg SSIDInvalidName{
 		1193, "Invalid SSID. Allowed characters: 1 to 32 chars (letters, digits, dot, underscore, hyphen, space.)"};
 	static const struct msg AddDeviceFailed {1194, "Failed to add new device."};
-	static const struct msg ApplyConfigFailed {1195, "Failed to apply configuration to device."};
-	static const struct msg RecordNotDeleted {1197, "Record could not be deleted."};
-	static const struct msg ClientAlreadyBlocked {1198, "Client is already blocked."};
-	static const struct msg ClientAlreadyUnblocked {1199, "Client is already unblocked."};
+	static const struct msg RecordNotDeleted {1195, "Record could not be deleted."};
+	static const struct msg ClientAlreadyBlocked {1196, "Client is already blocked."};
+	static const struct msg ClientAlreadyUnblocked {1197, "Client is already unblocked."};
     static const struct msg SimulationDoesNotExist {
         7000, "Simulation Instance ID does not exist."
     };

--- a/src/framework/ow_constants.h
+++ b/src/framework/ow_constants.h
@@ -443,9 +443,9 @@ namespace OpenWifi::RESTAPI::Errors {
 	static const struct msg SSIDInvalidName{
 		1193, "Invalid SSID. Allowed characters: 1 to 32 chars (letters, digits, dot, underscore, hyphen, space.)"};
 	static const struct msg AddDeviceFailed {1194, "Failed to add new device."};
-	static const struct msg RecordNotDeleted {1195, "Record could not be deleted."};
-	static const struct msg ClientAlreadyBlocked {1196, "Client is already blocked."};
-	static const struct msg ClientAlreadyUnblocked {1197, "Client is already unblocked."};
+	static const struct msg RecordNotDeleted {1197, "Record could not be deleted."};
+	static const struct msg ClientAlreadyBlocked {1198, "Client is already blocked."};
+	static const struct msg ClientAlreadyUnblocked {1199, "Client is already unblocked."};
     static const struct msg SimulationDoesNotExist {
         7000, "Simulation Instance ID does not exist."
     };


### PR DESCRIPTION
[#39 ]

**Problem Fixed:-**

- During login, if the subscriber’s device was already executing a command (such as configuration apply), the request failed.
- However, the system returned a generic ConfigBlockInvalid error which was wrong.
- This caused the mobile app to display an incorrect and misleading message.
- Removed unused **SubConfigNotRefresh** and replaced it with **ApplyConfigFailed** for correct error handling.

This PR updates the error handling to return accurate error messages.

**Current Behaviour:-**

- If **provisioning configuration apply** **fails** (for example, when the device is already executing another command), **ApplyConfigFailed** is returned instead of **ConfigBlockInvalid**.

- The mobile app now shows accurate error responses that reflect the actual failure reason.