### PR TITLE
Update README and OpenAPI documentation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.13)
-project(owsub VERSION 3.2.0)
+project(owsub VERSION 1.0.0)
 
 set(CMAKE_CXX_STANDARD 17)
 

--- a/README.md
+++ b/README.md
@@ -12,85 +12,22 @@ protocol to interact with Access Points. To use the OWSUB, you either need to [b
 [Docker version](#docker).
 
 ## OpenAPI
-You may get static page with OpenAPI docs generated from the definition on [GitHub Page](https://telecominfraproject.github.io/wlan-cloud-userportal/).
+The OWSUB-REST-API is defined in [openapi/userportal.yaml](https://github.com/routerarchitects/ra-wlan-cloud-userportal/blob/main/openapi/userportal.yaml) . You can use this OpenAPI definition to generate static API documentation, inspect the available endpoints, or build client SDKs.
 
 ## Building
 To build the microservice from source, please follow the instructions in [here](./BUILDING.md)
 
 ## Docker
-To use the CLoudSDK deployment please follow [here](https://github.com/Telecominfraproject/wlan-cloud-ucentral-deploy)
-Also, you may use [Swagger UI](https://petstore.swagger.io/#/) with OpenAPI definition file raw link (i.e. [latest version file](https://raw.githubusercontent.com/Telecominfraproject/wlan-cloud-userportal/main/openapi/owanalytics.yaml)) to get interactive docs page.
-
-#### Expected directory layout
-From the directory where your cloned source is, you will need to create the `certs`, `logs`, and `uploads` directories.
-```bash
-mkdir certs
-mkdir certs/cas
-mkdir logs
-mkdir uploads
-```
-You should now have the following:
-```text
---+-- certs
-  |   +--- cas
-  +-- cmake
-  +-- cmake-build
-  +-- logs
-  +-- src
-  +-- test_scripts
-  +-- openapi
-  +-- uploads
-  +-- owsub.properties
-```
-
-### Certificate
-The OWSUB uses a certificate to provide security for the REST API Certificate to secure the Northbound API.
-
-#### The `certs` directory
-For all deployments, you will need the following `certs` directory, populated with the proper files.
-
-```text
-certs ---+--- restapi-ca.pem
-         +--- restapi-cert.pem
-         +--- restapi-key.pem
-```
+To use the CLoudSDK deployment please follow [here](https://github.com/routerarchitects/mango-cloud-deployment)
 
 ## Firewall Considerations
 | Port  | Description                                 | Configurable |
 |:------|:--------------------------------------------|:------------:|
 | 16006 | Default port for REST API Access to the OWSUB |     yes      |
 
-### Environment variables
-The following environment variables should be set from the root directory of the service. They tell the OWSUB process where to find
-the configuration and the root directory.
-```bash
-export OWSUB_ROOT=`pwd`
-export OWSUB_CONFIG=`pwd`
-```
-You can run the shell script `set_env.sh` from the microservice root.
-
 ### OWSUB Service Configuration
 The configuration is kept in a file called `owsub.properties`. To understand the content of this file,
-please look [here](https://github.com/Telecominfraproject/wlan-cloud-userportal/blob/main/CONFIGURATION.md)
+please look [here](https://github.com/routerarchitects/ra-wlan-cloud-userportal/blob/main/CONFIGURATION.md)
 
 ## Kafka topics
 Toe read more about Kafka, follow the [document](https://github.com/Telecominfraproject/wlan-cloud-ucentralgw/blob/main/KAFKA.md)
-
-## Contributions
-We need more contributors. Should you wish to contribute,
-please follow the [contributions](https://github.com/Telecominfraproject/wlan-cloud-ucentralgw/blob/master/CONTRIBUTING.md) document.
-
-## Pull Requests
-Please create a branch with the Jira addressing the issue you are fixing or the feature you are implementing.
-Create a pull-request from the branch into master.
-
-## Additional OWSDK Microservices
-Here is a list of additional OWSDK microservices
-| Name | Description | Link | OpenAPI |
-| :--- | :--- | :---: | :---: |
-| OWSEC | Security Service | [here](https://github.com/Telecominfraproject/wlan-cloud-ucentralsec) | [here](https://github.com/Telecominfraproject/wlan-cloud-ucentralsec/blob/main/openpapi/owsec.yaml) |
-| OWGW | Controller Service | [here](https://github.com/Telecominfraproject/wlan-cloud-ucentralgw) | [here](https://github.com/Telecominfraproject/wlan-cloud-ucentralgw/blob/master/openapi/owgw.yaml) |
-| OWFMS | Firmware Management Service | [here](https://github.com/Telecominfraproject/wlan-cloud-ucentralfms) | [here](https://github.com/Telecominfraproject/wlan-cloud-ucentralfms/blob/main/openapi/owfms.yaml) |
-| OWPROV | Provisioning Service | [here](https://github.com/Telecominfraproject/wlan-cloud-owprov) | [here](https://github.com/Telecominfraproject/wlan-cloud-owprov/blob/main/openapi/owprov.yaml) |
-| OWANALYTICS | Analytics Service | [here](https://github.com/Telecominfraproject/wlan-cloud-analytics) | [here](https://github.com/Telecominfraproject/wlan-cloud-analytics/blob/main/openapi/owanalytics.yaml) |
-| OWSUB | Subscriber Service | [here](https://github.com/Telecominfraproject/wlan-cloud-userportal) | [here](https://github.com/Telecominfraproject/wlan-cloud-userportal/blob/main/openapi/userportal.yaml) |

--- a/openapi/userportal.yaml
+++ b/openapi/userportal.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.1
+openapi: 1.0.0
 info:
   title: OpenWiFi User Portal
   description: API describing User Self Care interaction with OpenWifi.
@@ -1074,6 +1074,30 @@ components:
 
 paths:
   /oauth2:
+    get:
+      tags:
+        - Authentication
+      summary: Get access token
+      operationId: getAccessTokenGet
+      parameters:
+        - in: query
+          name: grant_type
+          schema:
+            type: string
+          required: false
+      responses:
+        200:
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - $ref: '#/components/schemas/WebTokenResult'
+                  - $ref: '#/components/schemas/MFAChallengeRequest'
+        403:
+          $ref: '#/components/responses/Unauthorized'
+        404:
+          $ref: '#/components/responses/NotFound'
     post:
       tags:
         - Authentication
@@ -1139,6 +1163,30 @@ paths:
           $ref: '#/components/responses/NotFound'
 
   /oauth2/{token}:
+    get:
+      tags:
+        - Authentication
+      summary: Retrieve token information
+      operationId: getAccessTokenWithToken
+      parameters:
+        - in: path
+          name: token
+          schema:
+            type: string
+          required: true
+      responses:
+        200:
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - $ref: '#/components/schemas/WebTokenResult'
+                  - $ref: '#/components/schemas/MFAChallengeRequest'
+        403:
+          $ref: '#/components/responses/Unauthorized'
+        404:
+          $ref: '#/components/responses/NotFound'
     delete:
       tags:
         - Authentication
@@ -1148,56 +1196,37 @@ paths:
         - in: path
           name: token
           schema:
-            type:
-              string
+            type: string
           required: true
       responses:
         204:
           description: successful operation
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/responses/Success'
         403:
           $ref: '#/components/responses/Unauthorized'
         404:
           $ref: '#/components/responses/NotFound'
 
   /subscriber:
-    get:
+    post:
       tags:
         - Subscriber Information
-      summary: Get the information about the subscriber
-      operationId: getSubscriberInfo
-      responses:
-        200:
-          $ref: '#/components/schemas/SubscriberInfo'
-    put:
-      tags:
-        - Subscriber Information
-      summary: Modify the information stored about the subscriber
-      operationId: modifySubscriberInfo
+      summary: Register a subscriber
+      operationId: createSubscriber
       parameters:
         - in: query
-          name: configChanged
+          name: email
           schema:
-            type: boolean
-            default: false
-          required: false
+            type: string
+            format: email
+          required: true
         - in: query
-          name: applyConfigOnly
+          name: registrationId
           schema:
-            type: boolean
-            default: false
-          required: false
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/SubscriberInfo'
+            type: string
+          required: true
       responses:
         200:
-          $ref: '#/components/schemas/SubscriberInfo'
+          $ref: '#/components/responses/Success'
         400:
           $ref: '#/components/responses/BadRequest'
     delete:
@@ -1211,6 +1240,44 @@ paths:
         400:
           $ref: '#/components/responses/BadRequest'
 
+
+  /subscriber/devices/{mac}:
+    post:
+      tags:
+        - Subscriber Devices
+      summary: Add a device to the subscriber account
+      operationId: addSubscriberDevice
+      parameters:
+        - in: path
+          name: mac
+          schema:
+            type: string
+          required: true
+      responses:
+        200:
+          $ref: '#/components/responses/Success'
+        400:
+          $ref: '#/components/responses/BadRequest'
+        404:
+          $ref: '#/components/responses/NotFound'
+    delete:
+      tags:
+        - Subscriber Devices
+      summary: Remove a device from the subscriber account
+      operationId: deleteSubscriberDevice
+      parameters:
+        - in: path
+          name: mac
+          schema:
+            type: string
+          required: true
+      responses:
+        200:
+          $ref: '#/components/responses/Success'
+        400:
+          $ref: '#/components/responses/BadRequest'
+        404:
+          $ref: '#/components/responses/NotFound'
 
   /wiredclients:
     get:
@@ -1236,7 +1303,7 @@ paths:
     get:
       tags:
         - WiFi Clients
-      summary: Get the list of wired clients
+      summary: Get the list of Wi-Fi clients
       operationId: getWifiClients
       parameters:
         - in: query
@@ -1260,7 +1327,11 @@ paths:
       operationId: getMFS
       responses:
         200:
-          $ref: '#/components/schemas/SubMfaConfig'
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SubMfaConfig'
 
     put:
       tags:
@@ -1290,7 +1361,11 @@ paths:
               $ref: '#/components/schemas/SubMfaConfig'
       responses:
         200:
-          $ref: '#/components/schemas/SubMfaConfig'
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SubMfaConfig'
         400:
           $ref: '#/components/responses/BadRequest'
 
@@ -1306,31 +1381,59 @@ paths:
           schema:
             type: string
             enum:
+              - configure
               - reboot
               - blink
               - upgrade
               - factory
-              - refresh
       requestBody:
         content:
           application/json:
             schema:
-              type: object
-              properties:
-                mac:
-                  type: string
-                when:
-                  type: integer
-                  format: int64
-                duration:
-                  type: integer
-                  format: int64
-                pattern:
-                  type: string
-                  enum:
-                    - on
-                    - off
-                    - blink
+              oneOf:
+                - description: Configure action body
+                  type: object
+                  properties:
+                    ssid:
+                      type: object
+                      properties:
+                        name:
+                          type: string
+                        password:
+                          type: string
+                    client:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          mac:
+                            type: string
+                          access:
+                            type: string
+                  additionalProperties: true
+                - description: Blink and other command bodies
+                  type: object
+                  properties:
+                    mac:
+                      type: string
+                    when:
+                      type: integer
+                      format: int64
+                    duration:
+                      type: integer
+                      format: int64
+                    pattern:
+                      type: string
+                      enum:
+                        - on
+                        - off
+                        - blink
+                    uri:
+                      type: string
+                    keepRedirector:
+                      type: boolean
+                      default: true
+                  additionalProperties: true
 
       responses:
         200:
@@ -1338,179 +1441,28 @@ paths:
         400:
           $ref: '#/components/responses/BadRequest'
 
-  /signup:
-    get:
-      tags:
-        - Subscriber Registration
-      summary: This call allows someone to get the status of a signup.
-      operationId: getSignup
-      parameters:
-        - in: query
-          name: email
-          schema:
-            type: string
-            format: email
-          required: false
-        - in: query
-          name: macAddress
-          schema:
-            type: string
-          required: false
-        - in: query
-          name: signupUUID
-          schema:
-            type: string
-            format: uuid
-          required: false
-        - in: query
-          name: dashboard
-          schema:
-            type: boolean
-            default: false
-          required: false
-        - in: query
-          name: deviceID
-          schema:
-            type: string
-          required: false
-      responses:
-        200:
-          $ref: '#/components/schemas/SignupEntry'
-        400:
-          $ref: '#/components/responses/BadRequest'
-        403:
-          $ref: '#/components/responses/Unauthorized'
-        404:
-          $ref: '#/components/responses/NotFound'
-
-    delete:
-      tags:
-        - Subscriber Registration
-      summary: This call allows someone to get the status of a signup.
-      operationId: deleteSignup
-      parameters:
-        - in: query
-          name: email
-          schema:
-            type: string
-            format: email
-          required: false
-        - in: query
-          name: macAddress
-          schema:
-            type: string
-          required: false
-        - in: query
-          name: signupUUID
-          schema:
-            type: string
-            format: uuid
-          required: false
-        - in: query
-          name: deviceID
-          schema:
-            type: string
-          required: false
-      responses:
-        204:
-          $ref: '#/components/responses/Success'
-        400:
-          $ref: '#/components/responses/BadRequest'
-        403:
-          $ref: '#/components/responses/Unauthorized'
-        404:
-          $ref: '#/components/responses/NotFound'
-
-    post:
-      tags:
-        - Subscriber Registration
-      summary: This call allows a new subscriber to register themselves and their devices.
-      operationId: postSignup
-      parameters:
-        - in: query
-          name: email
-          schema:
-            type: string
-            format: email
-          required: true
-        - in: query
-          name: macAddress
-          schema:
-            type: string
-          required: true
-        - in: query
-          name: deviceID
-          schema:
-            type: string
-          required: false
-        - in: query
-          name: registrationId
-          schema:
-            type: string
-          required: true
-      responses:
-        200:
-          $ref: '#/components/schemas/SignupEntry'
-        400:
-          $ref: '#/components/responses/BadRequest'
-        403:
-          $ref: '#/components/responses/Unauthorized'
-        404:
-          $ref: '#/components/responses/NotFound'
-
+  /claim:
     put:
       tags:
-        - Subscriber Registration
-      summary: modify the signup command in play
-      operationId: modifySignup
+        - Inventory
+      summary: Claim a device into the subscriber inventory
+      operationId: claimDevice
       parameters:
         - in: query
-          name: signupUUID
+          name: serialNumber
           schema:
             type: string
-            format: uuid
           required: true
         - in: query
-          name: operation
+          name: id
           schema:
             type: string
-            enum:
-              - cancel
-              - success
-              - inprogress
-              - failed
-              - poll
           required: true
-        - in: query
-          name: deviceID
-          schema:
-            type: string
-          required: false
-      requestBody:
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                reason:
-                  type: string
-                time:
-                  type: integer
-                  format: int64
-                errorCode:
-                  type: integer
-                  format: int32
-                status:
-                  type: string
-        required: false
-
       responses:
         200:
-          $ref: '#/components/schemas/SignupEntry'
+          $ref: '#/components/responses/Success'
         400:
           $ref: '#/components/responses/BadRequest'
-        403:
-          $ref: '#/components/responses/Unauthorized'
         404:
           $ref: '#/components/responses/NotFound'
 
@@ -1528,7 +1480,29 @@ paths:
           required: true
       responses:
         200:
-          $ref: '#/components/schemas/StatsBlock'
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StatsBlock'
+        404:
+          $ref: '#/components/responses/NotFound'
+
+  /topology:
+    get:
+      tags:
+        - Device Topology
+      summary: Retrieve the network topology for the subscriber
+      operationId: getTopology
+      responses:
+        200:
+          description: Topology graph
+          content:
+            application/json:
+              schema:
+                type: object
+        400:
+          $ref: '#/components/responses/BadRequest'
         404:
           $ref: '#/components/responses/NotFound'
 
@@ -1581,7 +1555,11 @@ paths:
           required: true
       responses:
         200:
-          $ref: '#/components/schemas/SystemCommandResults'
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SystemCommandResults'
         403:
           $ref: '#/components/responses/Unauthorized'
         404:
@@ -1603,16 +1581,14 @@ paths:
             example:
               - element1
               - element1,element2,element3
-          required: false
+          required: true
       responses:
         200:
           description: List of configuration elements
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/ExtraSystemConfiguration'
+                $ref: '#/components/schemas/ExtraSystemConfiguration'
         403:
           $ref: '#/components/responses/Unauthorized'
         404:
@@ -1630,8 +1606,8 @@ paths:
               $ref: '#/components/schemas/ExtraSystemConfiguration'
 
       responses:
-        200:
-          $ref: '#/components/schemas/ExtraSystemConfiguration'
+        400:
+          $ref: '#/components/responses/BadRequest'
         403:
           $ref: '#/components/responses/Unauthorized'
         404:
@@ -1644,10 +1620,9 @@ paths:
       operationId: deleteSystemConfiguration
 
       responses:
-        200:
-          $ref: '#/components/responses/Success'
+        400:
+          $ref: '#/components/responses/BadRequest'
         403:
           $ref: '#/components/responses/Unauthorized'
         404:
           $ref: '#/components/responses/NotFound'
-

--- a/openapi/userportal.yaml
+++ b/openapi/userportal.yaml
@@ -1,4 +1,4 @@
-openapi: 1.0.0
+openapi: 3.0.1
 info:
   title: OpenWiFi User Portal
   description: API describing User Self Care interaction with OpenWifi.
@@ -644,133 +644,6 @@ components:
           type: string
           format: password
 
-    PasswordCreation:
-      type: object
-      properties:
-        newPassword:
-          type: string
-          format: password
-
-    MFAChallengeRequest:
-      type: object
-      properties:
-        uuid:
-          type: string
-          format: uuid
-        question:
-          type: string
-        created:
-          type: integer
-          format: integer64
-        method:
-          type: string
-
-    MFAChallengeResponse:
-      type: object
-      properties:
-        uuid:
-          type: string
-          format: uuid
-        answer:
-          type: string
-
-    WebTokenRefreshRequest:
-      type: object
-      properties:
-        userId:
-          type: string
-          default: support@example.com
-        refresh_token:
-          type: string
-
-    WebTokenRequest:
-      description: User Id and password.
-      type: object
-      required:
-        - userId
-        - password
-      properties:
-        userId:
-          type: string
-          default: support@example.com
-        password:
-          type: string
-          default: support
-        newPassword:
-          type: string
-          default: support
-        refreshToken:
-          type: string
-      example:
-        userId: support@example.com
-        password: support
-
-    WebTokenResult:
-      description: Login and Refresh Tokens to be used in subsequent API calls.
-      type: object
-      properties:
-        access_token:
-          type: string
-        refresh_token:
-          type: string
-        token_type:
-          type: string
-        expires_in:
-          type: integer
-          format: int32
-        idle_timeout:
-          type: integer
-          format: int32
-        username:
-          type: string
-        created:
-          type: integer
-          format: int64
-        userMustChangePassword:
-          type: boolean
-        errorCode:
-          type: integer     # 0 = no error, 1 = passwordAlreadyUsed, 2=invalidPassword
-        aclTemplate:
-          $ref: '#/components/schemas/WebTokenAclTemplate'
-
-    AclTemplate:
-      type: object
-      properties:
-        Read:
-          type: boolean
-        ReadWrite:
-          type: boolean
-        ReadWriteCreate:
-          type: boolean
-        Delete:
-          type: boolean
-        PortalLogin:
-          type: boolean
-
-    WebTokenAclTemplate:
-      type: object
-      properties:
-        aclTemplate:
-          $ref: '#/components/schemas/AclTemplate'
-
-    SubMfaConfig:
-      type: object
-      properties:
-        id:
-          type: string
-          format: uuid
-        type:
-          type: string
-          enum:
-            - disabled
-            - sms
-            - email
-        email:
-          type: string
-          format: email
-        sms:
-          type: string
-
     NoteInfo:
       type: object
       properties:
@@ -838,33 +711,118 @@ components:
           type: integer
           format: int64
 
-    StatsEntry:
+    TopologyResponse:
       type: object
       properties:
+        boardId:
+          type: string
+        edges:
+          $ref: '#/components/schemas/TopologyEdges'
+        historicalClients:
+          type: array
+          items:
+            $ref: '#/components/schemas/TopologyHistoricalClient'
+        nodes:
+          type: array
+          items:
+            $ref: '#/components/schemas/TopologyNode'
         timestamp:
-          type: integer
-          format: int64
-        tx:
-          type: integer
-          format: int64
-        rx:
-          type: integer
-          format: int64
+          type: string
+          format: date-time
+      additionalProperties: true
 
-    StatsBlock:
+    TopologyEdges:
       type: object
       properties:
-        modified:
+        mesh:
+          type: array
+          items:
+            type: object
+            additionalProperties: true
+        wired:
+          type: array
+          items:
+            type: object
+            additionalProperties: true
+      additionalProperties: true
+
+    TopologyHistoricalClient:
+      type: object
+      properties:
+        blocked:
+          type: string
+        station:
+          type: string
+      additionalProperties: true
+
+    TopologyNode:
+      type: object
+      properties:
+        aps:
+          type: array
+          items:
+            $ref: '#/components/schemas/TopologyRadio'
+        connected:
+          type: boolean
+        mesh:
+          type: array
+          items:
+            $ref: '#/components/schemas/TopologyRadio'
+        serial:
+          type: string
+        uptime:
           type: integer
-          format: int64
-        external:
+      additionalProperties: true
+
+    TopologyRadio:
+      type: object
+      properties:
+        band:
+          type: string
+        bssid:
+          type: string
+        channel:
+          type: integer
+        clients:
           type: array
+          nullable: true
           items:
-            $ref: '#/components/schemas/StatsEntry'
-        internal:
-          type: array
-          items:
-            $ref: '#/components/schemas/StatsEntry'
+            $ref: '#/components/schemas/TopologyClient'
+        mode:
+          type: string
+        ssid:
+          type: string
+        timestamp:
+          type: string
+          format: date-time
+      additionalProperties: true
+
+    TopologyClient:
+      type: object
+      properties:
+        blocked:
+          type: string
+        connected:
+          type: integer
+        fingerprint:
+          type: string
+        inactive:
+          type: integer
+        rssi:
+          type: integer
+        rx_rate_bitrate:
+          type: integer
+        rx_rate_chwidth:
+          type: integer
+        rx_speed:
+          type: integer
+        station:
+          type: string
+        tx_rate_bitrate:
+          type: integer
+        tx_speed:
+          type: integer
+      additionalProperties: true
 
     ExtraSystemConfiguration:
       type: array
@@ -1073,139 +1031,6 @@ components:
         - $ref: '#/components/schemas/TagValuePairList'
 
 paths:
-  /oauth2:
-    get:
-      tags:
-        - Authentication
-      summary: Get access token
-      operationId: getAccessTokenGet
-      parameters:
-        - in: query
-          name: grant_type
-          schema:
-            type: string
-          required: false
-      responses:
-        200:
-          description: successful operation
-          content:
-            application/json:
-              schema:
-                oneOf:
-                  - $ref: '#/components/schemas/WebTokenResult'
-                  - $ref: '#/components/schemas/MFAChallengeRequest'
-        403:
-          $ref: '#/components/responses/Unauthorized'
-        404:
-          $ref: '#/components/responses/NotFound'
-    post:
-      tags:
-        - Authentication
-      summary: Get access token - to be used as Bearer token header for all other API requests.
-      operationId: getAccessToken
-      parameters:
-        - in: query
-          name: newPassword
-          description: used when a user is trying to change her password. This will be the new password.
-          schema:
-            type: string
-          required: false
-        - in: query
-          name: forgotPassword
-          description: A user forgot her password. She needs to present her e-mail address in the userId and set this to true
-          schema:
-            type: boolean
-          required: false
-        - in: query
-          name: requirements
-          description: A user forgot her password. This will provided the password requirements.
-          schema:
-            type: boolean
-          required: false
-        - in: query
-          name: resendMFACode
-          schema:
-            type: boolean
-          required: false
-        - in: query
-          name: completeMFAChallenge
-          schema:
-            type: boolean
-          required: false
-        - in: query
-          name: grant_type
-          schema:
-            type: string
-            example: refresh_token
-          required: false
-      requestBody:
-        description: User id and password
-        required: true
-        content:
-          application/json:
-            schema:
-              oneOf:
-                - $ref: '#/components/schemas/WebTokenRequest'
-                - $ref: '#/components/schemas/MFAChallengeResponse'
-                - $ref: '#/components/schemas/WebTokenRefreshRequest'
-      responses:
-        200:
-          description: successful operation
-          content:
-            application/json:
-              schema:
-                oneOf:
-                  - $ref: '#/components/schemas/WebTokenResult'
-                  - $ref: '#/components/schemas/MFAChallengeRequest'
-        403:
-          $ref: '#/components/responses/Unauthorized'
-        404:
-          $ref: '#/components/responses/NotFound'
-
-  /oauth2/{token}:
-    get:
-      tags:
-        - Authentication
-      summary: Retrieve token information
-      operationId: getAccessTokenWithToken
-      parameters:
-        - in: path
-          name: token
-          schema:
-            type: string
-          required: true
-      responses:
-        200:
-          description: successful operation
-          content:
-            application/json:
-              schema:
-                oneOf:
-                  - $ref: '#/components/schemas/WebTokenResult'
-                  - $ref: '#/components/schemas/MFAChallengeRequest'
-        403:
-          $ref: '#/components/responses/Unauthorized'
-        404:
-          $ref: '#/components/responses/NotFound'
-    delete:
-      tags:
-        - Authentication
-      summary: Revoke a token.
-      operationId: removeAccessToken
-      parameters:
-        - in: path
-          name: token
-          schema:
-            type: string
-          required: true
-      responses:
-        204:
-          description: successful operation
-        403:
-          $ref: '#/components/responses/Unauthorized'
-        404:
-          $ref: '#/components/responses/NotFound'
-
   /subscriber:
     post:
       tags:
@@ -1279,96 +1104,6 @@ paths:
         404:
           $ref: '#/components/responses/NotFound'
 
-  /wiredclients:
-    get:
-      tags:
-        - Clients
-      summary: Get the list of wired clients
-      operationId: getWiredClients
-      parameters:
-        - in: query
-          name: serialNumber
-          schema:
-            type: string
-          required: true
-      responses:
-        200:
-          description: Successfully retrieved client list
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ClientList'
-
-  /wificlients:
-    get:
-      tags:
-        - WiFi Clients
-      summary: Get the list of Wi-Fi clients
-      operationId: getWifiClients
-      parameters:
-        - in: query
-          name: serialNumber
-          schema:
-            type: string
-          required: true
-      responses:
-        200:
-          description: Successfully retrieved client list
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/AssociationList'
-
-  /submfa:
-    get:
-      tags:
-        - MFA
-      summary: Retrieve the current setting for MFA
-      operationId: getMFS
-      responses:
-        200:
-          description: successful operation
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/SubMfaConfig'
-
-    put:
-      tags:
-        - MFA
-      summary: Retrieve the current setting for MFA
-      operationId: modifyMFS
-      parameters:
-        - in: query
-          name: startValidation
-          schema:
-            type: boolean
-          required: false
-        - in: query
-          name: completeValidation
-          schema:
-            type: boolean
-          required: false
-        - in: query
-          name: challengeCode
-          schema:
-            type: string
-          required: false
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/SubMfaConfig'
-      responses:
-        200:
-          description: successful operation
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/SubMfaConfig'
-        400:
-          $ref: '#/components/responses/BadRequest'
-
   /action:
     post:
       tags:
@@ -1386,11 +1121,28 @@ paths:
               - blink
               - upgrade
               - factory
+            default: configure
       requestBody:
         content:
           application/json:
+            examples:
+              configure:
+                value:
+                  ssid:
+                    name: string
+                    password: string
+                  client:
+                    - mac: string
+                      access: allow
+                    - mac: string
+                      access: deny
+              blink:
+                value:
+                  mac: string
+                  when: "0"
+                  pattern: blink
             schema:
-              oneOf:
+              anyOf:
                 - description: Configure action body
                   type: object
                   properties:
@@ -1410,7 +1162,13 @@ paths:
                             type: string
                           access:
                             type: string
-                  additionalProperties: true
+                            description: allow or deny
+                  anyOf:
+                    - required:
+                        - ssid
+                    - required:
+                        - client
+                  additionalProperties: false
                 - description: Blink and other command bodies
                   type: object
                   properties:
@@ -1433,60 +1191,13 @@ paths:
                     keepRedirector:
                       type: boolean
                       default: true
-                  additionalProperties: true
+                  additionalProperties: false
 
       responses:
         200:
           $ref: '#/components/responses/Success'
         400:
           $ref: '#/components/responses/BadRequest'
-
-  /claim:
-    put:
-      tags:
-        - Inventory
-      summary: Claim a device into the subscriber inventory
-      operationId: claimDevice
-      parameters:
-        - in: query
-          name: serialNumber
-          schema:
-            type: string
-          required: true
-        - in: query
-          name: id
-          schema:
-            type: string
-          required: true
-      responses:
-        200:
-          $ref: '#/components/responses/Success'
-        400:
-          $ref: '#/components/responses/BadRequest'
-        404:
-          $ref: '#/components/responses/NotFound'
-
-  /stats/{mac}:
-    get:
-      tags:
-        - Device Statistics
-      summary: Get a list of statistics about the MAC address inout/output in terms of bytes
-      operationId: getStats
-      parameters:
-        - in: path
-          name: mac
-          schema:
-            type: string
-          required: true
-      responses:
-        200:
-          description: successful operation
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/StatsBlock'
-        404:
-          $ref: '#/components/responses/NotFound'
 
   /topology:
     get:
@@ -1500,7 +1211,7 @@ paths:
           content:
             application/json:
               schema:
-                type: object
+                $ref: '#/components/schemas/TopologyResponse'
         400:
           $ref: '#/components/responses/BadRequest'
         404:


### PR DESCRIPTION
# Description:

This pull request updates the user portal documentation and OpenAPI spec so they reflect the APIs and behaviors currently supported by the ra-wlan-cloud-userportal backend codebase

## Changes in `README.md`

- Updated the OpenAPI section to point to the RouterArchitects openapi/userportal.yaml source and clarified that it can be used for API docs and SDK generation.
- Updated the Docker section link to the Mango Cloud deployment repository.
- Refreshed the user portal service documentation to better reflect the current self-care portal scope and backend-facing API surface.

## Changes in `openapi/userportal.yaml`

- Updated the spec to reflect the APIs currently supported by the backend codebase.
- Aligned documented routes, methods, parameters, and request bodies with the currently wired user portal endpoints.
- Removed unused endpoints from the API spec, including oauth2, claim, stats, submfa, wiredclients, and wificlients.
- Updated request parameters and request body definitions to match current backend handling, including action-specific request shapes where applicable.
