### PR TITLE
[SCHEDULES-API]: Implement parental-control Schedules API in UserPortal

### DIFF
--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -160,6 +160,32 @@ jobs:
             exit 1
           fi
 
+      - name: Run Schedules Contract Tests
+        env:
+          USERPORTAL_URL: https://localhost:16006
+        run: |
+          echo "Running Schedules contract tests..."
+          if ! python3 test_scripts/integration/test_schedules_contract.py; then
+            echo "Schedules contract tests failed! Container logs:"
+            docker logs userportal
+            echo "Fake server logs:"
+            cat fake_server.log
+            exit 1
+          fi
+
+      - name: Run Schedules Integration Tests
+        env:
+          USERPORTAL_URL: https://localhost:16006
+        run: |
+          echo "Running Schedules integration tests..."
+          if ! python3 test_scripts/integration/test_schedules_api.py; then
+            echo "Schedules integration tests failed! Container logs:"
+            docker logs userportal
+            echo "Fake server logs:"
+            cat fake_server.log
+            exit 1
+          fi
+
       - name: Print UserPortal Logs on Failure
         if: failure()
         run: |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -142,9 +142,12 @@ add_executable(owsub
         src/RESTAPI/RESTAPI_claim_handler.cpp src/RESTAPI/RESTAPI_claim_handler.h
         src/sdks/SDK_fms.cpp src/sdks/SDK_fms.h src/StatsSvr.cpp src/StatsSvr.h src/RESTAPI/RESTAPI_stats_handler.cpp src/RESTAPI/RESTAPI_stats_handler.h
         src/RESTAPI/RESTAPI_topology_handler.cpp src/RESTAPI/RESTAPI_topology_handler.h
+        src/RESTAPI/RESTAPI_parental_control_utils.cpp src/RESTAPI/RESTAPI_parental_control_utils.h
         src/RESTAPI/RESTAPI_groups_list_handler.cpp src/RESTAPI/RESTAPI_groups_list_handler.h
+        src/RESTAPI/RESTAPI_schedules_list_handler.cpp src/RESTAPI/RESTAPI_schedules_list_handler.h
         src/sdks/SDK_parental_control.cpp src/sdks/SDK_parental_control.h
         src/RESTAPI/RESTAPI_groups_handler.cpp src/RESTAPI/RESTAPI_groups_handler.h
+        src/RESTAPI/RESTAPI_schedules_handler.cpp src/RESTAPI/RESTAPI_schedules_handler.h
         )
 
 target_link_libraries(owsub PUBLIC

--- a/src/RESTAPI/RESTAPI_groups_handler.cpp
+++ b/src/RESTAPI/RESTAPI_groups_handler.cpp
@@ -7,89 +7,12 @@
 #include "RESTAPI_groups_handler.h"
 #include "Poco/JSON/Array.h"
 #include "Poco/JSON/Stringifier.h"
+#include "RESTAPI_parental_control_utils.h"
 #include "fmt/format.h"
 #include "framework/utils.h"
-#include "sdks/SDK_gw.h"
 #include "sdks/SDK_parental_control.h"
-#include "sdks/SDK_prov.h"
 
 namespace OpenWifi {
-
-	namespace {
-		bool IsValidConfigRawCommand(const Poco::JSON::Array::Ptr &command) {
-			return command && command->size() >= 2 && command->get(0).isString() &&
-				   command->get(1).isString();
-		}
-
-		bool ExtractDeleteConfigRaw(const Poco::JSON::Object::Ptr &callResponse,
-									Poco::JSON::Array::Ptr &deleteConfigRaw) {
-			deleteConfigRaw.reset();
-			if (!callResponse) {
-				return true;
-			}
-			if (!callResponse->has("config-raw")) {
-				return true;
-			}
-			if (!callResponse->isArray("config-raw")) {
-				return false;
-			}
-			deleteConfigRaw = callResponse->getArray("config-raw");
-			if (!deleteConfigRaw) {
-				return false;
-			}
-			for (std::size_t i = 0; i < deleteConfigRaw->size(); ++i) {
-				if (!deleteConfigRaw->isArray(i)) {
-					return false;
-				}
-				if (!IsValidConfigRawCommand(deleteConfigRaw->getArray(i))) {
-					return false;
-				}
-			}
-			return true;
-		}
-	} // namespace
-
-	// Strips all existing config-raw entries whose UCI path (index 1) starts with
-	// "parental_control" or "parental_control.", then appends the parental-control
-	// service's own config-raw entries (from the DELETE response).
-	// If the result is empty, removes config-raw entirely.
-	static void MergeConfigRaw(Poco::JSON::Object::Ptr &gatewayConfig,
-							   const Poco::JSON::Array::Ptr &deleteConfigRaw) {
-		auto mergedRaw = Poco::makeShared<Poco::JSON::Array>();
-
-		if (gatewayConfig->has("config-raw") && gatewayConfig->isArray("config-raw")) {
-			auto currentRaw = gatewayConfig->getArray("config-raw");
-			for (std::size_t i = 0; i < currentRaw->size(); ++i) {
-				if (!currentRaw->isArray(i))
-					continue;
-				auto cmd = currentRaw->getArray(i);
-				if (!cmd || cmd->size() < 2)
-					continue;
-				if (cmd->get(1).isString()) {
-					std::string path = cmd->getElement<std::string>(1);
-					if (path == "parental_control" || path.find("parental_control.") == 0)
-						continue;
-				}
-				mergedRaw->add(cmd);
-			}
-		}
-
-		if (deleteConfigRaw) {
-			for (std::size_t i = 0; i < deleteConfigRaw->size(); ++i) {
-				if (!deleteConfigRaw->isArray(i))
-					continue;
-				auto cmd = deleteConfigRaw->getArray(i);
-				if (cmd)
-					mergedRaw->add(cmd);
-			}
-		}
-
-		if (mergedRaw->size() > 0) {
-			gatewayConfig->set("config-raw", mergedRaw);
-		} else {
-			gatewayConfig->remove("config-raw");
-		}
-	}
 
 	void RESTAPI_groups_handler::DoGet() {
 		if (UserInfo_.userinfo.id.empty()) {
@@ -205,83 +128,19 @@ namespace OpenWifi {
 		}
 
 		Poco::JSON::Array::Ptr deleteConfigRaw;
-		if (!ExtractDeleteConfigRaw(callResponse, deleteConfigRaw)) {
+		if (!RESTAPI::ParentalControl::ExtractConfigRawSnapshot(callResponse, deleteConfigRaw)) {
 			Logger().error(fmt::format("DoDelete: invalid parental-control delete payload "
 									   "(subscriber={} group={})",
 									   UserInfo_.userinfo.id, groupId));
 			return InternalError(RESTAPI::Errors::InternalError);
 		}
 
-		// If the parental-control service returned a body with config-raw entries,
-		// apply the merged config to the subscriber's gateway device.
-		if (deleteConfigRaw && deleteConfigRaw->size() > 0) {
-			const std::string operatorId = UserInfo_.userinfo.owner;
-			if (operatorId.empty()) {
-				Logger().error(fmt::format("DoDelete: operator id missing for gateway apply "
-										   "(subscriber={} group={})",
-										   UserInfo_.userinfo.id, groupId));
-				return UnAuthorized(RESTAPI::Errors::OperatorIdMustExist);
-			}
-
-			ProvObjects::SubscriberDeviceList devList;
-			Poco::Net::HTTPResponse::HTTPStatus provStatus;
-			Poco::JSON::Object::Ptr provResponse;
-			if (!SDK::Prov::Subscriber::GetDevices(this, UserInfo_.userinfo.id, operatorId, devList,
-												   provStatus, provResponse)) {
-				Logger().error(fmt::format("DoDelete: provisioning lookup failed "
-										   "(subscriber={} group={})",
-										   UserInfo_.userinfo.id, groupId));
-				return InternalError(RESTAPI::Errors::InternalError);
-			}
-
-			std::string gatewaySerial;
-			for (const auto &dev : devList.subscriberDevices) {
-				std::string grp = dev.deviceGroup;
-				Poco::toLowerInPlace(grp);
-				if (grp == "olg") {
-					gatewaySerial = dev.serialNumber;
-					break;
-				}
-			}
-
-			if (gatewaySerial.empty()) {
-				Logger().error(fmt::format("DoDelete: gateway serial not resolved "
-										   "(subscriber={} group={})",
-										   UserInfo_.userinfo.id, groupId));
-				return InternalError(RESTAPI::Errors::MissingSerialNumber);
-			}
-
-			Poco::JSON::Object::Ptr gwResponse;
-			Poco::Net::HTTPResponse::HTTPStatus gwStatus;
-			if (!SDK::GW::Device::GetConfig(this, gatewaySerial, gwStatus, gwResponse)) {
-				if (gwStatus == Poco::Net::HTTPResponse::HTTP_OK) {
-					Logger().error(
-						fmt::format("DoDelete: gateway config malformed (serial={})", gatewaySerial));
-					return InternalError(RESTAPI::Errors::InternalError);
-				}
-				Logger().error(
-					fmt::format("DoDelete: gateway config load failed (serial={})", gatewaySerial));
-				return InternalError(RESTAPI::Errors::InternalError);
-			}
-
-			if (!gwResponse || !gwResponse->has("configuration") ||
-				!gwResponse->isObject("configuration")) {
-				Logger().error(
-					fmt::format("DoDelete: gateway config malformed (serial={})", gatewaySerial));
-				return InternalError(RESTAPI::Errors::InternalError);
-			}
-
-			auto gatewayConfig = gwResponse->getObject("configuration");
-			MergeConfigRaw(gatewayConfig, deleteConfigRaw);
-
-			Poco::JSON::Object::Ptr configureResponse;
-			Poco::Net::HTTPResponse::HTTPStatus configureStatus;
-			if (!SDK::GW::Device::Configure(this, gatewaySerial, gatewayConfig, configureStatus,
-											configureResponse)) {
-				Logger().error(
-					fmt::format("DoDelete: gateway configure failed (serial={})", gatewaySerial));
-				return InternalError(RESTAPI::Errors::InternalError);
-			}
+		if (!RESTAPI::ParentalControl::HandleApplyConfigRawResult(
+				*this, RESTAPI::ParentalControl::ApplyConfigRaw(*this, Logger(),
+																UserInfo_.userinfo.id,
+																UserInfo_.userinfo.owner, groupId,
+																deleteConfigRaw, "DoDelete", "group"))) {
+			return;
 		}
 
 		// YAML contract: DELETE public success returns empty HTTP 200.

--- a/src/RESTAPI/RESTAPI_parental_control_utils.cpp
+++ b/src/RESTAPI/RESTAPI_parental_control_utils.cpp
@@ -290,6 +290,24 @@ namespace OpenWifi::RESTAPI::ParentalControl {
 		if (!configRaw) {
 			return false;
 		}
+		for (std::size_t i = 0; i < configRaw->size(); ++i) {
+			try {
+				auto cmd = configRaw->getArray(i);
+				if (!cmd) {
+					return false;
+				}
+				if (cmd->size() != 2 && cmd->size() != 3) {
+					return false;
+				}
+				for (std::size_t j = 0; j < cmd->size(); ++j) {
+					if (!cmd->get(j).isString()) {
+						return false;
+					}
+				}
+			} catch (...) {
+				return false;
+			}
+		}
 		return true;
 	}
 
@@ -376,7 +394,7 @@ namespace OpenWifi::RESTAPI::ParentalControl {
 		case ApplyConfigRawResult::Applied:
 			return true;
 		case ApplyConfigRawResult::MissingOperatorId:
-			handler.BadRequest(RESTAPI::Errors::OperatorIdMustExist);
+			handler.UnAuthorized(RESTAPI::Errors::OperatorIdMustExist);
 			return false;
 		case ApplyConfigRawResult::MissingGatewaySerial:
 			handler.InternalError(RESTAPI::Errors::MissingSerialNumber);

--- a/src/RESTAPI/RESTAPI_parental_control_utils.cpp
+++ b/src/RESTAPI/RESTAPI_parental_control_utils.cpp
@@ -1,0 +1,395 @@
+/*
+ * SPDX-License-Identifier: AGPL-3.0 OR LicenseRef-Commercial
+ * Copyright (c) 2025 Infernet Systems Pvt Ltd
+ * Portions copyright (c) Telecom Infra Project (TIP), BSD-3-Clause
+ */
+
+#include "RESTAPI_parental_control_utils.h"
+#include "Poco/Format.h"
+#include "fmt/format.h"
+#include "sdks/SDK_gw.h"
+#include "sdks/SDK_prov.h"
+#include <cctype>
+#include <set>
+#include <vector>
+
+namespace OpenWifi::RESTAPI::ParentalControl {
+
+	namespace {
+		bool MinuteToTimeString(int minuteOfDay, std::string &timeValue) {
+			if (minuteOfDay < 0 || minuteOfDay > 1439) {
+				return false;
+			}
+
+			const int hour = minuteOfDay / 60;
+			const int minute = minuteOfDay % 60;
+			timeValue = Poco::format("%02d:%02d", hour, minute);
+			return true;
+		}
+	} // namespace
+
+	bool NormalizeScheduleResponse(Poco::JSON::Object::Ptr schedule) {
+		if (!schedule || !schedule->has("start_minute") || !schedule->has("stop_minute")) {
+			return false;
+		}
+
+		int startMinute = 0;
+		int stopMinute = 0;
+		try {
+			startMinute = schedule->getValue<int>("start_minute");
+			stopMinute = schedule->getValue<int>("stop_minute");
+		} catch (...) {
+			return false;
+		}
+
+		std::string startTime;
+		std::string stopTime;
+		if (!MinuteToTimeString(startMinute, startTime) ||
+			!MinuteToTimeString(stopMinute, stopTime)) {
+			return false;
+		}
+
+		schedule->set("start_time", startTime);
+		schedule->set("stop_time", stopTime);
+		schedule->remove("start_minute");
+		schedule->remove("stop_minute");
+		schedule->remove("config-raw");
+		return true;
+	}
+
+	bool ParseTimeString(const Poco::Dynamic::Var &value, int &minuteOfDay) {
+		if (!value.isString()) {
+			return false;
+		}
+
+		const auto timeValue = value.convert<std::string>();
+		if (timeValue.size() != 5 || timeValue[2] != ':' ||
+			!std::isdigit(static_cast<unsigned char>(timeValue[0])) ||
+			!std::isdigit(static_cast<unsigned char>(timeValue[1])) ||
+			!std::isdigit(static_cast<unsigned char>(timeValue[3])) ||
+			!std::isdigit(static_cast<unsigned char>(timeValue[4]))) {
+			return false;
+		}
+
+		const int hour = (timeValue[0] - '0') * 10 + (timeValue[1] - '0');
+		const int minute = (timeValue[3] - '0') * 10 + (timeValue[4] - '0');
+		if (hour > 23 || minute > 59) {
+			return false;
+		}
+
+		minuteOfDay = (hour * 60) + minute;
+		return true;
+	}
+
+	bool ValidateWeekdays(const Poco::JSON::Array::Ptr &weekdays) {
+		if (!weekdays || weekdays->size() == 0) {
+			return false;
+		}
+
+		std::set<int> seenDays;
+		for (std::size_t i = 0; i < weekdays->size(); ++i) {
+			try {
+				const int day = weekdays->getElement<int>(i);
+				if (day < 0 || day > 6 || !seenDays.insert(day).second) {
+					return false;
+				}
+			} catch (...) {
+				return false;
+			}
+		}
+		return true;
+	}
+
+	bool ParseAndValidateScheduleRequest(RESTAPIHandler &handler,
+										  const Poco::JSON::Object::Ptr &body,
+										  bool enabledRequired,
+										  ParsedScheduleRequest &out) {
+		std::vector<std::string> names;
+		body->getNames(names);
+		for (const auto &name : names) {
+			if (name != "name" && name != "description" && name != "enabled" &&
+				name != "action_type" && name != "target_kind" && name != "target_value" &&
+				name != "start_time" && name != "stop_time" && name != "weekdays") {
+				handler.BadRequest(RESTAPI::Errors::MissingOrInvalidParameters,
+								   "Unknown field: " + name);
+				return false;
+			}
+		}
+
+		if (!body->has("name") || body->isNull("name") || !body->get("name").isString()) {
+			handler.BadRequest(RESTAPI::Errors::MissingOrInvalidParameters, "name is required");
+			return false;
+		}
+		out.name = body->getValue<std::string>("name");
+		Poco::trimInPlace(out.name);
+		if (out.name.empty()) {
+			handler.BadRequest(RESTAPI::Errors::MissingOrInvalidParameters,
+							   "name must be non-empty");
+			return false;
+		}
+
+		if (!body->has("action_type") || body->isNull("action_type") ||
+			!body->get("action_type").isString() ||
+			body->getValue<std::string>("action_type") != "BLOCK") {
+			handler.BadRequest(RESTAPI::Errors::MissingOrInvalidParameters,
+							   "action_type must be BLOCK");
+			return false;
+		}
+
+		if (!body->has("target_kind") || body->isNull("target_kind") ||
+			!body->get("target_kind").isString()) {
+			handler.BadRequest(RESTAPI::Errors::MissingOrInvalidParameters,
+							   "target_kind is required");
+			return false;
+		}
+		out.targetKind = body->getValue<std::string>("target_kind");
+		if (out.targetKind != "INTERNET" && out.targetKind != "APP") {
+			handler.BadRequest(RESTAPI::Errors::MissingOrInvalidParameters,
+							   "target_kind must be INTERNET or APP");
+			return false;
+		}
+
+		if (!body->has("target_value")) {
+			handler.BadRequest(RESTAPI::Errors::MissingOrInvalidParameters,
+							   "target_value is required");
+			return false;
+		}
+		if (body->isNull("target_value")) {
+			if (out.targetKind != "INTERNET") {
+				handler.BadRequest(RESTAPI::Errors::MissingOrInvalidParameters,
+								   "APP schedules require a non-empty target_value");
+				return false;
+			}
+		} else {
+			if (!body->get("target_value").isString()) {
+				handler.BadRequest(RESTAPI::Errors::MissingOrInvalidParameters,
+								   "target_value must be a string or null");
+				return false;
+			}
+			out.targetValue = body->getValue<std::string>("target_value");
+			Poco::trimInPlace(out.targetValue);
+			if (out.targetKind == "APP") {
+				if (out.targetValue.empty()) {
+					handler.BadRequest(RESTAPI::Errors::MissingOrInvalidParameters,
+									   "APP schedules require a non-empty target_value");
+					return false;
+				}
+			} else {
+				handler.BadRequest(RESTAPI::Errors::MissingOrInvalidParameters,
+								   "INTERNET schedules require target_value to be null");
+				return false;
+			}
+		}
+
+		if (!body->has("start_time") ||
+			!ParseTimeString(body->get("start_time"), out.startMinute)) {
+			handler.BadRequest(RESTAPI::Errors::MissingOrInvalidParameters,
+							   "start_time must use HH:MM format");
+			return false;
+		}
+		if (!body->has("stop_time") ||
+			!ParseTimeString(body->get("stop_time"), out.stopMinute)) {
+			handler.BadRequest(RESTAPI::Errors::MissingOrInvalidParameters,
+							   "stop_time must use HH:MM format");
+			return false;
+		}
+		if (out.startMinute == out.stopMinute) {
+			handler.BadRequest(RESTAPI::Errors::MissingOrInvalidParameters,
+							   "start_time and stop_time must not represent the same minute");
+			return false;
+		}
+
+		if (!body->has("weekdays") || !body->isArray("weekdays") ||
+			!ValidateWeekdays(body->getArray("weekdays"))) {
+			handler.BadRequest(RESTAPI::Errors::MissingOrInvalidParameters,
+							   "weekdays must contain distinct values in the range 0..6");
+			return false;
+		}
+		out.weekdays = body->getArray("weekdays");
+
+		if (enabledRequired) {
+			if (!body->has("enabled") || body->isNull("enabled") ||
+				body->get("enabled").type() != typeid(bool)) {
+				handler.BadRequest(RESTAPI::Errors::MissingOrInvalidParameters,
+								   "enabled is required and must be a boolean");
+				return false;
+			}
+			out.enabled = body->getValue<bool>("enabled");
+		} else {
+			if (body->has("enabled")) {
+				if (body->isNull("enabled") || body->get("enabled").type() != typeid(bool)) {
+					handler.BadRequest(RESTAPI::Errors::MissingOrInvalidParameters,
+									   "enabled must be a boolean");
+					return false;
+				}
+				out.enabled = body->getValue<bool>("enabled");
+			} else {
+				out.enabled = true;
+			}
+		}
+
+		if (enabledRequired && !body->has("description")) {
+			handler.BadRequest(RESTAPI::Errors::MissingOrInvalidParameters,
+							   "description is required for PUT");
+			return false;
+		}
+
+		if (body->isNull("description")) {
+			out.description = std::nullopt;
+		} else if (body->has("description")) {
+			if (!body->get("description").isString()) {
+				handler.BadRequest(RESTAPI::Errors::MissingOrInvalidParameters,
+								   "description must be a string or null");
+				return false;
+			}
+			std::string desc = body->getValue<std::string>("description");
+			Poco::trimInPlace(desc);
+			out.description = std::move(desc);
+		} else {
+			out.description = std::nullopt;
+		}
+
+		return true;
+	}
+
+	Poco::JSON::Object BuildScheduleRequestBody(const ParsedScheduleRequest &req) {
+		Poco::JSON::Object body;
+		body.set("name", req.name);
+		if (req.description.has_value()) {
+			body.set("description", *req.description);
+		} else {
+			body.set("description", Poco::Dynamic::Var());
+		}
+		body.set("enabled", req.enabled);
+		body.set("action_type", "BLOCK");
+		body.set("target_kind", req.targetKind);
+		if (req.targetKind == "APP") {
+			body.set("target_value", req.targetValue);
+		} else {
+			body.set("target_value", Poco::Dynamic::Var());
+		}
+		body.set("start_minute", req.startMinute);
+		body.set("stop_minute", req.stopMinute);
+		body.set("weekdays", req.weekdays);
+		return body;
+	}
+
+	bool ExtractConfigRawSnapshot(const Poco::JSON::Object::Ptr &callResponse,
+								  Poco::JSON::Array::Ptr &configRaw) {
+		configRaw.reset();
+		if (!callResponse) {
+			return true;
+		}
+		if (!callResponse->has("config-raw") || callResponse->isNull("config-raw")) {
+			return true;
+		}
+		if (!callResponse->isArray("config-raw")) {
+			return false;
+		}
+		configRaw = callResponse->getArray("config-raw");
+		if (!configRaw) {
+			return false;
+		}
+		return true;
+	}
+
+	ApplyConfigRawResult ApplyConfigRaw(RESTAPIHandler &handler, Poco::Logger &logger,
+										const std::string &subscriberId,
+										const std::string &operatorId, const std::string &objectId,
+										const Poco::JSON::Array::Ptr &configRaw,
+										const std::string &operationName,
+										const std::string &objectType) {
+		if (!configRaw) {
+			return ApplyConfigRawResult::NoConfigApplyNeeded;
+		}
+
+		if (operatorId.empty()) {
+			logger.error(fmt::format("{}: operator id missing for gateway apply (subscriber={} {}={})",
+									 operationName, subscriberId, objectType, objectId));
+			return ApplyConfigRawResult::MissingOperatorId;
+		}
+
+		ProvObjects::SubscriberDeviceList devList;
+		Poco::Net::HTTPResponse::HTTPStatus provStatus;
+		Poco::JSON::Object::Ptr provResponse;
+		if (!SDK::Prov::Subscriber::GetDevices(&handler, subscriberId, operatorId, devList,
+											   provStatus, provResponse)) {
+			logger.error(fmt::format("{}: provisioning lookup failed (subscriber={} {}={})",
+									 operationName, subscriberId, objectType, objectId));
+			return ApplyConfigRawResult::ProvisioningLookupFailed;
+		}
+
+		std::string gatewaySerial;
+		for (const auto &dev : devList.subscriberDevices) {
+			std::string grp = dev.deviceGroup;
+			Poco::toLowerInPlace(grp);
+			if (grp == "olg") {
+				gatewaySerial = dev.serialNumber;
+				break;
+			}
+		}
+
+		if (gatewaySerial.empty()) {
+			logger.error(fmt::format("{}: gateway serial not resolved (subscriber={} {}={})",
+									 operationName, subscriberId, objectType, objectId));
+			return ApplyConfigRawResult::MissingGatewaySerial;
+		}
+
+		Poco::JSON::Object::Ptr gwResponse;
+		Poco::Net::HTTPResponse::HTTPStatus gwStatus;
+		if (!SDK::GW::Device::GetConfig(&handler, gatewaySerial, gwStatus, gwResponse)) {
+			if (gwStatus == Poco::Net::HTTPResponse::HTTP_OK) {
+				logger.error(fmt::format("{}: gateway config malformed (serial={})", operationName,
+										 gatewaySerial));
+			} else {
+				logger.error(fmt::format("{}: gateway config load failed (serial={})",
+										 operationName, gatewaySerial));
+			}
+			return ApplyConfigRawResult::GatewayConfigLoadFailed;
+		}
+
+		if (!gwResponse || !gwResponse->has("configuration") ||
+			!gwResponse->isObject("configuration")) {
+			logger.error(fmt::format("{}: gateway config malformed (serial={})", operationName,
+									 gatewaySerial));
+			return ApplyConfigRawResult::GatewayConfigMalformed;
+		}
+
+		auto gatewayConfig = gwResponse->getObject("configuration");
+		gatewayConfig->set("config-raw", configRaw);
+
+		Poco::JSON::Object::Ptr configureResponse;
+		Poco::Net::HTTPResponse::HTTPStatus configureStatus;
+		if (!SDK::GW::Device::Configure(&handler, gatewaySerial, gatewayConfig, configureStatus,
+										configureResponse)) {
+			logger.error(fmt::format("{}: gateway configure failed (serial={})", operationName,
+									 gatewaySerial));
+			return ApplyConfigRawResult::GatewayConfigureFailed;
+		}
+
+		return ApplyConfigRawResult::Applied;
+	}
+
+	bool HandleApplyConfigRawResult(RESTAPIHandler &handler, ApplyConfigRawResult result) {
+		switch (result) {
+		case ApplyConfigRawResult::NoConfigApplyNeeded:
+		case ApplyConfigRawResult::Applied:
+			return true;
+		case ApplyConfigRawResult::MissingOperatorId:
+			handler.BadRequest(RESTAPI::Errors::OperatorIdMustExist);
+			return false;
+		case ApplyConfigRawResult::MissingGatewaySerial:
+			handler.InternalError(RESTAPI::Errors::MissingSerialNumber);
+			return false;
+		case ApplyConfigRawResult::ProvisioningLookupFailed:
+		case ApplyConfigRawResult::GatewayConfigLoadFailed:
+		case ApplyConfigRawResult::GatewayConfigMalformed:
+		case ApplyConfigRawResult::GatewayConfigureFailed:
+			handler.InternalError(RESTAPI::Errors::InternalError);
+			return false;
+		}
+		handler.InternalError(RESTAPI::Errors::InternalError);
+		return false;
+	}
+
+} // namespace OpenWifi::RESTAPI::ParentalControl

--- a/src/RESTAPI/RESTAPI_parental_control_utils.cpp
+++ b/src/RESTAPI/RESTAPI_parental_control_utils.cpp
@@ -374,6 +374,9 @@ namespace OpenWifi::RESTAPI::ParentalControl {
 		}
 
 		auto gatewayConfig = gwResponse->getObject("configuration");
+		// Replacing the full config-raw section is intentional because parental-control is
+		// currently the only service producing config-raw, and the gateway-fetched config-raw
+		// doesn't include a reliable ownership marker to enable selective merging.
 		gatewayConfig->set("config-raw", configRaw);
 
 		Poco::JSON::Object::Ptr configureResponse;

--- a/src/RESTAPI/RESTAPI_parental_control_utils.h
+++ b/src/RESTAPI/RESTAPI_parental_control_utils.h
@@ -1,0 +1,64 @@
+/*
+ * SPDX-License-Identifier: AGPL-3.0 OR LicenseRef-Commercial
+ * Copyright (c) 2025 Infernet Systems Pvt Ltd
+ * Portions copyright (c) Telecom Infra Project (TIP), BSD-3-Clause
+ */
+
+#pragma once
+
+#include "Poco/JSON/Array.h"
+#include "Poco/JSON/Object.h"
+#include "framework/RESTAPI_Handler.h"
+#include <optional>
+#include <string>
+
+namespace OpenWifi::RESTAPI::ParentalControl {
+
+	enum class ApplyConfigRawResult {
+		NoConfigApplyNeeded,
+		Applied,
+		MissingOperatorId,
+		ProvisioningLookupFailed,
+		MissingGatewaySerial,
+		GatewayConfigLoadFailed,
+		GatewayConfigMalformed,
+		GatewayConfigureFailed
+	};
+
+	bool NormalizeScheduleResponse(Poco::JSON::Object::Ptr schedule);
+
+	bool ParseTimeString(const Poco::Dynamic::Var &value, int &minuteOfDay);
+
+	bool ValidateWeekdays(const Poco::JSON::Array::Ptr &weekdays);
+
+	bool ExtractConfigRawSnapshot(const Poco::JSON::Object::Ptr &callResponse,
+								  Poco::JSON::Array::Ptr &configRaw);
+
+	ApplyConfigRawResult ApplyConfigRaw(RESTAPIHandler &handler, Poco::Logger &logger,
+										const std::string &subscriberId,
+										const std::string &operatorId, const std::string &objectId,
+										const Poco::JSON::Array::Ptr &configRaw,
+										const std::string &operationName,
+										const std::string &objectType);
+
+	struct ParsedScheduleRequest {
+		std::string name;
+		std::optional<std::string> description;
+		bool enabled = true;
+		std::string targetKind;
+		std::string targetValue;
+		int startMinute = 0;
+		int stopMinute = 0;
+		Poco::JSON::Array::Ptr weekdays;
+	};
+
+	bool ParseAndValidateScheduleRequest(RESTAPIHandler &handler,
+										  const Poco::JSON::Object::Ptr &body,
+										  bool enabledRequired,
+										  ParsedScheduleRequest &out);
+
+	Poco::JSON::Object BuildScheduleRequestBody(const ParsedScheduleRequest &req);
+
+	bool HandleApplyConfigRawResult(RESTAPIHandler &handler, ApplyConfigRawResult result);
+
+} // namespace OpenWifi::RESTAPI::ParentalControl

--- a/src/RESTAPI/RESTAPI_routers.cpp
+++ b/src/RESTAPI/RESTAPI_routers.cpp
@@ -19,6 +19,8 @@
 #include "RESTAPI/RESTAPI_wifiClients_handler.h"
 #include "RESTAPI/RESTAPI_groups_list_handler.h"
 #include "RESTAPI/RESTAPI_groups_handler.h"
+#include "RESTAPI/RESTAPI_schedules_list_handler.h"
+#include "RESTAPI/RESTAPI_schedules_handler.h"
 
 #include "framework/RESTAPI_SystemCommand.h"
 #include "framework/RESTAPI_WebSocketServer.h"
@@ -34,7 +36,8 @@ namespace OpenWifi {
 							  RESTAPI_action_handler, RESTAPI_mfa_handler, RESTAPI_claim_handler,
 							  RESTAPI_system_command, RESTAPI_system_configuration,
                               RESTAPI_stats_handler, RESTAPI_topology_handler,
-							  RESTAPI_webSocketServer, RESTAPI_groups_list_handler, RESTAPI_groups_handler>(Path, Bindings, L, S, TransactionId);
+							  RESTAPI_webSocketServer, RESTAPI_groups_list_handler, RESTAPI_groups_handler,
+							  RESTAPI_schedules_list_handler, RESTAPI_schedules_handler>(Path, Bindings, L, S, TransactionId);
 	}
 
 	Poco::Net::HTTPRequestHandler *
@@ -45,7 +48,8 @@ namespace OpenWifi {
 								RESTAPI_action_handler, RESTAPI_mfa_handler, RESTAPI_claim_handler,
 								RESTAPI_system_command, RESTAPI_system_configuration,
 								RESTAPI_topology_handler,
-								RESTAPI_stats_handler, RESTAPI_groups_list_handler, RESTAPI_groups_handler>(Path, Bindings, L, S, TransactionId);
+								RESTAPI_stats_handler, RESTAPI_groups_list_handler, RESTAPI_groups_handler,
+								RESTAPI_schedules_list_handler, RESTAPI_schedules_handler>(Path, Bindings, L, S, TransactionId);
 	}
 
 } // namespace OpenWifi

--- a/src/RESTAPI/RESTAPI_schedules_handler.cpp
+++ b/src/RESTAPI/RESTAPI_schedules_handler.cpp
@@ -1,0 +1,138 @@
+/*
+ * SPDX-License-Identifier: AGPL-3.0 OR LicenseRef-Commercial
+ * Copyright (c) 2025 Infernet Systems Pvt Ltd
+ * Portions copyright (c) Telecom Infra Project (TIP), BSD-3-Clause
+ */
+
+#include "RESTAPI_schedules_handler.h"
+#include "RESTAPI_parental_control_utils.h"
+#include "fmt/format.h"
+#include "framework/utils.h"
+#include "sdks/SDK_parental_control.h"
+
+namespace OpenWifi {
+
+	void RESTAPI_schedules_handler::DoGet() {
+		if (UserInfo_.userinfo.id.empty()) {
+			return UnAuthorized(RESTAPI::Errors::InvalidSubscriberId);
+		}
+
+		const auto scheduleId = GetBinding("schedule_id", "");
+		if (scheduleId.empty()) {
+			return BadRequest(RESTAPI::Errors::MissingUUID);
+		}
+		if (!Utils::ValidUUID(scheduleId)) {
+			return BadRequest(RESTAPI::Errors::UnknownId);
+		}
+
+		Poco::Net::HTTPResponse::HTTPStatus callStatus;
+		Poco::JSON::Object::Ptr callResponse;
+
+		if (!SDK::ParentalControl::GetSchedule(this, UserInfo_.userinfo.id, scheduleId, callStatus,
+											   callResponse)) {
+			return ForwardErrorResponse(this, callStatus, callResponse);
+		}
+
+		if (!RESTAPI::ParentalControl::NormalizeScheduleResponse(callResponse)) {
+			return InternalError(RESTAPI::Errors::InternalError);
+		}
+		return ReturnObject(*callResponse);
+	}
+
+	void RESTAPI_schedules_handler::DoPut() {
+		if (UserInfo_.userinfo.id.empty()) {
+			return UnAuthorized(RESTAPI::Errors::InvalidSubscriberId);
+		}
+
+		const auto scheduleId = GetBinding("schedule_id", "");
+		if (scheduleId.empty()) {
+			return BadRequest(RESTAPI::Errors::MissingUUID);
+		}
+		if (!Utils::ValidUUID(scheduleId)) {
+			return BadRequest(RESTAPI::Errors::UnknownId);
+		}
+
+		if (!ParsedBody_) {
+			return BadRequest(RESTAPI::Errors::InvalidJSONDocument);
+		}
+
+		RESTAPI::ParentalControl::ParsedScheduleRequest req;
+		if (!RESTAPI::ParentalControl::ParseAndValidateScheduleRequest(*this, ParsedBody_,
+																	   /*enabledRequired=*/true,
+																	   req)) {
+			return;
+		}
+
+		Poco::JSON::Object body = RESTAPI::ParentalControl::BuildScheduleRequestBody(req);
+
+		Poco::Net::HTTPResponse::HTTPStatus callStatus;
+		Poco::JSON::Object::Ptr callResponse;
+		if (!SDK::ParentalControl::UpdateSchedule(this, UserInfo_.userinfo.id, scheduleId, body,
+												  callStatus, callResponse)) {
+			return ForwardErrorResponse(this, callStatus, callResponse);
+		}
+
+		Poco::JSON::Array::Ptr configRaw;
+		if (!RESTAPI::ParentalControl::ExtractConfigRawSnapshot(callResponse, configRaw)) {
+			Logger().error(fmt::format("DoPut: invalid parental-control update payload "
+									   "(subscriber={} schedule={})",
+									   UserInfo_.userinfo.id, scheduleId));
+			return InternalError(RESTAPI::Errors::InternalError);
+		}
+
+		if (!RESTAPI::ParentalControl::HandleApplyConfigRawResult(
+				*this, RESTAPI::ParentalControl::ApplyConfigRaw(*this, Logger(),
+																UserInfo_.userinfo.id,
+																UserInfo_.userinfo.owner, scheduleId,
+																configRaw, "DoPut", "schedule"))) {
+			return;
+		}
+
+		if (!RESTAPI::ParentalControl::NormalizeScheduleResponse(callResponse)) {
+			return InternalError(RESTAPI::Errors::InternalError);
+		}
+		return ReturnObject(*callResponse);
+	}
+
+	void RESTAPI_schedules_handler::DoDelete() {
+		if (UserInfo_.userinfo.id.empty()) {
+			return UnAuthorized(RESTAPI::Errors::InvalidSubscriberId);
+		}
+
+		const auto scheduleId = GetBinding("schedule_id", "");
+		if (scheduleId.empty()) {
+			return BadRequest(RESTAPI::Errors::MissingUUID);
+		}
+		if (!Utils::ValidUUID(scheduleId)) {
+			return BadRequest(RESTAPI::Errors::UnknownId);
+		}
+
+		Poco::Net::HTTPResponse::HTTPStatus callStatus;
+		Poco::JSON::Object::Ptr callResponse;
+		std::string rawResponseBody;
+
+		if (!SDK::ParentalControl::DeleteSchedule(this, UserInfo_.userinfo.id, scheduleId,
+												  callStatus, callResponse, rawResponseBody)) {
+			return ForwardErrorResponse(this, callStatus, callResponse);
+		}
+
+		Poco::JSON::Array::Ptr configRaw;
+		if (!RESTAPI::ParentalControl::ExtractConfigRawSnapshot(callResponse, configRaw)) {
+			Logger().error(fmt::format("DoDelete: invalid parental-control delete payload "
+									   "(subscriber={} schedule={})",
+									   UserInfo_.userinfo.id, scheduleId));
+			return InternalError(RESTAPI::Errors::InternalError);
+		}
+
+		if (!RESTAPI::ParentalControl::HandleApplyConfigRawResult(
+				*this, RESTAPI::ParentalControl::ApplyConfigRaw(*this, Logger(),
+																UserInfo_.userinfo.id,
+																UserInfo_.userinfo.owner, scheduleId,
+																configRaw, "DoDelete", "schedule"))) {
+			return;
+		}
+
+		return OK();
+	}
+
+} // namespace OpenWifi

--- a/src/RESTAPI/RESTAPI_schedules_handler.h
+++ b/src/RESTAPI/RESTAPI_schedules_handler.h
@@ -1,0 +1,31 @@
+/*
+ * SPDX-License-Identifier: AGPL-3.0 OR LicenseRef-Commercial
+ * Copyright (c) 2025 Infernet Systems Pvt Ltd
+ * Portions copyright (c) Telecom Infra Project (TIP), BSD-3-Clause
+ */
+
+#pragma once
+
+#include "framework/RESTAPI_Handler.h"
+
+namespace OpenWifi {
+	class RESTAPI_schedules_handler : public RESTAPIHandler {
+	  public:
+		RESTAPI_schedules_handler(const RESTAPIHandler::BindingMap &bindings, Poco::Logger &L,
+								  RESTAPI_GenericServerAccounting &Server, uint64_t TransactionId,
+								  bool Internal)
+			: RESTAPIHandler(bindings, L,
+							 std::vector<std::string>{Poco::Net::HTTPRequest::HTTP_GET,
+													  Poco::Net::HTTPRequest::HTTP_PUT,
+													  Poco::Net::HTTPRequest::HTTP_DELETE,
+													  Poco::Net::HTTPRequest::HTTP_OPTIONS},
+							 Server, TransactionId, Internal) {}
+
+		static auto PathName() { return std::list<std::string>{"/api/v1/schedules/{schedule_id}"}; }
+
+		void DoGet() override;
+		void DoPut() override;
+		void DoDelete() override;
+		void DoPost() override {}
+	};
+} // namespace OpenWifi

--- a/src/RESTAPI/RESTAPI_schedules_list_handler.cpp
+++ b/src/RESTAPI/RESTAPI_schedules_list_handler.cpp
@@ -1,0 +1,72 @@
+/*
+ * SPDX-License-Identifier: AGPL-3.0 OR LicenseRef-Commercial
+ * Copyright (c) 2025 Infernet Systems Pvt Ltd
+ * Portions copyright (c) Telecom Infra Project (TIP), BSD-3-Clause
+ */
+
+#include "RESTAPI_schedules_list_handler.h"
+#include "Poco/JSON/Stringifier.h"
+#include "RESTAPI_parental_control_utils.h"
+#include "sdks/SDK_parental_control.h"
+
+namespace OpenWifi {
+
+	void RESTAPI_schedules_list_handler::DoGet() {
+		if (UserInfo_.userinfo.id.empty()) {
+			return UnAuthorized(RESTAPI::Errors::InvalidSubscriberId);
+		}
+
+		Poco::Net::HTTPResponse::HTTPStatus callStatus;
+		Poco::JSON::Array::Ptr arrayResponse;
+		Poco::JSON::Object::Ptr errorResponse;
+
+		if (!SDK::ParentalControl::GetSchedules(this, UserInfo_.userinfo.id, callStatus,
+												arrayResponse, errorResponse)) {
+			return ForwardErrorResponse(this, callStatus, errorResponse);
+		}
+
+		for (std::size_t i = 0; i < arrayResponse->size(); ++i) {
+			if (!arrayResponse->isObject(i) ||
+				!RESTAPI::ParentalControl::NormalizeScheduleResponse(arrayResponse->getObject(i))) {
+				return InternalError(RESTAPI::Errors::InternalError);
+			}
+		}
+
+		std::ostringstream ss;
+		Poco::JSON::Stringifier::condense(*arrayResponse, ss);
+		return ReturnRawJSON(ss.str());
+	}
+
+	void RESTAPI_schedules_list_handler::DoPost() {
+		if (UserInfo_.userinfo.id.empty()) {
+			return UnAuthorized(RESTAPI::Errors::InvalidSubscriberId);
+		}
+
+		if (!ParsedBody_) {
+			return BadRequest(RESTAPI::Errors::InvalidJSONDocument);
+		}
+
+		RESTAPI::ParentalControl::ParsedScheduleRequest req;
+		if (!RESTAPI::ParentalControl::ParseAndValidateScheduleRequest(*this, ParsedBody_,
+																	   /*enabledRequired=*/false,
+																	   req)) {
+			return;
+		}
+
+		Poco::JSON::Object body = RESTAPI::ParentalControl::BuildScheduleRequestBody(req);
+
+		Poco::Net::HTTPResponse::HTTPStatus callStatus;
+		Poco::JSON::Object::Ptr callResponse;
+
+		if (!SDK::ParentalControl::CreateSchedule(this, UserInfo_.userinfo.id, body, callStatus,
+												  callResponse)) {
+			return ForwardErrorResponse(this, callStatus, callResponse);
+		}
+
+		if (!RESTAPI::ParentalControl::NormalizeScheduleResponse(callResponse)) {
+			return InternalError(RESTAPI::Errors::InternalError);
+		}
+		return ReturnObject(*callResponse);
+	}
+
+} // namespace OpenWifi

--- a/src/RESTAPI/RESTAPI_schedules_list_handler.h
+++ b/src/RESTAPI/RESTAPI_schedules_list_handler.h
@@ -1,0 +1,30 @@
+/*
+ * SPDX-License-Identifier: AGPL-3.0 OR LicenseRef-Commercial
+ * Copyright (c) 2025 Infernet Systems Pvt Ltd
+ * Portions copyright (c) Telecom Infra Project (TIP), BSD-3-Clause
+ */
+
+#pragma once
+
+#include "framework/RESTAPI_Handler.h"
+
+namespace OpenWifi {
+	class RESTAPI_schedules_list_handler : public RESTAPIHandler {
+	  public:
+		RESTAPI_schedules_list_handler(const RESTAPIHandler::BindingMap &bindings, Poco::Logger &L,
+									   RESTAPI_GenericServerAccounting &Server,
+									   uint64_t TransactionId, bool Internal)
+			: RESTAPIHandler(bindings, L,
+							 std::vector<std::string>{Poco::Net::HTTPRequest::HTTP_GET,
+													  Poco::Net::HTTPRequest::HTTP_POST,
+													  Poco::Net::HTTPRequest::HTTP_OPTIONS},
+							 Server, TransactionId, Internal) {}
+
+		static auto PathName() { return std::list<std::string>{"/api/v1/schedules"}; }
+
+		void DoGet() override;
+		void DoPost() override;
+		void DoDelete() override {}
+		void DoPut() override {}
+	};
+} // namespace OpenWifi

--- a/src/sdks/SDK_parental_control.cpp
+++ b/src/sdks/SDK_parental_control.cpp
@@ -81,4 +81,61 @@ namespace OpenWifi::SDK::ParentalControl {
 		return CallResponse != nullptr;
 	}
 
+	bool GetSchedules(RESTAPIHandler *client, const std::string &SubscriberId,
+					  Poco::Net::HTTPResponse::HTTPStatus &CallStatus,
+					  Poco::JSON::Array::Ptr &ArrayResponse,
+					  Poco::JSON::Object::Ptr &ObjectResponse) {
+		std::string endpoint = "/api/v1/subscribers/" + SubscriberId + "/schedules";
+		auto API = OpenAPIRequestGet(uSERVICE_MANGO_PARENTAL_CONTROL, endpoint, {}, 60000);
+		CallStatus = API.Do(ArrayResponse, ObjectResponse,
+							client ? client->UserInfo_.webtoken.access_token_ : "");
+		return IsParsedArraySuccess(CallStatus, ArrayResponse);
+	}
+
+	bool CreateSchedule(RESTAPIHandler *client, const std::string &SubscriberId,
+						const Poco::JSON::Object &Body,
+						Poco::Net::HTTPResponse::HTTPStatus &CallStatus,
+						Poco::JSON::Object::Ptr &CallResponse) {
+		std::string endpoint = "/api/v1/subscribers/" + SubscriberId + "/schedules";
+		auto API = OpenAPIRequestPost(uSERVICE_MANGO_PARENTAL_CONTROL, endpoint, {}, Body, 60000);
+		CallStatus = API.Do(CallResponse, client ? client->UserInfo_.webtoken.access_token_ : "");
+		return IsParsedObjectSuccess(CallStatus, CallResponse);
+	}
+
+	bool GetSchedule(RESTAPIHandler *client, const std::string &SubscriberId,
+					 const std::string &ScheduleId, Poco::Net::HTTPResponse::HTTPStatus &CallStatus,
+					 Poco::JSON::Object::Ptr &CallResponse) {
+		std::string endpoint = "/api/v1/subscribers/" + SubscriberId + "/schedules/" + ScheduleId;
+		auto API = OpenAPIRequestGet(uSERVICE_MANGO_PARENTAL_CONTROL, endpoint, {}, 60000);
+		CallStatus = API.Do(CallResponse, client ? client->UserInfo_.webtoken.access_token_ : "");
+		return IsParsedObjectSuccess(CallStatus, CallResponse);
+	}
+
+	bool UpdateSchedule(RESTAPIHandler *client, const std::string &SubscriberId,
+						const std::string &ScheduleId, const Poco::JSON::Object &Body,
+						Poco::Net::HTTPResponse::HTTPStatus &CallStatus,
+						Poco::JSON::Object::Ptr &CallResponse) {
+		std::string endpoint = "/api/v1/subscribers/" + SubscriberId + "/schedules/" + ScheduleId;
+		auto API = OpenAPIRequestPut(uSERVICE_MANGO_PARENTAL_CONTROL, endpoint, {}, Body, 120000);
+		CallStatus = API.Do(CallResponse, client ? client->UserInfo_.webtoken.access_token_ : "");
+		return IsParsedObjectSuccess(CallStatus, CallResponse);
+	}
+
+	bool DeleteSchedule(RESTAPIHandler *client, const std::string &SubscriberId,
+						const std::string &ScheduleId,
+						Poco::Net::HTTPResponse::HTTPStatus &CallStatus,
+						Poco::JSON::Object::Ptr &CallResponse, std::string &RawResponseBody) {
+		std::string endpoint = "/api/v1/subscribers/" + SubscriberId + "/schedules/" + ScheduleId;
+		auto API = OpenAPIRequestDelete(uSERVICE_MANGO_PARENTAL_CONTROL, endpoint, {}, 120000);
+		CallStatus = API.Do(CallResponse, RawResponseBody,
+							client ? client->UserInfo_.webtoken.access_token_ : "");
+		if (CallStatus != Poco::Net::HTTPResponse::HTTP_OK) {
+			return false;
+		}
+		if (RawResponseBody.empty()) {
+			return true;
+		}
+		return CallResponse != nullptr;
+	}
+
 } // namespace OpenWifi::SDK::ParentalControl

--- a/src/sdks/SDK_parental_control.h
+++ b/src/sdks/SDK_parental_control.h
@@ -42,4 +42,28 @@ namespace OpenWifi::SDK::ParentalControl {
 	                 Poco::JSON::Object::Ptr &CallResponse,
 	                 std::string &RawResponseBody);
 
+	bool GetSchedules(RESTAPIHandler *client, const std::string &SubscriberId,
+					  Poco::Net::HTTPResponse::HTTPStatus &CallStatus,
+					  Poco::JSON::Array::Ptr &ArrayResponse,
+					  Poco::JSON::Object::Ptr &ObjectResponse);
+
+	bool CreateSchedule(RESTAPIHandler *client, const std::string &SubscriberId,
+						const Poco::JSON::Object &Body,
+						Poco::Net::HTTPResponse::HTTPStatus &CallStatus,
+						Poco::JSON::Object::Ptr &CallResponse);
+
+	bool GetSchedule(RESTAPIHandler *client, const std::string &SubscriberId,
+					 const std::string &ScheduleId, Poco::Net::HTTPResponse::HTTPStatus &CallStatus,
+					 Poco::JSON::Object::Ptr &CallResponse);
+
+	bool UpdateSchedule(RESTAPIHandler *client, const std::string &SubscriberId,
+						const std::string &ScheduleId, const Poco::JSON::Object &Body,
+						Poco::Net::HTTPResponse::HTTPStatus &CallStatus,
+						Poco::JSON::Object::Ptr &CallResponse);
+
+	bool DeleteSchedule(RESTAPIHandler *client, const std::string &SubscriberId,
+						const std::string &ScheduleId,
+						Poco::Net::HTTPResponse::HTTPStatus &CallStatus,
+						Poco::JSON::Object::Ptr &CallResponse, std::string &RawResponseBody);
+
 } // namespace OpenWifi::SDK::ParentalControl

--- a/test_scripts/fakes/fake_downstream_services.py
+++ b/test_scripts/fakes/fake_downstream_services.py
@@ -490,6 +490,8 @@ class FakeHandler(http.server.BaseHTTPRequestHandler):
                     }
                     if current_scenario == "config-raw-null":
                         resp_obj["config-raw"] = None
+                    elif current_scenario == "config-raw-malformed":
+                        resp_obj["config-raw"] = [123]
                     elif current_scenario.startswith("config-raw") or current_scenario.startswith("delete-config-raw"):
                         resp_obj["config-raw"] = [
                             ["set", "parental_control.ci_rule.enabled", "1"]
@@ -584,6 +586,10 @@ class FakeHandler(http.server.BaseHTTPRequestHandler):
                 self.send_response(200)
                 self.end_headers()
                 self.wfile.write(json.dumps({"config-raw": None}).encode())
+            elif current_scenario == "config-raw-malformed":
+                self.send_response(200)
+                self.end_headers()
+                self.wfile.write(json.dumps({"config-raw": [123]}).encode())
             elif current_scenario.startswith("config-raw") or current_scenario.startswith("delete-config-raw"):
                 self.send_response(200)
                 self.end_headers()

--- a/test_scripts/fakes/fake_downstream_services.py
+++ b/test_scripts/fakes/fake_downstream_services.py
@@ -27,6 +27,21 @@ def init_db():
             description TEXT
         )
     """)
+    cursor.execute("""
+        CREATE TABLE IF NOT EXISTS mock_schedules (
+            id UUID PRIMARY KEY,
+            subscriber_id TEXT,
+            name TEXT,
+            description TEXT,
+            enabled BOOLEAN,
+            action_type TEXT,
+            target_kind TEXT,
+            target_value TEXT,
+            start_minute INTEGER,
+            stop_minute INTEGER,
+            weekdays INTEGER[]
+        )
+    """)
     return conn
 
 # Let this throw an exception and crash the server if Postgres is not available
@@ -139,6 +154,64 @@ class FakeHandler(http.server.BaseHTTPRequestHandler):
                 self.wfile.write(json.dumps(groups).encode())
             return
 
+        if "/api/v1/subscribers/" in self.path and "/schedules" in self.path:
+            if current_scenario == "pc-404":
+                self.send_response(404)
+                self.end_headers()
+                self.wfile.write(json.dumps({"error":"not_found","message":"schedule not found"}).encode())
+                return
+            
+            cursor = db_conn.cursor()
+            match = re.search(r'/schedules/([a-f0-9\-]+)', self.path)
+            if match:
+                schedule_id = match.group(1)
+                cursor.execute("""
+                    SELECT id, name, description, enabled, action_type, target_kind, target_value, start_minute, stop_minute, weekdays 
+                    FROM mock_schedules WHERE id = %s
+                """, (schedule_id,))
+                row = cursor.fetchone()
+                if row:
+                    self.send_response(200)
+                    self.end_headers()
+                    self.wfile.write(json.dumps({
+                        "id": str(row[0]),
+                        "name": row[1],
+                        "description": row[2],
+                        "enabled": row[3],
+                        "action_type": row[4],
+                        "target_kind": row[5],
+                        "target_value": row[6],
+                        "start_minute": row[7],
+                        "stop_minute": row[8],
+                        "weekdays": row[9]
+                    }).encode())
+                else:
+                    self.send_response(404)
+                    self.end_headers()
+                    self.wfile.write(json.dumps({"error":"not_found","message":"schedule not found"}).encode())
+            else:
+                cursor.execute("""
+                    SELECT id, name, description, enabled, action_type, target_kind, target_value, start_minute, stop_minute, weekdays 
+                    FROM mock_schedules WHERE subscriber_id = 'sub1'
+                """)
+                rows = cursor.fetchall()
+                schedules = [{
+                    "id": str(r[0]),
+                    "name": r[1],
+                    "description": r[2],
+                    "enabled": r[3],
+                    "action_type": r[4],
+                    "target_kind": r[5],
+                    "target_value": r[6],
+                    "start_minute": r[7],
+                    "stop_minute": r[8],
+                    "weekdays": r[9]
+                } for r in rows]
+                self.send_response(200)
+                self.end_headers()
+                self.wfile.write(json.dumps(schedules).encode())
+            return
+
         # Gateway/Prov fakes remain scenario-based and hardcoded
         if "/api/v1/subscriberDevice" in self.path:
             if current_scenario in ["prov-502", "delete-config-raw-prov-502"]:
@@ -205,7 +278,7 @@ class FakeHandler(http.server.BaseHTTPRequestHandler):
                 "configuration": {
                     "config-raw": [
                         ["set", "wifi.ssid", "RouterTestSSID"],
-                        ["set", "parental_control.old_rule", "enabled", "1"]
+                        ["set", "parental_control.old_rule.enabled", "1"]
                     ]
                 }
             }
@@ -241,6 +314,7 @@ class FakeHandler(http.server.BaseHTTPRequestHandler):
         if "/reset-db" in self.path:
             cursor = db_conn.cursor()
             cursor.execute("TRUNCATE TABLE mock_groups")
+            cursor.execute("TRUNCATE TABLE mock_schedules")
             self.send_response(200)
             self.end_headers()
             return
@@ -293,6 +367,42 @@ class FakeHandler(http.server.BaseHTTPRequestHandler):
             self.wfile.write(json.dumps({"id": new_id, "name": req_data.get("name"), "description": req_data.get("description", "")}).encode())
             return
 
+        if "/api/v1/subscribers/" in self.path and "/schedules" in self.path:
+            if current_scenario == "pc-409":
+                self.send_response(409)
+                self.end_headers()
+                self.wfile.write(json.dumps({"error":"conflict","message":"schedule conflict"}).encode())
+                return
+                
+            req_data = json.loads(body.decode())
+            new_id = str(uuid.uuid4())
+            cursor = db_conn.cursor()
+            cursor.execute("""
+                INSERT INTO mock_schedules (id, subscriber_id, name, description, enabled, action_type, target_kind, target_value, start_minute, stop_minute, weekdays)
+                VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+            """, (
+                new_id, "sub1", req_data.get("name"), req_data.get("description"),
+                req_data.get("enabled", True), req_data.get("action_type", "BLOCK"),
+                req_data.get("target_kind"), req_data.get("target_value"),
+                req_data.get("start_minute"), req_data.get("stop_minute"),
+                req_data.get("weekdays")
+            ))
+            self.send_response(200)
+            self.end_headers()
+            self.wfile.write(json.dumps({
+                "id": new_id,
+                "name": req_data.get("name"),
+                "description": req_data.get("description"),
+                "enabled": req_data.get("enabled", True),
+                "action_type": req_data.get("action_type", "BLOCK"),
+                "target_kind": req_data.get("target_kind"),
+                "target_value": req_data.get("target_value"),
+                "start_minute": req_data.get("start_minute"),
+                "stop_minute": req_data.get("stop_minute"),
+                "weekdays": req_data.get("weekdays")
+            }).encode())
+            return
+
         self.send_response(404)
         self.end_headers()
 
@@ -336,6 +446,66 @@ class FakeHandler(http.server.BaseHTTPRequestHandler):
                 self.end_headers()
             return
 
+        if "/api/v1/subscribers/" in self.path and "/schedules" in self.path:
+            if current_scenario == "pc-404":
+                self.send_response(404)
+                self.end_headers()
+                self.wfile.write(json.dumps({"error":"not_found","message":"schedule not found"}).encode())
+                return
+            elif current_scenario == "pc-409":
+                self.send_response(409)
+                self.end_headers()
+                self.wfile.write(json.dumps({"error":"conflict","message":"schedule conflict"}).encode())
+                return
+                
+            # DB-backed PUT
+            match = re.search(r'/schedules/([a-f0-9\-]+)', self.path)
+            if match:
+                schedule_id = match.group(1)
+                req_data = json.loads(body.decode())
+                cursor = db_conn.cursor()
+                cursor.execute("""
+                    UPDATE mock_schedules 
+                    SET name = %s, description = %s, enabled = %s, action_type = %s, target_kind = %s, target_value = %s, start_minute = %s, stop_minute = %s, weekdays = %s 
+                    WHERE id = %s
+                """, (
+                    req_data.get("name"), req_data.get("description"),
+                    req_data.get("enabled"), req_data.get("action_type"),
+                    req_data.get("target_kind"), req_data.get("target_value"),
+                    req_data.get("start_minute"), req_data.get("stop_minute"),
+                    req_data.get("weekdays"), schedule_id
+                ))
+                if cursor.rowcount > 0:
+                    resp_obj = {
+                        "id": schedule_id,
+                        "name": req_data.get("name"),
+                        "description": req_data.get("description"),
+                        "enabled": req_data.get("enabled"),
+                        "action_type": req_data.get("action_type"),
+                        "target_kind": req_data.get("target_kind"),
+                        "target_value": req_data.get("target_value"),
+                        "start_minute": req_data.get("start_minute"),
+                        "stop_minute": req_data.get("stop_minute"),
+                        "weekdays": req_data.get("weekdays")
+                    }
+                    if current_scenario == "config-raw-null":
+                        resp_obj["config-raw"] = None
+                    elif current_scenario.startswith("config-raw") or current_scenario.startswith("delete-config-raw"):
+                        resp_obj["config-raw"] = [
+                            ["set", "parental_control.ci_rule.enabled", "1"]
+                        ]
+                    self.send_response(200)
+                    self.end_headers()
+                    self.wfile.write(json.dumps(resp_obj).encode())
+                else:
+                    self.send_response(404)
+                    self.end_headers()
+                    self.wfile.write(json.dumps({"error":"not_found","message":"schedule not found"}).encode())
+            else:
+                self.send_response(404)
+                self.end_headers()
+            return
+
         self.send_response(404)
         self.end_headers()
 
@@ -367,13 +537,59 @@ class FakeHandler(http.server.BaseHTTPRequestHandler):
                     self.wfile.write(json.dumps({"error":"not_found","message":"group not found"}).encode())
                     return
 
-            if current_scenario.startswith("config-raw") or current_scenario.startswith("delete-config-raw"):
+            if current_scenario == "config-raw-null":
+                self.send_response(200)
+                self.end_headers()
+                self.wfile.write(json.dumps({"config-raw": None}).encode())
+            elif current_scenario.startswith("config-raw") or current_scenario.startswith("delete-config-raw"):
                 self.send_response(200)
                 self.end_headers()
                 res = {
                     "config-raw": [
-                        ["delete", "parental_control.ci_rule"],
-                        ["set", "parental_control.ci_rule", "enabled", "0"]
+                        ["set", "parental_control.ci_rule.enabled", "0"]
+                    ]
+                }
+                self.wfile.write(json.dumps(res).encode())
+            else:
+                self.send_response(200)
+                self.end_headers()
+                self.wfile.write(b"")
+            return
+
+        if "/api/v1/subscribers/" in self.path and "/schedules" in self.path:
+            if current_scenario == "pc-404":
+                self.send_response(404)
+                self.end_headers()
+                self.wfile.write(json.dumps({"error":"not_found","message":"schedule not found"}).encode())
+                return
+            elif current_scenario == "pc-409":
+                self.send_response(409)
+                self.end_headers()
+                self.wfile.write(json.dumps({"error":"conflict","message":"schedule conflict"}).encode())
+                return
+                
+            # DB-backed DELETE
+            match = re.search(r'/schedules/([a-f0-9\-]+)', self.path)
+            if match:
+                schedule_id = match.group(1)
+                cursor = db_conn.cursor()
+                cursor.execute("DELETE FROM mock_schedules WHERE id = %s", (schedule_id,))
+                if cursor.rowcount == 0 and current_scenario == "normal":
+                    self.send_response(404)
+                    self.end_headers()
+                    self.wfile.write(json.dumps({"error":"not_found","message":"schedule not found"}).encode())
+                    return
+
+            if current_scenario == "config-raw-null":
+                self.send_response(200)
+                self.end_headers()
+                self.wfile.write(json.dumps({"config-raw": None}).encode())
+            elif current_scenario.startswith("config-raw") or current_scenario.startswith("delete-config-raw"):
+                self.send_response(200)
+                self.end_headers()
+                res = {
+                    "config-raw": [
+                        ["set", "parental_control.ci_rule.enabled", "0"]
                     ]
                 }
                 self.wfile.write(json.dumps(res).encode())

--- a/test_scripts/integration/test_groups_api.py
+++ b/test_scripts/integration/test_groups_api.py
@@ -151,9 +151,8 @@ def test_delete_orchestration():
         assert "config-raw" in payload["configuration"], "config-raw missing from configuration"
         
         config_raw = payload["configuration"]["config-raw"]
-        assert any(len(entry) > 1 and entry[1] == "wifi.ssid" for entry in config_raw), "Missing wifi.ssid from merged config-raw"
-        assert any(len(entry) > 1 and entry[1] == "parental_control.ci_rule" for entry in config_raw), "Missing parental_control.ci_rule from merged config-raw"
-        assert not any(len(entry) > 1 and entry[1] == "parental_control.old_rule" for entry in config_raw), "parental_control.old_rule was not deleted"
+        assert any(len(entry) > 1 and entry[1] == "parental_control.ci_rule.enabled" for entry in config_raw), "Missing parental_control.ci_rule.enabled from replaced config-raw"
+        assert not any(len(entry) > 1 and entry[1] == "wifi.ssid" for entry in config_raw), "wifi.ssid was preserved but replacement-only contract requires direct replacement"
         print("✅ DELETE config-raw happy path passed")
 
     # J) DELETE item with scenario "delete-config-raw-prov-502"

--- a/test_scripts/integration/test_groups_api.py
+++ b/test_scripts/integration/test_groups_api.py
@@ -141,7 +141,7 @@ def test_delete_orchestration():
     
     with open_url(f"{FAKE_URL}/observations") as r:
         obs = json.loads(r.read())
-        assert any("inventory" in call["path"] or "subscriber" in call["path"] for call in obs["calls"]), "Provisioning lookup not called"
+        assert any("inventory" in call["path"] or "subscriberDevice" in call["path"] for call in obs["calls"]), "Provisioning lookup not called"
         assert any("device" in call["path"] and call["method"] == "GET" for call in obs["calls"]), "Gateway get-config not called"
         assert any("configure" in call["path"] and call["method"] == "POST" for call in obs["calls"]), "Gateway configure not called"
         

--- a/test_scripts/integration/test_schedules_api.py
+++ b/test_scripts/integration/test_schedules_api.py
@@ -179,6 +179,21 @@ def test_forwarded_failures():
 
     print("✅ Forwarded downstream failure tests passed")
 
+def create_test_schedule(name="test"):
+    payload = {
+        "name": name,
+        "description": "desc",
+        "action_type": "BLOCK",
+        "target_kind": "INTERNET",
+        "target_value": None,
+        "start_time": "08:00",
+        "stop_time": "17:00",
+        "weekdays": [1]
+    }
+    status, body = request("POST", "/api/v1/schedules", body=payload)
+    assert status == 200, f"Expected 200 on test schedule creation, got {status}"
+    return body["id"]
+
 def test_put_orchestration():
     print("Testing PUT /schedules/{id} config-raw orchestrations...")
     payload = {
@@ -193,7 +208,8 @@ def test_put_orchestration():
         "weekdays": [1]
     }
     # Happy path config-raw
-    status, body = request("PUT", f"/api/v1/schedules/{VALID_SCHEDULE_ID}", body=payload, scenario="config-raw")
+    sched_id = create_test_schedule("orch-happy-path")
+    status, body = request("PUT", f"/api/v1/schedules/{sched_id}", body=payload, scenario="config-raw")
     assert status == 200, f"Expected 200, got {status}"
     
     with open_url(f"{FAKE_URL}/observations") as r:
@@ -213,26 +229,32 @@ def test_put_orchestration():
         print("✅ PUT config-raw happy path passed")
 
     # Failure-path PUT with scenario "delete-config-raw-prov-502"
-    status, _ = request("PUT", f"/api/v1/schedules/{VALID_SCHEDULE_ID}", body=payload, scenario="delete-config-raw-prov-502")
+    sched_id = create_test_schedule("orch-prov-502")
+    status, _ = request("PUT", f"/api/v1/schedules/{sched_id}", body=payload, scenario="delete-config-raw-prov-502")
     assert status == 500, f"Expected 500 for provisioning failure on PUT, got {status}"
     
     # Failure-path PUT with scenario "delete-config-raw-gw-get-malformed"
-    status, _ = request("PUT", f"/api/v1/schedules/{VALID_SCHEDULE_ID}", body=payload, scenario="delete-config-raw-gw-get-malformed")
+    sched_id = create_test_schedule("orch-gw-malformed")
+    status, _ = request("PUT", f"/api/v1/schedules/{sched_id}", body=payload, scenario="delete-config-raw-gw-get-malformed")
     assert status == 500, f"Expected 500 for gw-get malformed failure on PUT, got {status}"
 
     # Failure-path PUT with scenario "delete-config-raw-gw-get-502"
-    status, _ = request("PUT", f"/api/v1/schedules/{VALID_SCHEDULE_ID}", body=payload, scenario="delete-config-raw-gw-get-502")
+    sched_id = create_test_schedule("orch-gw-get-502")
+    status, _ = request("PUT", f"/api/v1/schedules/{sched_id}", body=payload, scenario="delete-config-raw-gw-get-502")
     assert status == 500, f"Expected 500 for gw get failure on PUT, got {status}"
     
     # Failure-path PUT with scenario "delete-config-raw-gw-configure-502"
-    status, _ = request("PUT", f"/api/v1/schedules/{VALID_SCHEDULE_ID}", body=payload, scenario="delete-config-raw-gw-configure-502")
+    sched_id = create_test_schedule("orch-gw-conf-502")
+    status, _ = request("PUT", f"/api/v1/schedules/{sched_id}", body=payload, scenario="delete-config-raw-gw-configure-502")
     assert status == 500, f"Expected 500 for gw configure failure on PUT, got {status}"
     
     print("✅ PUT config-raw error scenarios passed")
 
 def test_delete_orchestration():
     print("Testing DELETE /schedules/{id} config-raw orchestrations...")
-    status, body = request("DELETE", f"/api/v1/schedules/{VALID_SCHEDULE_ID}", scenario="config-raw")
+    # Happy path config-raw
+    sched_id = create_test_schedule("del-happy-path")
+    status, body = request("DELETE", f"/api/v1/schedules/{sched_id}", scenario="config-raw")
     assert status == 200, f"Expected 200, got {status}"
     
     with open_url(f"{FAKE_URL}/observations") as r:
@@ -252,19 +274,23 @@ def test_delete_orchestration():
         print("✅ DELETE config-raw happy path passed")
 
     # DELETE item with scenario "delete-config-raw-prov-502"
-    status, _ = request("DELETE", f"/api/v1/schedules/{VALID_SCHEDULE_ID}", scenario="delete-config-raw-prov-502")
+    sched_id = create_test_schedule("del-prov-502")
+    status, _ = request("DELETE", f"/api/v1/schedules/{sched_id}", scenario="delete-config-raw-prov-502")
     assert status == 500, f"Expected 500 for provisioning failure, got {status}"
     
     # DELETE item with scenario "delete-config-raw-gw-get-malformed"
-    status, _ = request("DELETE", f"/api/v1/schedules/{VALID_SCHEDULE_ID}", scenario="delete-config-raw-gw-get-malformed")
+    sched_id = create_test_schedule("del-gw-malformed")
+    status, _ = request("DELETE", f"/api/v1/schedules/{sched_id}", scenario="delete-config-raw-gw-get-malformed")
     assert status == 500, f"Expected 500 for gw-get malformed failure, got {status}"
 
     # DELETE item with scenario "delete-config-raw-gw-get-502"
-    status, _ = request("DELETE", f"/api/v1/schedules/{VALID_SCHEDULE_ID}", scenario="delete-config-raw-gw-get-502")
+    sched_id = create_test_schedule("del-gw-get-502")
+    status, _ = request("DELETE", f"/api/v1/schedules/{sched_id}", scenario="delete-config-raw-gw-get-502")
     assert status == 500, f"Expected 500 for gw get failure, got {status}"
     
     # DELETE item with scenario "delete-config-raw-gw-configure-502"
-    status, _ = request("DELETE", f"/api/v1/schedules/{VALID_SCHEDULE_ID}", scenario="delete-config-raw-gw-configure-502")
+    sched_id = create_test_schedule("del-gw-conf-502")
+    status, _ = request("DELETE", f"/api/v1/schedules/{sched_id}", scenario="delete-config-raw-gw-configure-502")
     assert status == 500, f"Expected 500 for gw configure failure, got {status}"
     
     print("✅ DELETE config-raw error scenarios passed")

--- a/test_scripts/integration/test_schedules_api.py
+++ b/test_scripts/integration/test_schedules_api.py
@@ -225,6 +225,9 @@ def test_put_orchestration():
         
         config_raw = payload_gw["configuration"]["config-raw"]
         assert any(len(entry) > 1 and entry[1] == "parental_control.ci_rule.enabled" for entry in config_raw), "Missing parental_control.ci_rule.enabled from replaced config-raw"
+        # This test intentionally verifies full replacement of gateway config-raw with the
+        # downstream parental-control snapshot; unrelated older entries like wifi.ssid are
+        # expected to be removed under the current system design.
         assert not any(len(entry) > 1 and entry[1] == "wifi.ssid" for entry in config_raw), "wifi.ssid was preserved but replacement-only contract requires direct replacement"
         print("✅ PUT config-raw happy path passed")
 

--- a/test_scripts/integration/test_schedules_api.py
+++ b/test_scripts/integration/test_schedules_api.py
@@ -214,7 +214,7 @@ def test_put_orchestration():
     
     with open_url(f"{FAKE_URL}/observations") as r:
         obs = json.loads(r.read())
-        assert any("inventory" in call["path"] or "subscriber" in call["path"] for call in obs["calls"]), "Provisioning lookup not called on PUT"
+        assert any("inventory" in call["path"] or "subscriberDevice" in call["path"] for call in obs["calls"]), "Provisioning lookup not called on PUT"
         assert any("device" in call["path"] and call["method"] == "GET" for call in obs["calls"]), "Gateway get-config not called on PUT"
         assert any("configure" in call["path"] and call["method"] == "POST" for call in obs["calls"]), "Gateway configure not called on PUT"
         
@@ -259,7 +259,7 @@ def test_delete_orchestration():
     
     with open_url(f"{FAKE_URL}/observations") as r:
         obs = json.loads(r.read())
-        assert any("inventory" in call["path"] or "subscriber" in call["path"] for call in obs["calls"]), "Provisioning lookup not called"
+        assert any("inventory" in call["path"] or "subscriberDevice" in call["path"] for call in obs["calls"]), "Provisioning lookup not called"
         assert any("device" in call["path"] and call["method"] == "GET" for call in obs["calls"]), "Gateway get-config not called"
         assert any("configure" in call["path"] and call["method"] == "POST" for call in obs["calls"]), "Gateway configure not called"
         
@@ -320,7 +320,7 @@ def test_config_raw_null_handling():
     
     with open_url(f"{FAKE_URL}/observations") as r:
         obs = json.loads(r.read())
-        assert not any("inventory" in call["path"] or "subscriber" in call["path"] for call in obs["calls"]), "Provisioning called unexpectedly on config-raw-null PUT"
+        assert not any("inventory" in call["path"] or "subscriberDevice" in call["path"] for call in obs["calls"]), "Provisioning called unexpectedly on config-raw-null PUT"
         assert not any("device" in call["path"] for call in obs["calls"]), "Gateway GET called unexpectedly on config-raw-null PUT"
         assert not any("configure" in call["path"] for call in obs["calls"]), "Gateway configure called unexpectedly on config-raw-null PUT"
 
@@ -330,7 +330,7 @@ def test_config_raw_null_handling():
     
     with open_url(f"{FAKE_URL}/observations") as r:
         obs = json.loads(r.read())
-        assert not any("inventory" in call["path"] or "subscriber" in call["path"] for call in obs["calls"]), "Provisioning called unexpectedly on config-raw-null DELETE"
+        assert not any("inventory" in call["path"] or "subscriberDevice" in call["path"] for call in obs["calls"]), "Provisioning called unexpectedly on config-raw-null DELETE"
         assert not any("device" in call["path"] for call in obs["calls"]), "Gateway GET called unexpectedly on config-raw-null DELETE"
         assert not any("configure" in call["path"] for call in obs["calls"]), "Gateway configure called unexpectedly on config-raw-null DELETE"
 
@@ -356,7 +356,7 @@ def test_post_config_raw_skip_apply():
     with open_url(f"{FAKE_URL}/observations") as r:
         obs = json.loads(r.read())
         assert any("schedules" in call["path"] and call["method"] == "POST" for call in obs["calls"]), "Downstream schedules POST not called"
-        assert not any("inventory" in call["path"] or "subscriber" in call["path"] for call in obs["calls"]), "Provisioning lookup unexpectedly called on POST"
+        assert not any("inventory" in call["path"] or "subscriberDevice" in call["path"] for call in obs["calls"]), "Provisioning lookup unexpectedly called on POST"
         assert not any("device" in call["path"] for call in obs["calls"]), "Gateway get-config unexpectedly called on POST"
         assert not any("configure" in call["path"] for call in obs["calls"]), "Gateway configure unexpectedly called on POST"
         

--- a/test_scripts/integration/test_schedules_api.py
+++ b/test_scripts/integration/test_schedules_api.py
@@ -1,0 +1,358 @@
+import urllib.request
+import urllib.error
+import json
+import os
+import sys
+import ssl
+
+USERPORTAL_URL = os.environ.get("USERPORTAL_URL", "http://localhost:16006")
+FAKE_URL = os.environ.get("FAKE_URL", "http://127.0.0.1:8080")
+TOKEN = "dummy-test-token"
+VALID_SCHEDULE_ID = "22222222-2222-4222-8222-222222222222"
+
+HTTPS_CONTEXT = ssl._create_unverified_context()
+
+def open_url(req_or_url):
+    url = req_or_url.full_url if hasattr(req_or_url, "full_url") else req_or_url
+    if str(url).startswith("https://"):
+        return urllib.request.urlopen(req_or_url, context=HTTPS_CONTEXT)
+    return urllib.request.urlopen(req_or_url)
+
+def set_scenario(scenario_name):
+    req1 = urllib.request.Request(f"{FAKE_URL}/reset-observations", data=b"", method="POST")
+    open_url(req1)
+    req2 = urllib.request.Request(
+        f"{FAKE_URL}/set-scenario",
+        data=json.dumps({"scenario": scenario_name}).encode(),
+        method="POST"
+    )
+    open_url(req2)
+
+def reset_db():
+    req = urllib.request.Request(f"{FAKE_URL}/reset-db", data=b"", method="POST")
+    open_url(req)
+
+def request(method, path, body=None, headers=None, scenario="normal"):
+    set_scenario(scenario)
+    if headers is None:
+        headers = {"Authorization": f"Bearer {TOKEN}"}
+    if body is not None:
+        if isinstance(body, dict) or isinstance(body, list):
+            body = json.dumps(body).encode()
+        headers["Content-Type"] = "application/json"
+    
+    req = urllib.request.Request(f"{USERPORTAL_URL}{path}", data=body, headers=headers, method=method)
+    try:
+        with open_url(req) as response:
+            res_body = response.read()
+            try:
+                return response.status, json.loads(res_body) if res_body else {}
+            except json.JSONDecodeError:
+                return response.status, res_body
+    except urllib.error.HTTPError as e:
+        res_body = e.read()
+        try:
+            return e.code, json.loads(res_body) if res_body else {}
+        except:
+            return e.code, res_body
+
+CREATED_SCHEDULE_ID = None
+
+def test_post_schedules():
+    global CREATED_SCHEDULE_ID
+    print("Testing POST /schedules stateful create...")
+    payload = {
+        "name": "test-schedule",
+        "description": "desc",
+        "action_type": "BLOCK",
+        "target_kind": "INTERNET",
+        "target_value": None,
+        "start_time": "08:00",
+        "stop_time": "17:00",
+        "weekdays": [1, 2, 3]
+    }
+    status, body = request("POST", "/api/v1/schedules", body=payload)
+    assert status == 200, f"Expected 200, got {status}. Body: {body}"
+    assert isinstance(body, dict), f"Expected JSON object, got {type(body)}. Body: {body}"
+    assert "id" in body and "name" in body, f"Expected created schedule fields. Body: {body}"
+    assert body["name"] == "test-schedule"
+    assert "start_time" in body and body["start_time"] == "08:00"
+    assert "stop_time" in body and body["stop_time"] == "17:00"
+    assert "start_minute" not in body
+    assert "stop_minute" not in body
+    CREATED_SCHEDULE_ID = body["id"]
+    print(f"✅ POST /schedules passed, created ID: {CREATED_SCHEDULE_ID}")
+
+def test_get_schedules():
+    print("Testing GET /schedules stateful list...")
+    status, body = request("GET", "/api/v1/schedules")
+    assert status == 200, f"Expected 200, got {status}. Body: {body}"
+    assert isinstance(body, list), f"Expected JSON array, got {type(body)}. Body: {body}"
+    assert any(s.get("id") == CREATED_SCHEDULE_ID for s in body), f"Expected newly created schedule in list. Body: {body}"
+    
+    # Assert normalization on list
+    for s in body:
+        assert "start_minute" not in s, f"start_minute should be absent from list item, got {s}"
+        assert "stop_minute" not in s, f"stop_minute should be absent from list item, got {s}"
+        assert "start_time" in s, f"start_time should be present in list item, got {s}"
+        assert "stop_time" in s, f"stop_time should be present in list item, got {s}"
+    print("✅ GET /schedules passed")
+
+def test_get_schedule_by_id():
+    print("Testing GET /schedules/{id} stateful read...")
+    status, body = request("GET", f"/api/v1/schedules/{CREATED_SCHEDULE_ID}")
+    assert status == 200, f"Expected 200, got {status}. Body: {body}"
+    assert isinstance(body, dict), f"Expected JSON object. Body: {body}"
+    assert body.get("id") == CREATED_SCHEDULE_ID, f"Expected matching ID. Body: {body}"
+    assert body.get("name") == "test-schedule"
+    
+    # Assert normalization on read
+    assert "start_minute" not in body, "start_minute should be absent from read"
+    assert "stop_minute" not in body, "stop_minute should be absent from read"
+    assert body.get("start_time") == "08:00", f"Expected normalized start_time '08:00', got {body.get('start_time')}"
+    assert body.get("stop_time") == "17:00", f"Expected normalized stop_time '17:00', got {body.get('stop_time')}"
+    print("✅ GET /schedules/{id} passed")
+
+def test_put_schedules():
+    print("Testing PUT /schedules/{id} stateful update...")
+    payload = {
+        "name": "updated-schedule",
+        "description": "new-desc",
+        "enabled": False,
+        "action_type": "BLOCK",
+        "target_kind": "APP",
+        "target_value": "YouTube",
+        "start_time": "09:00",
+        "stop_time": "18:00",
+        "weekdays": [0, 6]
+    }
+    status, body = request("PUT", f"/api/v1/schedules/{CREATED_SCHEDULE_ID}", body=payload)
+    assert status == 200, f"Expected 200, got {status}. Body: {body}"
+    assert body.get("name") == "updated-schedule", f"Expected updated name. Body: {body}"
+    assert body.get("enabled") is False, f"Expected updated enabled. Body: {body}"
+    assert body.get("target_kind") == "APP"
+    assert body.get("target_value") == "YouTube"
+    assert body.get("start_time") == "09:00"
+    
+    # Verify update persisted
+    status, read_body = request("GET", f"/api/v1/schedules/{CREATED_SCHEDULE_ID}")
+    assert read_body.get("name") == "updated-schedule", "GET after PUT did not return updated name"
+    print("✅ PUT /schedules passed")
+
+def test_delete_schedules_normal():
+    print("Testing DELETE /schedules/{id} stateful delete...")
+    status, body = request("DELETE", f"/api/v1/schedules/{CREATED_SCHEDULE_ID}")
+    assert status == 200, f"Expected 200, got {status}. Body: {body}"
+    
+    # Verify deletion persisted
+    status, _ = request("GET", f"/api/v1/schedules/{CREATED_SCHEDULE_ID}")
+    assert status == 404, f"Expected 404 after deletion, got {status}"
+    print("✅ DELETE /schedules normal passed")
+
+def test_forwarded_failures():
+    print("Testing forwarded downstream failures...")
+    status, _ = request("GET", f"/api/v1/schedules/{VALID_SCHEDULE_ID}", scenario="pc-404")
+    assert status == 404, f"Expected 404, got {status}"
+    
+    payload = {
+        "name": "test",
+        "description": "desc",
+        "enabled": True,
+        "action_type": "BLOCK",
+        "target_kind": "INTERNET",
+        "target_value": None,
+        "start_time": "08:00",
+        "stop_time": "17:00",
+        "weekdays": [1]
+    }
+    status, _ = request("PUT", f"/api/v1/schedules/{VALID_SCHEDULE_ID}", body=payload, scenario="pc-409")
+    assert status == 409, f"Expected 409, got {status}"
+
+    status, _ = request("POST", "/api/v1/schedules", body=payload, scenario="pc-409")
+    assert status == 409, f"Expected 409 for POST conflict, got {status}"
+
+    status, _ = request("PUT", f"/api/v1/schedules/{VALID_SCHEDULE_ID}", body=payload, scenario="pc-404")
+    assert status == 404, f"Expected 404 for PUT not-found, got {status}"
+
+    status, _ = request("DELETE", f"/api/v1/schedules/{VALID_SCHEDULE_ID}", scenario="pc-404")
+    assert status == 404, f"Expected 404 for DELETE not-found, got {status}"
+
+    print("✅ Forwarded downstream failure tests passed")
+
+def test_put_orchestration():
+    print("Testing PUT /schedules/{id} config-raw orchestrations...")
+    payload = {
+        "name": "orch-schedule",
+        "description": "desc",
+        "enabled": True,
+        "action_type": "BLOCK",
+        "target_kind": "INTERNET",
+        "target_value": None,
+        "start_time": "08:00",
+        "stop_time": "17:00",
+        "weekdays": [1]
+    }
+    # Happy path config-raw
+    status, body = request("PUT", f"/api/v1/schedules/{VALID_SCHEDULE_ID}", body=payload, scenario="config-raw")
+    assert status == 200, f"Expected 200, got {status}"
+    
+    with open_url(f"{FAKE_URL}/observations") as r:
+        obs = json.loads(r.read())
+        assert any("inventory" in call["path"] or "subscriber" in call["path"] for call in obs["calls"]), "Provisioning lookup not called on PUT"
+        assert any("device" in call["path"] and call["method"] == "GET" for call in obs["calls"]), "Gateway get-config not called on PUT"
+        assert any("configure" in call["path"] and call["method"] == "POST" for call in obs["calls"]), "Gateway configure not called on PUT"
+        
+        payload_gw = obs.get("last_configure_payload")
+        assert payload_gw is not None, "Gateway configure payload not recorded"
+        assert "configuration" in payload_gw, "Payload missing 'configuration'"
+        assert "config-raw" in payload_gw["configuration"], "config-raw missing from configuration"
+        
+        config_raw = payload_gw["configuration"]["config-raw"]
+        assert any(len(entry) > 1 and entry[1] == "parental_control.ci_rule.enabled" for entry in config_raw), "Missing parental_control.ci_rule.enabled from replaced config-raw"
+        assert not any(len(entry) > 1 and entry[1] == "wifi.ssid" for entry in config_raw), "wifi.ssid was preserved but replacement-only contract requires direct replacement"
+        print("✅ PUT config-raw happy path passed")
+
+    # Failure-path PUT with scenario "delete-config-raw-prov-502"
+    status, _ = request("PUT", f"/api/v1/schedules/{VALID_SCHEDULE_ID}", body=payload, scenario="delete-config-raw-prov-502")
+    assert status == 500, f"Expected 500 for provisioning failure on PUT, got {status}"
+    
+    # Failure-path PUT with scenario "delete-config-raw-gw-get-malformed"
+    status, _ = request("PUT", f"/api/v1/schedules/{VALID_SCHEDULE_ID}", body=payload, scenario="delete-config-raw-gw-get-malformed")
+    assert status == 500, f"Expected 500 for gw-get malformed failure on PUT, got {status}"
+
+    # Failure-path PUT with scenario "delete-config-raw-gw-get-502"
+    status, _ = request("PUT", f"/api/v1/schedules/{VALID_SCHEDULE_ID}", body=payload, scenario="delete-config-raw-gw-get-502")
+    assert status == 500, f"Expected 500 for gw get failure on PUT, got {status}"
+    
+    # Failure-path PUT with scenario "delete-config-raw-gw-configure-502"
+    status, _ = request("PUT", f"/api/v1/schedules/{VALID_SCHEDULE_ID}", body=payload, scenario="delete-config-raw-gw-configure-502")
+    assert status == 500, f"Expected 500 for gw configure failure on PUT, got {status}"
+    
+    print("✅ PUT config-raw error scenarios passed")
+
+def test_delete_orchestration():
+    print("Testing DELETE /schedules/{id} config-raw orchestrations...")
+    status, body = request("DELETE", f"/api/v1/schedules/{VALID_SCHEDULE_ID}", scenario="config-raw")
+    assert status == 200, f"Expected 200, got {status}"
+    
+    with open_url(f"{FAKE_URL}/observations") as r:
+        obs = json.loads(r.read())
+        assert any("inventory" in call["path"] or "subscriber" in call["path"] for call in obs["calls"]), "Provisioning lookup not called"
+        assert any("device" in call["path"] and call["method"] == "GET" for call in obs["calls"]), "Gateway get-config not called"
+        assert any("configure" in call["path"] and call["method"] == "POST" for call in obs["calls"]), "Gateway configure not called"
+        
+        payload = obs.get("last_configure_payload")
+        assert payload is not None, "Gateway configure payload not recorded"
+        assert "configuration" in payload, "Payload missing 'configuration'"
+        assert "config-raw" in payload["configuration"], "config-raw missing from configuration"
+        
+        config_raw = payload["configuration"]["config-raw"]
+        assert not any(len(entry) > 1 and entry[1] == "wifi.ssid" for entry in config_raw), "wifi.ssid was preserved but replacement-only contract requires direct replacement"
+        assert any(len(entry) > 1 and entry[1] == "parental_control.ci_rule.enabled" for entry in config_raw), "Missing parental_control.ci_rule.enabled from replaced config-raw"
+        print("✅ DELETE config-raw happy path passed")
+
+    # DELETE item with scenario "delete-config-raw-prov-502"
+    status, _ = request("DELETE", f"/api/v1/schedules/{VALID_SCHEDULE_ID}", scenario="delete-config-raw-prov-502")
+    assert status == 500, f"Expected 500 for provisioning failure, got {status}"
+    
+    # DELETE item with scenario "delete-config-raw-gw-get-malformed"
+    status, _ = request("DELETE", f"/api/v1/schedules/{VALID_SCHEDULE_ID}", scenario="delete-config-raw-gw-get-malformed")
+    assert status == 500, f"Expected 500 for gw-get malformed failure, got {status}"
+
+    # DELETE item with scenario "delete-config-raw-gw-get-502"
+    status, _ = request("DELETE", f"/api/v1/schedules/{VALID_SCHEDULE_ID}", scenario="delete-config-raw-gw-get-502")
+    assert status == 500, f"Expected 500 for gw get failure, got {status}"
+    
+    # DELETE item with scenario "delete-config-raw-gw-configure-502"
+    status, _ = request("DELETE", f"/api/v1/schedules/{VALID_SCHEDULE_ID}", scenario="delete-config-raw-gw-configure-502")
+    assert status == 500, f"Expected 500 for gw configure failure, got {status}"
+    
+    print("✅ DELETE config-raw error scenarios passed")
+
+def test_config_raw_null_handling():
+    print("Testing config-raw: null handling...")
+    
+    # Ensure POST doesn't fail
+    payload = {
+        "name": "null-config-raw-test",
+        "description": "desc",
+        "action_type": "BLOCK",
+        "target_kind": "INTERNET",
+        "target_value": None,
+        "start_time": "08:00",
+        "stop_time": "17:00",
+        "weekdays": [1]
+    }
+    status, body = request("POST", "/api/v1/schedules", body=payload)
+    assert status == 200, f"Expected 200, got {status}"
+    tid = body["id"]
+
+    # PUT path under config-raw-null scenario: must succeed and not return 500 or trigger gw update
+    payload["enabled"] = False
+    status, body = request("PUT", f"/api/v1/schedules/{tid}", body=payload, scenario="config-raw-null")
+    assert status == 200, f"Expected 200 for PUT with config-raw: null, got {status}"
+    
+    with open_url(f"{FAKE_URL}/observations") as r:
+        obs = json.loads(r.read())
+        assert not any("inventory" in call["path"] or "subscriber" in call["path"] for call in obs["calls"]), "Provisioning called unexpectedly on config-raw-null PUT"
+        assert not any("device" in call["path"] for call in obs["calls"]), "Gateway GET called unexpectedly on config-raw-null PUT"
+        assert not any("configure" in call["path"] for call in obs["calls"]), "Gateway configure called unexpectedly on config-raw-null PUT"
+
+    # DELETE path under config-raw-null scenario: must succeed and not return 500 or trigger gw update
+    status, body = request("DELETE", f"/api/v1/schedules/{tid}", scenario="config-raw-null")
+    assert status == 200, f"Expected 200 for DELETE with config-raw: null, got {status}"
+    
+    with open_url(f"{FAKE_URL}/observations") as r:
+        obs = json.loads(r.read())
+        assert not any("inventory" in call["path"] or "subscriber" in call["path"] for call in obs["calls"]), "Provisioning called unexpectedly on config-raw-null DELETE"
+        assert not any("device" in call["path"] for call in obs["calls"]), "Gateway GET called unexpectedly on config-raw-null DELETE"
+        assert not any("configure" in call["path"] for call in obs["calls"]), "Gateway configure called unexpectedly on config-raw-null DELETE"
+
+    print("✅ config-raw: null handling tests passed")
+
+def test_post_config_raw_skip_apply():
+    print("Testing POST /schedules with scenario config-raw (skip-apply)...")
+    payload = {
+        "name": "post-skip-apply-schedule",
+        "description": "desc",
+        "action_type": "BLOCK",
+        "target_kind": "INTERNET",
+        "target_value": None,
+        "start_time": "08:00",
+        "stop_time": "17:00",
+        "weekdays": [1]
+    }
+    # When scenario is config-raw, POST should succeed but not perform apply
+    status, body = request("POST", "/api/v1/schedules", body=payload, scenario="config-raw")
+    assert status == 200, f"Expected 200, got {status}. Body: {body}"
+    assert "id" in body
+    
+    with open_url(f"{FAKE_URL}/observations") as r:
+        obs = json.loads(r.read())
+        assert any("schedules" in call["path"] and call["method"] == "POST" for call in obs["calls"]), "Downstream schedules POST not called"
+        assert not any("inventory" in call["path"] or "subscriber" in call["path"] for call in obs["calls"]), "Provisioning lookup unexpectedly called on POST"
+        assert not any("device" in call["path"] for call in obs["calls"]), "Gateway get-config unexpectedly called on POST"
+        assert not any("configure" in call["path"] for call in obs["calls"]), "Gateway configure unexpectedly called on POST"
+        
+    print("✅ POST config-raw skip-apply passed")
+
+if __name__ == "__main__":
+    print("Starting schedules integration tests...")
+    try:
+        reset_db()
+        test_post_schedules()
+        test_get_schedules()
+        test_get_schedule_by_id()
+        test_put_schedules()
+        test_delete_schedules_normal()
+
+        test_forwarded_failures()
+        test_put_orchestration()
+        test_delete_orchestration()
+        test_config_raw_null_handling()
+        test_post_config_raw_skip_apply()
+        
+        print("🎉 All schedules integration tests passed!")
+    except AssertionError as e:
+        print(f"❌ TEST FAILED: {e}")
+        sys.exit(1)

--- a/test_scripts/integration/test_schedules_api.py
+++ b/test_scripts/integration/test_schedules_api.py
@@ -362,6 +362,44 @@ def test_post_config_raw_skip_apply():
         
     print("✅ POST config-raw skip-apply passed")
 
+def test_config_raw_malformed_handling():
+    print("Testing config-raw: malformed handling...")
+    
+    # 1. Test PUT with malformed config-raw
+    sched_id = create_test_schedule("malformed-put-test")
+    payload = {
+        "name": "malformed-put-test",
+        "description": "desc",
+        "enabled": True,
+        "action_type": "BLOCK",
+        "target_kind": "INTERNET",
+        "target_value": None,
+        "start_time": "08:00",
+        "stop_time": "17:00",
+        "weekdays": [1]
+    }
+    status, _ = request("PUT", f"/api/v1/schedules/{sched_id}", body=payload, scenario="config-raw-malformed")
+    assert status == 500, f"Expected 500 for malformed config-raw PUT, got {status}"
+    
+    with open_url(f"{FAKE_URL}/observations") as r:
+        obs = json.loads(r.read())
+        assert not any("inventory" in call["path"] or "subscriberDevice" in call["path"] for call in obs["calls"]), "Provisioning lookup unexpectedly called on malformed PUT"
+        assert not any("device" in call["path"] for call in obs["calls"]), "Gateway get-config unexpectedly called on malformed PUT"
+        assert not any("configure" in call["path"] for call in obs["calls"]), "Gateway configure called unexpectedly on malformed PUT"
+
+    # 2. Test DELETE with malformed config-raw
+    sched_id = create_test_schedule("malformed-del-test")
+    status, _ = request("DELETE", f"/api/v1/schedules/{sched_id}", scenario="config-raw-malformed")
+    assert status == 500, f"Expected 500 for malformed config-raw DELETE, got {status}"
+    
+    with open_url(f"{FAKE_URL}/observations") as r:
+        obs = json.loads(r.read())
+        assert not any("inventory" in call["path"] or "subscriberDevice" in call["path"] for call in obs["calls"]), "Provisioning lookup unexpectedly called on malformed DELETE"
+        assert not any("device" in call["path"] for call in obs["calls"]), "Gateway get-config unexpectedly called on malformed DELETE"
+        assert not any("configure" in call["path"] for call in obs["calls"]), "Gateway configure called unexpectedly on malformed DELETE"
+
+    print("✅ config-raw: malformed handling tests passed")
+
 if __name__ == "__main__":
     print("Starting schedules integration tests...")
     try:
@@ -377,6 +415,7 @@ if __name__ == "__main__":
         test_delete_orchestration()
         test_config_raw_null_handling()
         test_post_config_raw_skip_apply()
+        test_config_raw_malformed_handling()
         
         print("🎉 All schedules integration tests passed!")
     except AssertionError as e:

--- a/test_scripts/integration/test_schedules_contract.py
+++ b/test_scripts/integration/test_schedules_contract.py
@@ -1,0 +1,342 @@
+import urllib.request
+import urllib.error
+import json
+import os
+import sys
+import ssl
+
+USERPORTAL_URL = os.environ.get("USERPORTAL_URL", "http://localhost:16006")
+FAKE_URL = os.environ.get("FAKE_URL", "http://127.0.0.1:8080")
+VALID_SCHEDULE_ID = "22222222-2222-4222-8222-222222222222"
+
+HTTPS_CONTEXT = ssl._create_unverified_context()
+
+def open_url(req_or_url):
+    url = req_or_url.full_url if hasattr(req_or_url, "full_url") else req_or_url
+    if str(url).startswith("https://"):
+        return urllib.request.urlopen(req_or_url, context=HTTPS_CONTEXT)
+    return urllib.request.urlopen(req_or_url)
+
+def reset_observations():
+    req = urllib.request.Request(f"{FAKE_URL}/reset-observations", data=b"", method="POST")
+    open_url(req)
+
+def request(method, path, body=None, headers=None):
+    if headers is None:
+        headers = {"Authorization": "Bearer dummy-test-token"}
+    if body is not None:
+        body = json.dumps(body).encode("utf-8")
+        headers["Content-Type"] = "application/json"
+    
+    req = urllib.request.Request(f"{USERPORTAL_URL}{path}", data=body, headers=headers, method=method)
+    try:
+        with open_url(req) as response:
+            res_body = response.read()
+            try:
+                return response.status, json.loads(res_body) if res_body else {}
+            except json.JSONDecodeError:
+                return response.status, res_body
+    except urllib.error.HTTPError as e:
+        res_body = e.read()
+        try:
+            return e.code, json.loads(res_body) if res_body else {}
+        except json.JSONDecodeError:
+            return e.code, res_body
+    except urllib.error.URLError as e:
+        print(f"Connection failed: {e}")
+        return 000, {}
+
+def check_no_observations(test_name):
+    with open_url(f"{FAKE_URL}/observations") as r:
+        obs = json.loads(r.read())
+        assert len(obs["calls"]) == 0, f"{test_name}: Downstream services were unexpectedly called: {obs['calls']}"
+
+def test_auth_checks():
+    print("Testing Auth Rejections...")
+    reset_observations()
+    status, _ = request("GET", "/api/v1/schedules", headers={})
+    assert status == 403, f"Expected 403 for missing auth, got {status}"
+    check_no_observations("GET /schedules missing auth")
+
+    reset_observations()
+    status, _ = request("GET", "/api/v1/schedules", headers={"Authorization": "Bearer bad-token"})
+    assert status == 403, f"Expected 403 for bad auth, got {status}"
+    check_no_observations("GET /schedules bad auth")
+    print("✅ Auth tests passed")
+
+def test_local_validation():
+    print("Testing Local Request Validation...")
+
+    # GET invalid UUID
+    reset_observations()
+    status, _ = request("GET", "/api/v1/schedules/12345")
+    assert status == 400, f"Expected 400 for invalid UUID, got {status}"
+    check_no_observations("GET invalid UUID")
+    
+    # POST unknown field
+    reset_observations()
+    status, _ = request("POST", "/api/v1/schedules", body={
+        "name": "test", "description": "desc", "action_type": "BLOCK",
+        "target_kind": "INTERNET", "target_value": None,
+        "start_time": "08:00", "stop_time": "17:00", "weekdays": [1],
+        "extra": "bad"
+    })
+    assert status == 400, f"Expected 400 for unknown field, got {status}"
+    check_no_observations("POST unknown field")
+    
+    # POST missing name
+    reset_observations()
+    status, _ = request("POST", "/api/v1/schedules", body={
+        "description": "desc", "action_type": "BLOCK",
+        "target_kind": "INTERNET", "target_value": None,
+        "start_time": "08:00", "stop_time": "17:00", "weekdays": [1]
+    })
+    assert status == 400, f"Expected 400 for missing name, got {status}"
+    check_no_observations("POST missing name")
+    
+    # POST empty name
+    reset_observations()
+    status, _ = request("POST", "/api/v1/schedules", body={
+        "name": "   ", "description": "desc", "action_type": "BLOCK",
+        "target_kind": "INTERNET", "target_value": None,
+        "start_time": "08:00", "stop_time": "17:00", "weekdays": [1]
+    })
+    assert status == 400, f"Expected 400 for empty name, got {status}"
+    check_no_observations("POST empty name")
+
+    # POST invalid description type
+    reset_observations()
+    status, _ = request("POST", "/api/v1/schedules", body={
+        "name": "test", "description": 123, "action_type": "BLOCK",
+        "target_kind": "INTERNET", "target_value": None,
+        "start_time": "08:00", "stop_time": "17:00", "weekdays": [1]
+    })
+    assert status == 400, f"Expected 400 for invalid description type, got {status}"
+    check_no_observations("POST invalid description type")
+
+    # POST invalid action_type
+    reset_observations()
+    status, _ = request("POST", "/api/v1/schedules", body={
+        "name": "test", "description": "desc", "action_type": "ALLOW",
+        "target_kind": "INTERNET", "target_value": None,
+        "start_time": "08:00", "stop_time": "17:00", "weekdays": [1]
+    })
+    assert status == 400, f"Expected 400 for invalid action_type, got {status}"
+    check_no_observations("POST invalid action_type")
+
+    # POST missing action_type
+    reset_observations()
+    status, _ = request("POST", "/api/v1/schedules", body={
+        "name": "test", "description": "desc",
+        "target_kind": "INTERNET", "target_value": None,
+        "start_time": "08:00", "stop_time": "17:00", "weekdays": [1]
+    })
+    assert status == 400, f"Expected 400 for missing action_type, got {status}"
+    check_no_observations("POST missing action_type")
+
+    # POST invalid target_kind
+    reset_observations()
+    status, _ = request("POST", "/api/v1/schedules", body={
+        "name": "test", "description": "desc", "action_type": "BLOCK",
+        "target_kind": "WEBSITE", "target_value": "test.com",
+        "start_time": "08:00", "stop_time": "17:00", "weekdays": [1]
+    })
+    assert status == 400, f"Expected 400 for invalid target_kind, got {status}"
+    check_no_observations("POST invalid target_kind")
+
+    # POST missing target_kind
+    reset_observations()
+    status, _ = request("POST", "/api/v1/schedules", body={
+        "name": "test", "description": "desc", "action_type": "BLOCK",
+        "target_value": None,
+        "start_time": "08:00", "stop_time": "17:00", "weekdays": [1]
+    })
+    assert status == 400, f"Expected 400 for missing target_kind, got {status}"
+    check_no_observations("POST missing target_kind")
+
+    # POST APP target without target_value
+    reset_observations()
+    status, _ = request("POST", "/api/v1/schedules", body={
+        "name": "test", "description": "desc", "action_type": "BLOCK",
+        "target_kind": "APP", "target_value": None,
+        "start_time": "08:00", "stop_time": "17:00", "weekdays": [1]
+    })
+    assert status == 400, f"Expected 400 for APP schedule with null target_value, got {status}"
+    check_no_observations("POST APP target with null target_value")
+
+    # POST APP target with empty-string target_value
+    reset_observations()
+    status, _ = request("POST", "/api/v1/schedules", body={
+        "name": "test", "description": "desc", "action_type": "BLOCK",
+        "target_kind": "APP", "target_value": "",
+        "start_time": "08:00", "stop_time": "17:00", "weekdays": [1]
+    })
+    assert status == 400, f"Expected 400 for APP schedule with empty target_value, got {status}"
+    check_no_observations("POST APP target with empty target_value")
+
+    # POST INTERNET target with non-null target_value
+    reset_observations()
+    status, _ = request("POST", "/api/v1/schedules", body={
+        "name": "test", "description": "desc", "action_type": "BLOCK",
+        "target_kind": "INTERNET", "target_value": "something",
+        "start_time": "08:00", "stop_time": "17:00", "weekdays": [1]
+    })
+    assert status == 400, f"Expected 400 for INTERNET schedule with non-null target_value, got {status}"
+    check_no_observations("POST INTERNET target with non-null target_value")
+
+    # POST invalid start_time format
+    reset_observations()
+    status, _ = request("POST", "/api/v1/schedules", body={
+        "name": "test", "description": "desc", "action_type": "BLOCK",
+        "target_kind": "INTERNET", "target_value": None,
+        "start_time": "8:00", "stop_time": "17:00", "weekdays": [1]
+    })
+    assert status == 400, f"Expected 400 for invalid start_time format, got {status}"
+    check_no_observations("POST invalid start_time format")
+
+    # POST invalid stop_time format
+    reset_observations()
+    status, _ = request("POST", "/api/v1/schedules", body={
+        "name": "test", "description": "desc", "action_type": "BLOCK",
+        "target_kind": "INTERNET", "target_value": None,
+        "start_time": "08:00", "stop_time": "17:0", "weekdays": [1]
+    })
+    assert status == 400, f"Expected 400 for invalid stop_time format, got {status}"
+    check_no_observations("POST invalid stop_time format")
+
+    # POST equal start_time and stop_time
+    reset_observations()
+    status, _ = request("POST", "/api/v1/schedules", body={
+        "name": "test", "description": "desc", "action_type": "BLOCK",
+        "target_kind": "INTERNET", "target_value": None,
+        "start_time": "08:00", "stop_time": "08:00", "weekdays": [1]
+    })
+    assert status == 400, f"Expected 400 for equal start and stop times, got {status}"
+    check_no_observations("POST equal start_time and stop_time")
+
+    # POST empty weekdays
+    reset_observations()
+    status, _ = request("POST", "/api/v1/schedules", body={
+        "name": "test", "description": "desc", "action_type": "BLOCK",
+        "target_kind": "INTERNET", "target_value": None,
+        "start_time": "08:00", "stop_time": "17:00", "weekdays": []
+    })
+    assert status == 400, f"Expected 400 for empty weekdays, got {status}"
+    check_no_observations("POST empty weekdays")
+
+    # POST missing weekdays
+    reset_observations()
+    status, _ = request("POST", "/api/v1/schedules", body={
+        "name": "test", "description": "desc", "action_type": "BLOCK",
+        "target_kind": "INTERNET", "target_value": None,
+        "start_time": "08:00", "stop_time": "17:00"
+    })
+    assert status == 400, f"Expected 400 for missing weekdays, got {status}"
+    check_no_observations("POST missing weekdays")
+
+    # POST invalid weekdays (out of range)
+    reset_observations()
+    status, _ = request("POST", "/api/v1/schedules", body={
+        "name": "test", "description": "desc", "action_type": "BLOCK",
+        "target_kind": "INTERNET", "target_value": None,
+        "start_time": "08:00", "stop_time": "17:00", "weekdays": [7]
+    })
+    assert status == 400, f"Expected 400 for invalid weekday value, got {status}"
+    check_no_observations("POST invalid weekday value")
+
+    # POST invalid weekdays (duplicates)
+    reset_observations()
+    status, _ = request("POST", "/api/v1/schedules", body={
+        "name": "test", "description": "desc", "action_type": "BLOCK",
+        "target_kind": "INTERNET", "target_value": None,
+        "start_time": "08:00", "stop_time": "17:00", "weekdays": [1, 1]
+    })
+    assert status == 400, f"Expected 400 for duplicate weekdays, got {status}"
+    check_no_observations("POST duplicate weekdays")
+
+    # POST malformed JSON
+    reset_observations()
+    req = urllib.request.Request(f"{USERPORTAL_URL}/api/v1/schedules", data=b"{bad-json", headers={"Authorization": "Bearer dummy-test-token", "Content-Type": "application/json"}, method="POST")
+    try:
+        with open_url(req) as response:
+            status = response.status
+    except urllib.error.HTTPError as e:
+        status = e.code
+    assert status == 400, f"Expected 400 for malformed POST json, got {status}"
+    check_no_observations("POST malformed json")
+
+    # PUT missing description
+    reset_observations()
+    status, _ = request("PUT", f"/api/v1/schedules/{VALID_SCHEDULE_ID}", body={
+        "name": "test", "enabled": True, "action_type": "BLOCK",
+        "target_kind": "INTERNET", "target_value": None,
+        "start_time": "08:00", "stop_time": "17:00", "weekdays": [1]
+    })
+    assert status == 400, f"Expected 400 for missing description on PUT, got {status}"
+    check_no_observations("PUT missing description")
+
+    # PUT missing enabled
+    reset_observations()
+    status, _ = request("PUT", f"/api/v1/schedules/{VALID_SCHEDULE_ID}", body={
+        "name": "test", "description": "desc", "action_type": "BLOCK",
+        "target_kind": "INTERNET", "target_value": None,
+        "start_time": "08:00", "stop_time": "17:00", "weekdays": [1]
+    })
+    assert status == 400, f"Expected 400 for missing enabled on PUT, got {status}"
+    check_no_observations("PUT missing enabled")
+    
+    # PUT unknown field
+    reset_observations()
+    status, _ = request("PUT", f"/api/v1/schedules/{VALID_SCHEDULE_ID}", body={
+        "name": "test", "description": "desc", "enabled": True, "action_type": "BLOCK",
+        "target_kind": "INTERNET", "target_value": None,
+        "start_time": "08:00", "stop_time": "17:00", "weekdays": [1],
+        "extra": "bad"
+    })
+    assert status == 400, f"Expected 400 for unknown field on PUT, got {status}"
+    check_no_observations("PUT unknown field")
+
+    # PUT malformed JSON
+    reset_observations()
+    req = urllib.request.Request(f"{USERPORTAL_URL}/api/v1/schedules/{VALID_SCHEDULE_ID}", data=b"{bad-json", headers={"Authorization": "Bearer dummy-test-token", "Content-Type": "application/json"}, method="PUT")
+    try:
+        with open_url(req) as response:
+            status = response.status
+    except urllib.error.HTTPError as e:
+        status = e.code
+    assert status == 400, f"Expected 400 for malformed PUT json, got {status}"
+    check_no_observations("PUT malformed json")
+
+    # POST missing body
+    reset_observations()
+    req = urllib.request.Request(f"{USERPORTAL_URL}/api/v1/schedules", headers={"Authorization": "Bearer dummy-test-token", "Content-Type": "application/json"}, method="POST")
+    try:
+        with open_url(req) as response:
+            status = response.status
+    except urllib.error.HTTPError as e:
+        status = e.code
+    assert status == 400, f"Expected 400 for POST missing body, got {status}"
+    check_no_observations("POST missing body")
+
+    # PUT missing body
+    reset_observations()
+    req = urllib.request.Request(f"{USERPORTAL_URL}/api/v1/schedules/{VALID_SCHEDULE_ID}", headers={"Authorization": "Bearer dummy-test-token", "Content-Type": "application/json"}, method="PUT")
+    try:
+        with open_url(req) as response:
+            status = response.status
+    except urllib.error.HTTPError as e:
+        status = e.code
+    assert status == 400, f"Expected 400 for PUT missing body, got {status}"
+    check_no_observations("PUT missing body")
+
+    print("✅ Local validation tests passed")
+
+if __name__ == "__main__":
+    print("Starting schedules contract tests...")
+    try:
+        test_auth_checks()
+        test_local_validation()
+        print("🎉 All contract tests passed!")
+    except AssertionError as e:
+        print(f"❌ TEST FAILED: {e}")
+        sys.exit(1)


### PR DESCRIPTION
Related to #49 

### Problem Fixed

UserPortal previously lacked support for the Parental Control Schedules APIs. There was no UserPortal handling for subscriber schedule operations, no normalization layer for the public `start_time` / `stop_time` contract, and no integration path for forwarding Schedules requests to the downstream parental-control service. As a result, subscribers could not manage parental-control schedules through UserPortal.

This PR adds UserPortal support for the subscriber Schedules APIs, introduces shared parental-control utility helpers used by the schedule flow, implements approved `config-raw` synchronization for update and delete flows, and adds PR-level contract and integration validation for the documented Schedules behavior.

## Key Changes

### API support added

This PR adds UserPortal support for:

* `GET /api/v1/schedules`
* `POST /api/v1/schedules`
* `GET /api/v1/schedules/{schedule_id}`
* `PUT /api/v1/schedules/{schedule_id}`
* `DELETE /api/v1/schedules/{schedule_id}`

### UserPortal implementation

* Adds dedicated Schedules REST handlers and router wiring
* Extends `SDK_parental_control` for downstream schedule operations
* Adds shared parental-control utility helpers for request validation, downstream body construction, response normalization, and `config-raw` handling
* Adds UserPortal-side validation for request structure, request body, and path parameter handling
* Preserves documented downstream passthrough behavior for expected non-2xx downstream responses

### Public contract normalization

UserPortal now translates between the public Schedules contract and the downstream parental-control wire format:

* accepts public `start_time` / `stop_time`
* converts those values into downstream `start_minute` / `stop_minute`
* normalizes downstream schedule responses back into public `start_time` / `stop_time`

### Update/delete config-raw synchronization

For successful schedule update and delete responses that include `config-raw`, UserPortal now:

* extracts `config-raw` entries from the parental-control response
* resolves the subscriber gateway through provisioning
* fetches the current gateway configuration
* replaces the gateway `config-raw` section with the returned downstream snapshot
* pushes the updated configuration back through the gateway flow

This behavior is intentionally applied for update and delete flows only, consistent with the approved UserPortal Schedules contract.

### Shared parental-control utility integration

This PR introduces shared parental-control utility helpers used by the Schedules implementation. The related Groups-side changes are limited to adopting the same helpers and updating the related CI/tests.

## CI Workflow Update

This PR extends the existing `PR Tests` workflow to cover the Schedules API implementation.

For this PR, the relevant automated validation is the PR-specific `PR Tests` workflow:

* it builds the implementation from this branch
* it starts the local fake downstream test environment in CI
* it runs the Schedules contract test suite
* it runs the Schedules integration test suite

## Test Coverage

This PR adds PR-specific automated validation for the Schedules implementation through the `PR Tests` workflow.

### Contract coverage

Contract tests validate:

* auth rejection behavior
* invalid path/body validation behavior
* malformed JSON handling
* missing request body handling
* invalid time, weekday, and target-field validation behavior
* no-downstream-call behavior for local validation failures

### Integration coverage

Integration tests validate:

* Schedules lifecycle behavior through the repo-local fake downstream environment
* downstream passthrough failures
* schedule response normalization behavior
* update/delete `config-raw` orchestration behavior
* `config-raw` skip-apply behavior when downstream returns `null`
* orchestration failure handling for provisioning and gateway failure paths

### Stateful fake-downstream integration

The fake downstream test environment has also been extended for Schedules CRUD coverage:

* the fake parental-control Schedules endpoints now use a Postgres-backed test store to support stateful PR-level CRUD lifecycle validation
* this allows create → list → get → update → delete lifecycle validation against persisted fake state
* negative scenarios such as downstream `404`, `409`, provisioning failure, and gateway failure remain scenario-driven for deterministic CI coverage

## Test Evidence

PR validation now covers:

* contract tests for request validation and auth rejection behavior
* integration tests for Schedules lifecycle behavior through the repo-local fake downstream environment
* stateful fake-downstream CRUD validation backed by Postgres
* negative coverage for validation failures, downstream passthrough failures, and `config-raw` orchestration failure handling

Current status:

* PR Tests passing

## Reviewer Guidance

Please review this PR against the approved [UserPortal Schedules API YAML/contract](https://github.com/routerarchitects/mango-cloud-yaml/blob/main/userportal/rest/RESTAPI/RESTAPI_schedules_handler.yaml) and the intended UserPortal behavior for parental-control schedule operations.

Primary review focus areas:

* Verify that the new Schedules handlers match the documented request and response behavior
* Verify that local validation is enforced in UserPortal for invalid path/body inputs
* Verify that public `start_time` / `stop_time` handling is correctly translated to and from the downstream parental-control format
* Verify that downstream parental-control calls are isolated behind `SDK_parental_control`
* Verify that downstream passthrough behavior is preserved for documented non-2xx cases
* Verify that update/delete-flow `config-raw` handling correctly updates the gateway configuration path
* Verify that the PR-specific `PR Tests` workflow provides the intended contract and integration validation for the documented Schedules behavior
* Verify that the shared parental-control utility integration is appropriate and does not introduce unintended regressions in related parental-control flows