### PR TITLE
[GROUP-DEVICE-GROUP-SCHEDULE-API]: Implement parental-control group-device and group-schedule link APIs in UserPortal

### DIFF
--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -108,6 +108,7 @@ jobs:
             -e RUN_CHOWN=true \
             -e CI_FAKE_EXTERNAL_SERVICES=1 \
             -e FAKE_EXTERNAL_SERVICE_PARENTAL_CONTROL=http://127.0.0.1:8080 \
+            -e FAKE_EXTERNAL_SERVICE_NWTOPOLOGY=http://127.0.0.1:8080 \
             -e FAKE_EXTERNAL_SERVICE_OWPROV=http://127.0.0.1:8080 \
             -e FAKE_EXTERNAL_SERVICE_OWGW=http://127.0.0.1:8080 \
             -e FAKE_EXTERNAL_SERVICE_OWSEC=http://127.0.0.1:8080 \

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -122,7 +122,7 @@ jobs:
             -v "$PWD/ci-runtime:/owsub-data" \
             -e RUN_CHOWN=true \
             -e CI_FAKE_EXTERNAL_SERVICES=1 \
-            -e FAKE_EXTERNAL_SERVICE_PARENTAL_CONTROL=http://127.0.0.1:8080 \
+            -e FAKE_EXTERNAL_SERVICE_MANGO_PARENTAL_CONTROL=http://127.0.0.1:8080 \
             -e FAKE_EXTERNAL_SERVICE_NWTOPOLOGY=http://127.0.0.1:8080 \
             -e FAKE_EXTERNAL_SERVICE_OWPROV=http://127.0.0.1:8080 \
             -e FAKE_EXTERNAL_SERVICE_OWGW=http://127.0.0.1:8080 \

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -186,6 +186,58 @@ jobs:
             exit 1
           fi
 
+      - name: Run Group-Devices Contract Tests
+        env:
+          USERPORTAL_URL: https://localhost:16006
+        run: |
+          echo "Running Group-Devices contract tests..."
+          if ! python3 test_scripts/integration/test_group_devices_contract.py; then
+            echo "Group-Devices contract tests failed! Container logs:"
+            docker logs userportal
+            echo "Fake server logs:"
+            cat fake_server.log
+            exit 1
+          fi
+
+      - name: Run Group-Devices Integration Tests
+        env:
+          USERPORTAL_URL: https://localhost:16006
+        run: |
+          echo "Running Group-Devices integration tests..."
+          if ! python3 test_scripts/integration/test_group_devices_api.py; then
+            echo "Group-Devices integration tests failed! Container logs:"
+            docker logs userportal
+            echo "Fake server logs:"
+            cat fake_server.log
+            exit 1
+          fi
+
+      - name: Run Group-Schedules Contract Tests
+        env:
+          USERPORTAL_URL: https://localhost:16006
+        run: |
+          echo "Running Group-Schedules contract tests..."
+          if ! python3 test_scripts/integration/test_group_schedules_contract.py; then
+            echo "Group-Schedules contract tests failed! Container logs:"
+            docker logs userportal
+            echo "Fake server logs:"
+            cat fake_server.log
+            exit 1
+          fi
+
+      - name: Run Group-Schedules Integration Tests
+        env:
+          USERPORTAL_URL: https://localhost:16006
+        run: |
+          echo "Running Group-Schedules integration tests..."
+          if ! python3 test_scripts/integration/test_group_schedules_api.py; then
+            echo "Group-Schedules integration tests failed! Container logs:"
+            docker logs userportal
+            echo "Fake server logs:"
+            cat fake_server.log
+            exit 1
+          fi
+
       - name: Print UserPortal Logs on Failure
         if: failure()
         run: |

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -7,6 +7,21 @@ on:
       - master
 
 jobs:
+  unit-tests:
+    name: Unit Tests
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+
+      - name: Build unit-test image from repo-native Dockerfile
+        run: |
+          docker build --build-arg BUILD_TESTING=ON \
+            --target owsub-build -t userportal-unit-tests .
+
+      - name: Run native C++ unit tests
+        run: docker run --rm userportal-unit-tests sh -lc "cd /owsub/cmake-build && ctest --output-on-failure"
+
   integration-tests:
     name: Build & Integration Tests
     runs-on: ubuntu-22.04

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -148,6 +148,10 @@ add_executable(owsub
         src/sdks/SDK_parental_control.cpp src/sdks/SDK_parental_control.h
         src/RESTAPI/RESTAPI_groups_handler.cpp src/RESTAPI/RESTAPI_groups_handler.h
         src/RESTAPI/RESTAPI_schedules_handler.cpp src/RESTAPI/RESTAPI_schedules_handler.h
+        src/RESTAPI/RESTAPI_group_devices_list_handler.cpp src/RESTAPI/RESTAPI_group_devices_list_handler.h
+        src/RESTAPI/RESTAPI_group_devices_handler.cpp src/RESTAPI/RESTAPI_group_devices_handler.h
+        src/RESTAPI/RESTAPI_group_schedules_list_handler.cpp src/RESTAPI/RESTAPI_group_schedules_list_handler.h
+        src/RESTAPI/RESTAPI_group_schedules_handler.cpp src/RESTAPI/RESTAPI_group_schedules_handler.h
         )
 
 target_link_libraries(owsub PUBLIC

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -161,3 +161,65 @@ target_link_libraries(owsub PUBLIC
         CppKafka::cppkafka
         resolv
         fmt::fmt)
+
+include(CTest)
+
+if(BUILD_TESTING)
+    execute_process(COMMAND ldconfig)
+
+    # test_parental_control_utils
+    add_executable(test_parental_control_utils tests/unit/test_parental_control_utils.cpp)
+    target_include_directories(test_parental_control_utils PRIVATE src)
+    target_link_libraries(test_parental_control_utils PRIVATE
+        ${Poco_LIBRARIES}
+        ${MySQL_LIBRARIES}
+        ${ZLIB_LIBRARIES}
+        CppKafka::cppkafka
+        resolv
+        fmt::fmt
+    )
+    target_link_options(test_parental_control_utils PRIVATE "-Wl,-rpath,/usr/local/lib")
+    add_test(NAME test_parental_control_utils COMMAND test_parental_control_utils)
+
+    # test_sdk_parental_control
+    add_executable(test_sdk_parental_control tests/unit/test_sdk_parental_control.cpp)
+    target_include_directories(test_sdk_parental_control PRIVATE src)
+    target_link_libraries(test_sdk_parental_control PRIVATE
+        ${Poco_LIBRARIES}
+        ${MySQL_LIBRARIES}
+        ${ZLIB_LIBRARIES}
+        CppKafka::cppkafka
+        resolv
+        fmt::fmt
+    )
+    target_link_options(test_sdk_parental_control PRIVATE "-Wl,-rpath,/usr/local/lib")
+    add_test(NAME test_sdk_parental_control COMMAND test_sdk_parental_control)
+
+    # test_group_devices_handlers
+    add_executable(test_group_devices_handlers tests/unit/test_group_devices_handlers.cpp)
+    target_include_directories(test_group_devices_handlers PRIVATE src)
+    target_link_libraries(test_group_devices_handlers PRIVATE
+        ${Poco_LIBRARIES}
+        ${MySQL_LIBRARIES}
+        ${ZLIB_LIBRARIES}
+        CppKafka::cppkafka
+        resolv
+        fmt::fmt
+    )
+    target_link_options(test_group_devices_handlers PRIVATE "-Wl,-rpath,/usr/local/lib")
+    add_test(NAME test_group_devices_handlers COMMAND test_group_devices_handlers)
+
+    # test_group_schedules_handlers
+    add_executable(test_group_schedules_handlers tests/unit/test_group_schedules_handlers.cpp)
+    target_include_directories(test_group_schedules_handlers PRIVATE src)
+    target_link_libraries(test_group_schedules_handlers PRIVATE
+        ${Poco_LIBRARIES}
+        ${MySQL_LIBRARIES}
+        ${ZLIB_LIBRARIES}
+        CppKafka::cppkafka
+        resolv
+        fmt::fmt
+    )
+    target_link_options(test_group_schedules_handlers PRIVATE "-Wl,-rpath,/usr/local/lib")
+    add_test(NAME test_group_schedules_handlers COMMAND test_group_schedules_handlers)
+endif()

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,7 @@ ARG DEBIAN_VERSION=11.5-slim
 ARG POCO_VERSION=poco-tip-v2
 ARG CPPKAFKA_VERSION=tip-v1
 ARG VALIJASON_VERSION=tip-v1
+ARG BUILD_TESTING=OFF
 
 FROM debian:$DEBIAN_VERSION AS build-base
 
@@ -55,9 +56,12 @@ RUN cmake --build . --target install
 
 FROM build-base AS owsub-build
 
+ARG BUILD_TESTING
+
 ADD CMakeLists.txt build /owsub/
 ADD cmake /owsub/cmake
 ADD src /owsub/src
+ADD tests /owsub/tests
 ADD .git /owsub/.git
 
 COPY --from=poco-build /usr/local/include /usr/local/include
@@ -69,7 +73,7 @@ COPY --from=valijson-build /usr/local/include /usr/local/include
 WORKDIR /owsub
 RUN mkdir cmake-build
 WORKDIR /owsub/cmake-build
-RUN cmake ..
+RUN cmake -DBUILD_TESTING=${BUILD_TESTING} ..
 RUN cmake --build . --config Release -j8
 
 FROM debian:$DEBIAN_VERSION

--- a/src/RESTAPI/RESTAPI_group_devices_handler.cpp
+++ b/src/RESTAPI/RESTAPI_group_devices_handler.cpp
@@ -1,0 +1,94 @@
+/*
+ * SPDX-License-Identifier: AGPL-3.0 OR LicenseRef-Commercial
+ * Copyright (c) 2025 Infernet Systems Pvt Ltd
+ * Portions copyright (c) Telecom Infra Project (TIP), BSD-3-Clause
+ */
+
+#include "RESTAPI_group_devices_handler.h"
+#include "RESTAPI_parental_control_utils.h"
+#include "fmt/format.h"
+#include "framework/utils.h"
+#include "sdks/SDK_parental_control.h"
+
+namespace OpenWifi {
+
+	void RESTAPI_group_devices_handler::DoGet() {
+		if (UserInfo_.userinfo.id.empty()) {
+			return UnAuthorized(RESTAPI::Errors::InvalidSubscriberId);
+		}
+
+		const auto groupId = GetBinding("group_id", "");
+		if (groupId.empty()) {
+			return BadRequest(RESTAPI::Errors::MissingUUID);
+		}
+		if (!Utils::ValidUUID(groupId)) {
+			return BadRequest(RESTAPI::Errors::UnknownId);
+		}
+
+		auto clientMac = GetBinding("client_mac", "");
+		if (clientMac.empty() || !Utils::NormalizeMac(clientMac)) {
+			return BadRequest(RESTAPI::Errors::MissingOrInvalidParameters, "client_mac is missing or invalid");
+		}
+		std::string normalizedMac = Utils::SerialToMAC(clientMac);
+
+		Poco::Net::HTTPResponse::HTTPStatus callStatus;
+		Poco::JSON::Object::Ptr callResponse;
+
+		if (!SDK::ParentalControl::GetGroupDevice(this, UserInfo_.userinfo.id, groupId, normalizedMac,
+												 callStatus, callResponse)) {
+			return ForwardErrorResponse(this, callStatus, callResponse);
+		}
+
+		return ReturnObject(*callResponse);
+	}
+
+	void RESTAPI_group_devices_handler::DoDelete() {
+		if (UserInfo_.userinfo.id.empty()) {
+			return UnAuthorized(RESTAPI::Errors::InvalidSubscriberId);
+		}
+		if (UserInfo_.userinfo.owner.empty()) {
+			return UnAuthorized(RESTAPI::Errors::OperatorIdMustExist);
+		}
+
+		const auto groupId = GetBinding("group_id", "");
+		if (groupId.empty()) {
+			return BadRequest(RESTAPI::Errors::MissingUUID);
+		}
+		if (!Utils::ValidUUID(groupId)) {
+			return BadRequest(RESTAPI::Errors::UnknownId);
+		}
+
+		auto clientMac = GetBinding("client_mac", "");
+		if (clientMac.empty() || !Utils::NormalizeMac(clientMac)) {
+			return BadRequest(RESTAPI::Errors::MissingOrInvalidParameters, "client_mac is missing or invalid");
+		}
+		std::string normalizedMac = Utils::SerialToMAC(clientMac);
+
+		Poco::Net::HTTPResponse::HTTPStatus callStatus;
+		Poco::JSON::Object::Ptr callResponse;
+		std::string rawResponseBody;
+
+		if (!SDK::ParentalControl::DeleteGroupDevice(this, UserInfo_.userinfo.id, groupId, normalizedMac,
+													 callStatus, callResponse, rawResponseBody)) {
+			return ForwardErrorResponse(this, callStatus, callResponse);
+		}
+
+		Poco::JSON::Array::Ptr configRaw;
+		if (!RESTAPI::ParentalControl::ExtractConfigRawSnapshot(callResponse, configRaw, true)) {
+			Logger().error(fmt::format("DoDelete: invalid parental-control payload (subscriber={} group={} device={})",
+									   UserInfo_.userinfo.id, groupId, normalizedMac));
+			return InternalError(RESTAPI::Errors::InternalError);
+		}
+
+		if (!RESTAPI::ParentalControl::HandleApplyConfigRawResult(
+				*this, RESTAPI::ParentalControl::ApplyConfigRaw(*this, Logger(),
+																UserInfo_.userinfo.id,
+																UserInfo_.userinfo.owner, groupId,
+																configRaw, "DoDelete", "group_device"))) {
+			return;
+		}
+
+		return OK();
+	}
+
+} // namespace OpenWifi

--- a/src/RESTAPI/RESTAPI_group_devices_handler.h
+++ b/src/RESTAPI/RESTAPI_group_devices_handler.h
@@ -1,0 +1,30 @@
+/*
+ * SPDX-License-Identifier: AGPL-3.0 OR LicenseRef-Commercial
+ * Copyright (c) 2025 Infernet Systems Pvt Ltd
+ * Portions copyright (c) Telecom Infra Project (TIP), BSD-3-Clause
+ */
+
+#pragma once
+
+#include "framework/RESTAPI_Handler.h"
+
+namespace OpenWifi {
+	class RESTAPI_group_devices_handler : public RESTAPIHandler {
+	  public:
+		RESTAPI_group_devices_handler(const RESTAPIHandler::BindingMap &bindings, Poco::Logger &L,
+									  RESTAPI_GenericServerAccounting &Server, uint64_t TransactionId,
+									  bool Internal)
+			: RESTAPIHandler(bindings, L,
+							 std::vector<std::string>{Poco::Net::HTTPRequest::HTTP_GET,
+													  Poco::Net::HTTPRequest::HTTP_DELETE,
+													  Poco::Net::HTTPRequest::HTTP_OPTIONS},
+							 Server, TransactionId, Internal) {}
+
+		static auto PathName() { return std::list<std::string>{"/api/v1/groups/{group_id}/devices/{client_mac}"}; }
+
+		void DoGet() override;
+		void DoDelete() override;
+		void DoPost() override {}
+		void DoPut() override {}
+	};
+} // namespace OpenWifi

--- a/src/RESTAPI/RESTAPI_group_devices_list_handler.cpp
+++ b/src/RESTAPI/RESTAPI_group_devices_list_handler.cpp
@@ -1,0 +1,126 @@
+/*
+ * SPDX-License-Identifier: AGPL-3.0 OR LicenseRef-Commercial
+ * Copyright (c) 2025 Infernet Systems Pvt Ltd
+ * Portions copyright (c) Telecom Infra Project (TIP), BSD-3-Clause
+ */
+
+#include "RESTAPI_group_devices_list_handler.h"
+#include "Poco/JSON/Stringifier.h"
+#include "RESTAPI_parental_control_utils.h"
+#include "fmt/format.h"
+#include "framework/utils.h"
+#include "sdks/SDK_parental_control.h"
+
+namespace OpenWifi {
+
+	void RESTAPI_group_devices_list_handler::DoGet() {
+		if (UserInfo_.userinfo.id.empty()) {
+			return UnAuthorized(RESTAPI::Errors::InvalidSubscriberId);
+		}
+
+		const auto groupId = GetBinding("group_id", "");
+		if (groupId.empty()) {
+			return BadRequest(RESTAPI::Errors::MissingUUID);
+		}
+		if (!Utils::ValidUUID(groupId)) {
+			return BadRequest(RESTAPI::Errors::UnknownId);
+		}
+
+		Poco::Net::HTTPResponse::HTTPStatus callStatus;
+		Poco::JSON::Array::Ptr arrayResponse;
+		Poco::JSON::Object::Ptr objectResponse;
+
+		if (!SDK::ParentalControl::GetGroupDevices(this, UserInfo_.userinfo.id, groupId, callStatus,
+												  arrayResponse, objectResponse)) {
+			return ForwardErrorResponse(this, callStatus, objectResponse);
+		}
+
+		if (!arrayResponse) {
+			return InternalError(RESTAPI::Errors::InternalError);
+		}
+
+		std::ostringstream ss;
+		Poco::JSON::Stringifier::condense(*arrayResponse, ss);
+		return ReturnRawJSON(ss.str());
+	}
+
+	void RESTAPI_group_devices_list_handler::DoPost() {
+		if (UserInfo_.userinfo.id.empty()) {
+			return UnAuthorized(RESTAPI::Errors::InvalidSubscriberId);
+		}
+		if (UserInfo_.userinfo.owner.empty()) {
+			return UnAuthorized(RESTAPI::Errors::OperatorIdMustExist);
+		}
+
+		const auto groupId = GetBinding("group_id", "");
+		if (groupId.empty()) {
+			return BadRequest(RESTAPI::Errors::MissingUUID);
+		}
+		if (!Utils::ValidUUID(groupId)) {
+			return BadRequest(RESTAPI::Errors::UnknownId);
+		}
+
+		if (!ParsedBody_) {
+			return BadRequest(RESTAPI::Errors::InvalidJSONDocument);
+		}
+
+		std::vector<std::string> names;
+		ParsedBody_->getNames(names);
+		for (const auto &name : names) {
+			if (name != "client_mac") {
+				return BadRequest(RESTAPI::Errors::MissingOrInvalidParameters, "Unknown field: " + name);
+			}
+		}
+
+		if (!ParsedBody_->has("client_mac") || ParsedBody_->isNull("client_mac") || !ParsedBody_->get("client_mac").isString()) {
+			return BadRequest(RESTAPI::Errors::MissingOrInvalidParameters, "client_mac is required and must be a string");
+		}
+		std::string clientMac = ParsedBody_->getValue<std::string>("client_mac");
+		if (!Utils::NormalizeMac(clientMac)) {
+			return BadRequest(RESTAPI::Errors::MissingOrInvalidParameters, "client_mac is not a valid MAC address");
+		}
+		std::string normalizedMac = Utils::SerialToMAC(clientMac);
+
+		// topology validation check
+		std::string gatewaySerial;
+		RESTAPI::ParentalControl::ValidateMacResult valRes =
+			RESTAPI::ParentalControl::ValidateMacInTopology(*this, UserInfo_.userinfo.id,
+															UserInfo_.userinfo.owner,
+															normalizedMac, gatewaySerial);
+		if (!RESTAPI::ParentalControl::HandleValidateMacResult(*this, valRes)) {
+			return;
+		}
+
+		Poco::Net::HTTPResponse::HTTPStatus callStatus;
+		Poco::JSON::Object::Ptr callResponse;
+		Poco::JSON::Object downstreamBody;
+		downstreamBody.set("client_mac", normalizedMac);
+		if (!SDK::ParentalControl::CreateGroupDevice(this, UserInfo_.userinfo.id, groupId, downstreamBody,
+													 callStatus, callResponse)) {
+			return ForwardErrorResponse(this, callStatus, callResponse);
+		}
+
+		Poco::JSON::Array::Ptr configRaw;
+		if (!RESTAPI::ParentalControl::ExtractConfigRawSnapshot(callResponse, configRaw, true)) {
+			Logger().error(fmt::format("DoPost: invalid parental-control payload (subscriber={} group={})",
+									   UserInfo_.userinfo.id, groupId));
+			return InternalError(RESTAPI::Errors::InternalError);
+		}
+
+		if (!RESTAPI::ParentalControl::HandleApplyConfigRawResult(
+				*this, RESTAPI::ParentalControl::ApplyConfigRaw(*this, Logger(),
+																UserInfo_.userinfo.id,
+																UserInfo_.userinfo.owner, groupId,
+																configRaw, "DoPost", "group_device",
+																gatewaySerial))) {
+			return;
+		}
+
+		if (callResponse->has("config-raw")) {
+			callResponse->remove("config-raw");
+		}
+
+		return ReturnObject(*callResponse);
+	}
+
+} // namespace OpenWifi

--- a/src/RESTAPI/RESTAPI_group_devices_list_handler.h
+++ b/src/RESTAPI/RESTAPI_group_devices_list_handler.h
@@ -1,0 +1,30 @@
+/*
+ * SPDX-License-Identifier: AGPL-3.0 OR LicenseRef-Commercial
+ * Copyright (c) 2025 Infernet Systems Pvt Ltd
+ * Portions copyright (c) Telecom Infra Project (TIP), BSD-3-Clause
+ */
+
+#pragma once
+
+#include "framework/RESTAPI_Handler.h"
+
+namespace OpenWifi {
+	class RESTAPI_group_devices_list_handler : public RESTAPIHandler {
+	  public:
+		RESTAPI_group_devices_list_handler(const RESTAPIHandler::BindingMap &bindings, Poco::Logger &L,
+										   RESTAPI_GenericServerAccounting &Server, uint64_t TransactionId,
+										   bool Internal)
+			: RESTAPIHandler(bindings, L,
+							 std::vector<std::string>{Poco::Net::HTTPRequest::HTTP_GET,
+													  Poco::Net::HTTPRequest::HTTP_POST,
+													  Poco::Net::HTTPRequest::HTTP_OPTIONS},
+							 Server, TransactionId, Internal) {}
+
+		static auto PathName() { return std::list<std::string>{"/api/v1/groups/{group_id}/devices"}; }
+
+		void DoGet() override;
+		void DoPost() override;
+		void DoDelete() override {}
+		void DoPut() override {}
+	};
+} // namespace OpenWifi

--- a/src/RESTAPI/RESTAPI_group_schedules_handler.cpp
+++ b/src/RESTAPI/RESTAPI_group_schedules_handler.cpp
@@ -48,6 +48,9 @@ namespace OpenWifi {
 		if (UserInfo_.userinfo.id.empty()) {
 			return UnAuthorized(RESTAPI::Errors::InvalidSubscriberId);
 		}
+		if (UserInfo_.userinfo.owner.empty()) {
+			return UnAuthorized(RESTAPI::Errors::OperatorIdMustExist);
+		}
 
 		const auto groupId = GetBinding("group_id", "");
 		if (groupId.empty()) {

--- a/src/RESTAPI/RESTAPI_group_schedules_handler.cpp
+++ b/src/RESTAPI/RESTAPI_group_schedules_handler.cpp
@@ -1,0 +1,95 @@
+/*
+ * SPDX-License-Identifier: AGPL-3.0 OR LicenseRef-Commercial
+ * Copyright (c) 2025 Infernet Systems Pvt Ltd
+ * Portions copyright (c) Telecom Infra Project (TIP), BSD-3-Clause
+ */
+
+#include "RESTAPI_group_schedules_handler.h"
+#include "RESTAPI_parental_control_utils.h"
+#include "fmt/format.h"
+#include "framework/utils.h"
+#include "sdks/SDK_parental_control.h"
+
+namespace OpenWifi {
+
+	void RESTAPI_group_schedules_handler::DoGet() {
+		if (UserInfo_.userinfo.id.empty()) {
+			return UnAuthorized(RESTAPI::Errors::InvalidSubscriberId);
+		}
+
+		const auto groupId = GetBinding("group_id", "");
+		if (groupId.empty()) {
+			return BadRequest(RESTAPI::Errors::MissingUUID);
+		}
+		if (!Utils::ValidUUID(groupId)) {
+			return BadRequest(RESTAPI::Errors::UnknownId);
+		}
+
+		const auto scheduleId = GetBinding("schedule_id", "");
+		if (scheduleId.empty()) {
+			return BadRequest(RESTAPI::Errors::MissingUUID);
+		}
+		if (!Utils::ValidUUID(scheduleId)) {
+			return BadRequest(RESTAPI::Errors::UnknownId);
+		}
+
+		Poco::Net::HTTPResponse::HTTPStatus callStatus;
+		Poco::JSON::Object::Ptr callResponse;
+
+		if (!SDK::ParentalControl::GetGroupSchedule(this, UserInfo_.userinfo.id, groupId, scheduleId,
+													callStatus, callResponse)) {
+			return ForwardErrorResponse(this, callStatus, callResponse);
+		}
+
+		return ReturnObject(*callResponse);
+	}
+
+	void RESTAPI_group_schedules_handler::DoDelete() {
+		if (UserInfo_.userinfo.id.empty()) {
+			return UnAuthorized(RESTAPI::Errors::InvalidSubscriberId);
+		}
+
+		const auto groupId = GetBinding("group_id", "");
+		if (groupId.empty()) {
+			return BadRequest(RESTAPI::Errors::MissingUUID);
+		}
+		if (!Utils::ValidUUID(groupId)) {
+			return BadRequest(RESTAPI::Errors::UnknownId);
+		}
+
+		const auto scheduleId = GetBinding("schedule_id", "");
+		if (scheduleId.empty()) {
+			return BadRequest(RESTAPI::Errors::MissingUUID);
+		}
+		if (!Utils::ValidUUID(scheduleId)) {
+			return BadRequest(RESTAPI::Errors::UnknownId);
+		}
+
+		Poco::Net::HTTPResponse::HTTPStatus callStatus;
+		Poco::JSON::Object::Ptr callResponse;
+		std::string rawResponseBody;
+
+		if (!SDK::ParentalControl::DeleteGroupSchedule(this, UserInfo_.userinfo.id, groupId, scheduleId,
+													   callStatus, callResponse, rawResponseBody)) {
+			return ForwardErrorResponse(this, callStatus, callResponse);
+		}
+
+		Poco::JSON::Array::Ptr configRaw;
+		if (!RESTAPI::ParentalControl::ExtractConfigRawSnapshot(callResponse, configRaw, true)) {
+			Logger().error(fmt::format("DoDelete: invalid parental-control payload (subscriber={} group={} schedule={})",
+									   UserInfo_.userinfo.id, groupId, scheduleId));
+			return InternalError(RESTAPI::Errors::InternalError);
+		}
+
+		if (!RESTAPI::ParentalControl::HandleApplyConfigRawResult(
+				*this, RESTAPI::ParentalControl::ApplyConfigRaw(*this, Logger(),
+																UserInfo_.userinfo.id,
+																UserInfo_.userinfo.owner, groupId,
+																configRaw, "DoDelete", "group_schedule"))) {
+			return;
+		}
+
+		return OK();
+	}
+
+} // namespace OpenWifi

--- a/src/RESTAPI/RESTAPI_group_schedules_handler.h
+++ b/src/RESTAPI/RESTAPI_group_schedules_handler.h
@@ -1,0 +1,30 @@
+/*
+ * SPDX-License-Identifier: AGPL-3.0 OR LicenseRef-Commercial
+ * Copyright (c) 2025 Infernet Systems Pvt Ltd
+ * Portions copyright (c) Telecom Infra Project (TIP), BSD-3-Clause
+ */
+
+#pragma once
+
+#include "framework/RESTAPI_Handler.h"
+
+namespace OpenWifi {
+	class RESTAPI_group_schedules_handler : public RESTAPIHandler {
+	  public:
+		RESTAPI_group_schedules_handler(const RESTAPIHandler::BindingMap &bindings, Poco::Logger &L,
+										RESTAPI_GenericServerAccounting &Server, uint64_t TransactionId,
+										bool Internal)
+			: RESTAPIHandler(bindings, L,
+							 std::vector<std::string>{Poco::Net::HTTPRequest::HTTP_GET,
+													  Poco::Net::HTTPRequest::HTTP_DELETE,
+													  Poco::Net::HTTPRequest::HTTP_OPTIONS},
+							 Server, TransactionId, Internal) {}
+
+		static auto PathName() { return std::list<std::string>{"/api/v1/groups/{group_id}/schedules/{schedule_id}"}; }
+
+		void DoGet() override;
+		void DoDelete() override;
+		void DoPost() override {}
+		void DoPut() override {}
+	};
+} // namespace OpenWifi

--- a/src/RESTAPI/RESTAPI_group_schedules_list_handler.cpp
+++ b/src/RESTAPI/RESTAPI_group_schedules_list_handler.cpp
@@ -1,0 +1,191 @@
+/*
+ * SPDX-License-Identifier: AGPL-3.0 OR LicenseRef-Commercial
+ * Copyright (c) 2025 Infernet Systems Pvt Ltd
+ * Portions copyright (c) Telecom Infra Project (TIP), BSD-3-Clause
+ */
+
+#include "RESTAPI_group_schedules_list_handler.h"
+#include "Poco/JSON/Stringifier.h"
+#include "RESTAPI_parental_control_utils.h"
+#include "fmt/format.h"
+#include "framework/utils.h"
+#include "sdks/SDK_parental_control.h"
+#include <set>
+
+namespace OpenWifi {
+
+	void RESTAPI_group_schedules_list_handler::DoGet() {
+		if (UserInfo_.userinfo.id.empty()) {
+			return UnAuthorized(RESTAPI::Errors::InvalidSubscriberId);
+		}
+
+		const auto groupId = GetBinding("group_id", "");
+		if (groupId.empty()) {
+			return BadRequest(RESTAPI::Errors::MissingUUID);
+		}
+		if (!Utils::ValidUUID(groupId)) {
+			return BadRequest(RESTAPI::Errors::UnknownId);
+		}
+
+		Poco::Net::HTTPResponse::HTTPStatus callStatus;
+		Poco::JSON::Array::Ptr arrayResponse;
+		Poco::JSON::Object::Ptr objectResponse;
+
+		if (!SDK::ParentalControl::GetGroupSchedules(this, UserInfo_.userinfo.id, groupId, callStatus,
+													 arrayResponse, objectResponse)) {
+			return ForwardErrorResponse(this, callStatus, objectResponse);
+		}
+
+		if (!arrayResponse) {
+			return InternalError(RESTAPI::Errors::InternalError);
+		}
+
+		std::ostringstream ss;
+		Poco::JSON::Stringifier::condense(*arrayResponse, ss);
+		return ReturnRawJSON(ss.str());
+	}
+
+	void RESTAPI_group_schedules_list_handler::DoPost() {
+		if (UserInfo_.userinfo.id.empty()) {
+			return UnAuthorized(RESTAPI::Errors::InvalidSubscriberId);
+		}
+
+		const auto groupId = GetBinding("group_id", "");
+		if (groupId.empty()) {
+			return BadRequest(RESTAPI::Errors::MissingUUID);
+		}
+		if (!Utils::ValidUUID(groupId)) {
+			return BadRequest(RESTAPI::Errors::UnknownId);
+		}
+
+		if (!ParsedBody_) {
+			return BadRequest(RESTAPI::Errors::InvalidJSONDocument);
+		}
+
+		std::vector<std::string> names;
+		ParsedBody_->getNames(names);
+		for (const auto &name : names) {
+			if (name != "schedule_id") {
+				return BadRequest(RESTAPI::Errors::MissingOrInvalidParameters, "Unknown field: " + name);
+			}
+		}
+
+		if (!ParsedBody_->has("schedule_id") || ParsedBody_->isNull("schedule_id") || !ParsedBody_->get("schedule_id").isString()) {
+			return BadRequest(RESTAPI::Errors::MissingOrInvalidParameters, "schedule_id is required and must be a string");
+		}
+		std::string scheduleId = ParsedBody_->getValue<std::string>("schedule_id");
+		if (!Utils::ValidUUID(scheduleId)) {
+			return BadRequest(RESTAPI::Errors::MissingOrInvalidParameters, "schedule_id is not a valid UUID");
+		}
+
+		Poco::Net::HTTPResponse::HTTPStatus callStatus;
+		Poco::JSON::Object::Ptr callResponse;
+		if (!SDK::ParentalControl::CreateGroupSchedule(this, UserInfo_.userinfo.id, groupId, *ParsedBody_,
+													   callStatus, callResponse)) {
+			return ForwardErrorResponse(this, callStatus, callResponse);
+		}
+
+		Poco::JSON::Array::Ptr configRaw;
+		if (!RESTAPI::ParentalControl::ExtractConfigRawSnapshot(callResponse, configRaw, true)) {
+			Logger().error(fmt::format("DoPost: invalid parental-control payload (subscriber={} group={} schedule={})",
+									   UserInfo_.userinfo.id, groupId, scheduleId));
+			return InternalError(RESTAPI::Errors::InternalError);
+		}
+
+		if (!RESTAPI::ParentalControl::HandleApplyConfigRawResult(
+				*this, RESTAPI::ParentalControl::ApplyConfigRaw(*this, Logger(),
+																UserInfo_.userinfo.id,
+																UserInfo_.userinfo.owner, groupId,
+																configRaw, "DoPost", "group_schedule"))) {
+			return;
+		}
+
+		if (callResponse->has("config-raw")) {
+			callResponse->remove("config-raw");
+		}
+
+		return ReturnObject(*callResponse);
+	}
+
+	void RESTAPI_group_schedules_list_handler::DoPut() {
+		if (UserInfo_.userinfo.id.empty()) {
+			return UnAuthorized(RESTAPI::Errors::InvalidSubscriberId);
+		}
+
+		const auto groupId = GetBinding("group_id", "");
+		if (groupId.empty()) {
+			return BadRequest(RESTAPI::Errors::MissingUUID);
+		}
+		if (!Utils::ValidUUID(groupId)) {
+			return BadRequest(RESTAPI::Errors::UnknownId);
+		}
+
+		if (!ParsedBody_) {
+			return BadRequest(RESTAPI::Errors::InvalidJSONDocument);
+		}
+
+		std::vector<std::string> names;
+		ParsedBody_->getNames(names);
+		for (const auto &name : names) {
+			if (name != "schedule_ids") {
+				return BadRequest(RESTAPI::Errors::MissingOrInvalidParameters, "Unknown field: " + name);
+			}
+		}
+
+		if (!ParsedBody_->has("schedule_ids") || ParsedBody_->isNull("schedule_ids") || !ParsedBody_->isArray("schedule_ids")) {
+			return BadRequest(RESTAPI::Errors::MissingOrInvalidParameters, "schedule_ids is required and must be an array");
+		}
+
+		auto scheduleIdsArray = ParsedBody_->getArray("schedule_ids");
+		if (!scheduleIdsArray) {
+			return BadRequest(RESTAPI::Errors::MissingOrInvalidParameters, "schedule_ids is invalid");
+		}
+
+		std::set<std::string> uniqueIds;
+		for (std::size_t i = 0; i < scheduleIdsArray->size(); ++i) {
+			try {
+				if (!scheduleIdsArray->get(i).isString()) {
+					return BadRequest(RESTAPI::Errors::MissingOrInvalidParameters, "schedule_ids entries must be strings");
+				}
+				std::string id = scheduleIdsArray->getElement<std::string>(i);
+				if (!Utils::ValidUUID(id)) {
+					return BadRequest(RESTAPI::Errors::MissingOrInvalidParameters, "invalid UUID in schedule_ids");
+				}
+				if (!uniqueIds.insert(id).second) {
+					return BadRequest(RESTAPI::Errors::MissingOrInvalidParameters, "duplicate UUID in schedule_ids");
+				}
+			} catch (...) {
+				return BadRequest(RESTAPI::Errors::MissingOrInvalidParameters, "invalid UUID in schedule_ids");
+			}
+		}
+
+		Poco::Net::HTTPResponse::HTTPStatus callStatus;
+		Poco::JSON::Object::Ptr callResponse;
+		if (!SDK::ParentalControl::ReplaceGroupSchedules(this, UserInfo_.userinfo.id, groupId, *ParsedBody_,
+														 callStatus, callResponse)) {
+			return ForwardErrorResponse(this, callStatus, callResponse);
+		}
+
+		Poco::JSON::Array::Ptr configRaw;
+		if (!RESTAPI::ParentalControl::ExtractConfigRawSnapshot(callResponse, configRaw, true)) {
+			Logger().error(fmt::format("DoPut: invalid parental-control payload (subscriber={} group={})",
+									   UserInfo_.userinfo.id, groupId));
+			return InternalError(RESTAPI::Errors::InternalError);
+		}
+
+		if (!RESTAPI::ParentalControl::HandleApplyConfigRawResult(
+				*this, RESTAPI::ParentalControl::ApplyConfigRaw(*this, Logger(),
+																UserInfo_.userinfo.id,
+																UserInfo_.userinfo.owner, groupId,
+																configRaw, "DoPut", "group_schedule"))) {
+			return;
+		}
+
+		if (callResponse->has("config-raw")) {
+			callResponse->remove("config-raw");
+		}
+
+		return ReturnObject(*callResponse);
+	}
+
+} // namespace OpenWifi

--- a/src/RESTAPI/RESTAPI_group_schedules_list_handler.cpp
+++ b/src/RESTAPI/RESTAPI_group_schedules_list_handler.cpp
@@ -49,6 +49,9 @@ namespace OpenWifi {
 		if (UserInfo_.userinfo.id.empty()) {
 			return UnAuthorized(RESTAPI::Errors::InvalidSubscriberId);
 		}
+		if (UserInfo_.userinfo.owner.empty()) {
+			return UnAuthorized(RESTAPI::Errors::OperatorIdMustExist);
+		}
 
 		const auto groupId = GetBinding("group_id", "");
 		if (groupId.empty()) {
@@ -110,6 +113,9 @@ namespace OpenWifi {
 	void RESTAPI_group_schedules_list_handler::DoPut() {
 		if (UserInfo_.userinfo.id.empty()) {
 			return UnAuthorized(RESTAPI::Errors::InvalidSubscriberId);
+		}
+		if (UserInfo_.userinfo.owner.empty()) {
+			return UnAuthorized(RESTAPI::Errors::OperatorIdMustExist);
 		}
 
 		const auto groupId = GetBinding("group_id", "");

--- a/src/RESTAPI/RESTAPI_group_schedules_list_handler.h
+++ b/src/RESTAPI/RESTAPI_group_schedules_list_handler.h
@@ -1,0 +1,31 @@
+/*
+ * SPDX-License-Identifier: AGPL-3.0 OR LicenseRef-Commercial
+ * Copyright (c) 2025 Infernet Systems Pvt Ltd
+ * Portions copyright (c) Telecom Infra Project (TIP), BSD-3-Clause
+ */
+
+#pragma once
+
+#include "framework/RESTAPI_Handler.h"
+
+namespace OpenWifi {
+	class RESTAPI_group_schedules_list_handler : public RESTAPIHandler {
+	  public:
+		RESTAPI_group_schedules_list_handler(const RESTAPIHandler::BindingMap &bindings, Poco::Logger &L,
+											 RESTAPI_GenericServerAccounting &Server, uint64_t TransactionId,
+											 bool Internal)
+			: RESTAPIHandler(bindings, L,
+							 std::vector<std::string>{Poco::Net::HTTPRequest::HTTP_GET,
+													  Poco::Net::HTTPRequest::HTTP_POST,
+													  Poco::Net::HTTPRequest::HTTP_PUT,
+													  Poco::Net::HTTPRequest::HTTP_OPTIONS},
+							 Server, TransactionId, Internal) {}
+
+		static auto PathName() { return std::list<std::string>{"/api/v1/groups/{group_id}/schedules"}; }
+
+		void DoGet() override;
+		void DoPost() override;
+		void DoPut() override;
+		void DoDelete() override {}
+	};
+} // namespace OpenWifi

--- a/src/RESTAPI/RESTAPI_groups_handler.cpp
+++ b/src/RESTAPI/RESTAPI_groups_handler.cpp
@@ -89,8 +89,6 @@ namespace OpenWifi {
 				Poco::trimInPlace(descVal);
 				body.set("description", descVal);
 			}
-		} else {
-			body.set("description", Poco::Dynamic::Var());
 		}
 
 		Poco::Net::HTTPResponse::HTTPStatus callStatus;

--- a/src/RESTAPI/RESTAPI_groups_handler.cpp
+++ b/src/RESTAPI/RESTAPI_groups_handler.cpp
@@ -75,24 +75,22 @@ namespace OpenWifi {
 							  "name must be non-empty");
 		}
 
-		// description is required for PUT (full replacement); may be null.
-		if (!ParsedBody_->has("description")) {
-			return BadRequest(RESTAPI::Errors::MissingOrInvalidParameters,
-							  "description is required for PUT");
-		}
-
 		Poco::JSON::Object body;
 		body.set("name", nameVal);
-		if (ParsedBody_->isNull("description")) {
-			body.set("description", Poco::Dynamic::Var());
-		} else {
-			if (!ParsedBody_->get("description").isString()) {
-				return BadRequest(RESTAPI::Errors::MissingOrInvalidParameters,
-								  "description must be a string or null");
+		if (ParsedBody_->has("description")) {
+			if (ParsedBody_->isNull("description")) {
+				body.set("description", Poco::Dynamic::Var());
+			} else {
+				if (!ParsedBody_->get("description").isString()) {
+					return BadRequest(RESTAPI::Errors::MissingOrInvalidParameters,
+									  "description must be a string or null");
+				}
+				std::string descVal = ParsedBody_->getValue<std::string>("description");
+				Poco::trimInPlace(descVal);
+				body.set("description", descVal);
 			}
-			std::string descVal = ParsedBody_->getValue<std::string>("description");
-			Poco::trimInPlace(descVal);
-			body.set("description", descVal);
+		} else {
+			body.set("description", Poco::Dynamic::Var());
 		}
 
 		Poco::Net::HTTPResponse::HTTPStatus callStatus;

--- a/src/RESTAPI/RESTAPI_parental_control_utils.cpp
+++ b/src/RESTAPI/RESTAPI_parental_control_utils.cpp
@@ -29,7 +29,210 @@ namespace OpenWifi::RESTAPI::ParentalControl {
 			timeValue = Poco::format("%02d:%02d", hour, minute);
 			return true;
 		}
+
+		ValidateMacResult ResolveGatewaySerial(RESTAPIHandler &handler,
+											   const std::string &subscriberId,
+											   const std::string &operatorId,
+											   std::string &gatewaySerial) {
+			if (subscriberId.empty() || operatorId.empty()) {
+				return ValidateMacResult::MissingSubscriberOrOperator;
+			}
+
+			ProvObjects::SubscriberDeviceList devList;
+			Poco::Net::HTTPResponse::HTTPStatus provStatus = Poco::Net::HTTPResponse::HTTP_INTERNAL_SERVER_ERROR;
+			Poco::JSON::Object::Ptr provResponse;
+			if (!SDK::Prov::Subscriber::GetDevices(&handler, subscriberId, operatorId, devList,
+												   provStatus, provResponse)) {
+				if (provStatus == Poco::Net::HTTPResponse::HTTP_NOT_FOUND) {
+					return ValidateMacResult::SubscriberDevicesNotFound;
+				}
+				return ValidateMacResult::ProvisioningLookupFailed;
+			}
+
+			if (devList.subscriberDevices.empty()) {
+				return ValidateMacResult::SubscriberDevicesNotFound;
+			}
+
+			for (const auto &dev : devList.subscriberDevices) {
+				std::string grp = dev.deviceGroup;
+				Poco::toLowerInPlace(grp);
+				if (grp == "olg") {
+					gatewaySerial = dev.serialNumber;
+					break;
+				}
+			}
+
+			if (gatewaySerial.empty()) {
+				return ValidateMacResult::GatewaySerialNotFound;
+			}
+
+			return ValidateMacResult::Success;
+		}
+
+		ValidateMacResult ResolveVenueBoards(RESTAPIHandler &handler,
+											 const std::string &gatewaySerial,
+											 std::string &boardId) {
+			ProvObjects::InventoryTag inventory;
+			if (!SDK::Prov::Device::Get(&handler, gatewaySerial, inventory)) {
+				return ValidateMacResult::InventoryNotFound;
+			}
+
+			if (inventory.venue.empty()) {
+				return ValidateMacResult::VenueNotFound;
+			}
+
+			Poco::Net::HTTPServerResponse::HTTPStatus venueStatus = Poco::Net::HTTPServerResponse::HTTP_INTERNAL_SERVER_ERROR;
+			Poco::JSON::Object::Ptr venueResponse = Poco::makeShared<Poco::JSON::Object>();
+			ProvObjects::Venue venue;
+			if (!SDK::Prov::Venue::Get(&handler, inventory.venue, venue, venueStatus, venueResponse)) {
+				if (venueStatus == Poco::Net::HTTPResponse::HTTP_NOT_FOUND) {
+					return ValidateMacResult::VenueNotFound;
+				}
+				return ValidateMacResult::VenueLookupFailed;
+			}
+
+			if (venue.boards.empty() || venue.boards.front().empty()) {
+				return ValidateMacResult::BoardIdNotFound;
+			}
+
+			boardId = venue.boards.front();
+			return ValidateMacResult::Success;
+		}
+
+		ValidateMacResult FetchBoardTopology(RESTAPIHandler &handler,
+											 const std::string &boardId,
+											 Poco::JSON::Object::Ptr &topologyResponse) {
+			Poco::Net::HTTPServerResponse::HTTPStatus topoStatus = Poco::Net::HTTPServerResponse::HTTP_INTERNAL_SERVER_ERROR;
+			topologyResponse = Poco::makeShared<Poco::JSON::Object>();
+			if (!SDK::Topology::Get(&handler, boardId, topoStatus, topologyResponse)) {
+				return ValidateMacResult::TopologyNotFound;
+			}
+
+			if (!topologyResponse) {
+				return ValidateMacResult::TopologyNotFound;
+			}
+
+			return ValidateMacResult::Success;
+		}
+
+		ValidateMacResult MacPresentInTopologyPayload(const Poco::JSON::Object::Ptr &topologyResponse,
+													  const std::string &clientMac) {
+			if (!topologyResponse) {
+				return ValidateMacResult::TopologyNotFound;
+			}
+
+			// Check structures
+			bool hasNodes = topologyResponse->has("nodes");
+			bool hasHistClients = topologyResponse->has("historicalClients");
+			bool hasHistDevs = topologyResponse->has("historicalDevices");
+
+			if ((hasNodes && !topologyResponse->isArray("nodes")) ||
+				(hasHistClients && !topologyResponse->isArray("historicalClients")) ||
+				(hasHistDevs && !topologyResponse->isArray("historicalDevices")) ||
+				(!hasNodes && !hasHistClients && !hasHistDevs)) {
+				return ValidateMacResult::TopologyUnusable;
+			}
+
+			// Normalize client MAC to search
+			std::string targetMac = clientMac;
+			if (!Utils::NormalizeMac(targetMac)) {
+				return ValidateMacResult::MacNotPresentInTopology;
+			}
+			std::string targetMacFormatted = Utils::SerialToMAC(targetMac);
+			Poco::toLowerInPlace(targetMacFormatted);
+
+			// Check historicalClients
+			if (hasHistClients) {
+				auto histClients = topologyResponse->getArray("historicalClients");
+				for (std::size_t i = 0; i < histClients->size(); ++i) {
+					auto item = histClients->getObject(i);
+					if (!item) {
+						return ValidateMacResult::TopologyUnusable;
+					}
+					if (item->has("station") && item->get("station").isString()) {
+						std::string station = item->getValue<std::string>("station");
+						Poco::toLowerInPlace(station);
+						if (station == targetMacFormatted) {
+							return ValidateMacResult::Success;
+						}
+					}
+				}
+			}
+
+			// Check historicalDevices (array of MAC strings)
+			if (hasHistDevs) {
+				auto histDevs = topologyResponse->getArray("historicalDevices");
+				for (std::size_t i = 0; i < histDevs->size(); ++i) {
+					try {
+						if (!histDevs->get(i).isString()) {
+							return ValidateMacResult::TopologyUnusable;
+						}
+						std::string station = histDevs->getElement<std::string>(i);
+						if (Utils::NormalizeMac(station)) {
+							std::string normStation = Utils::SerialToMAC(station);
+							Poco::toLowerInPlace(normStation);
+							if (normStation == targetMacFormatted) {
+								return ValidateMacResult::Success;
+							}
+						}
+					} catch (...) {
+						return ValidateMacResult::TopologyUnusable;
+					}
+				}
+			}
+
+			// Check active nodes / aps / clients
+			if (hasNodes) {
+				auto nodes = topologyResponse->getArray("nodes");
+				for (std::size_t i = 0; i < nodes->size(); ++i) {
+					auto node = nodes->getObject(i);
+					if (!node) {
+						return ValidateMacResult::TopologyUnusable;
+					}
+					if (node->has("aps")) {
+						if (!node->isArray("aps")) {
+							return ValidateMacResult::TopologyUnusable;
+						}
+						auto aps = node->getArray("aps");
+						for (std::size_t apIndex = 0; apIndex < aps->size(); ++apIndex) {
+							auto ap = aps->getObject(apIndex);
+							if (!ap) {
+								return ValidateMacResult::TopologyUnusable;
+							}
+							if (ap->has("clients")) {
+								if (!ap->isArray("clients")) {
+									return ValidateMacResult::TopologyUnusable;
+								}
+								auto clients = ap->getArray("clients");
+								for (std::size_t clientIndex = 0; clientIndex < clients->size(); ++clientIndex) {
+									auto client = clients->getObject(clientIndex);
+									if (!client) {
+										return ValidateMacResult::TopologyUnusable;
+									}
+									if (client->has("station")) {
+										if (!client->get("station").isString()) {
+											return ValidateMacResult::TopologyUnusable;
+										}
+										std::string station = client->getValue<std::string>("station");
+										Poco::toLowerInPlace(station);
+										if (station == targetMacFormatted) {
+											return ValidateMacResult::Success;
+										}
+									}
+								}
+							}
+						}
+					}
+				}
+			}
+
+			return ValidateMacResult::MacNotPresentInTopology;
+		}
 	} // namespace
+
+	// =========================================================================
+	// Schedule Helpers
+	// =========================================================================
 
 	bool NormalizeScheduleResponse(Poco::JSON::Object::Ptr schedule) {
 		if (!schedule || !schedule->has("start_minute") || !schedule->has("stop_minute")) {
@@ -275,6 +478,39 @@ namespace OpenWifi::RESTAPI::ParentalControl {
 		return body;
 	}
 
+	// =========================================================================
+	// Topology/Device Validation Helpers
+	// =========================================================================
+
+	ValidateMacResult ValidateMacInTopology(RESTAPIHandler &handler,
+											const std::string &subscriberId,
+											const std::string &operatorId,
+											const std::string &clientMac,
+											std::string &gatewaySerial) {
+		ValidateMacResult result = ResolveGatewaySerial(handler, subscriberId, operatorId, gatewaySerial);
+		if (result != ValidateMacResult::Success) {
+			return result;
+		}
+
+		std::string boardId;
+		result = ResolveVenueBoards(handler, gatewaySerial, boardId);
+		if (result != ValidateMacResult::Success) {
+			return result;
+		}
+
+		Poco::JSON::Object::Ptr topologyResponse;
+		result = FetchBoardTopology(handler, boardId, topologyResponse);
+		if (result != ValidateMacResult::Success) {
+			return result;
+		}
+
+		return MacPresentInTopologyPayload(topologyResponse, clientMac);
+	}
+
+	// =========================================================================
+	// Config-Raw Extraction/Apply Helpers
+	// =========================================================================
+
 	bool ExtractConfigRawSnapshot(const Poco::JSON::Object::Ptr &callResponse,
 								  Poco::JSON::Array::Ptr &configRaw,
 								  bool required) {
@@ -398,6 +634,10 @@ namespace OpenWifi::RESTAPI::ParentalControl {
 		return ApplyConfigRawResult::Applied;
 	}
 
+	// =========================================================================
+	// HTTP/Result Mapping Helpers
+	// =========================================================================
+
 	bool HandleApplyConfigRawResult(RESTAPIHandler &handler, ApplyConfigRawResult result) {
 		switch (result) {
 		case ApplyConfigRawResult::NoConfigApplyNeeded:
@@ -418,186 +658,6 @@ namespace OpenWifi::RESTAPI::ParentalControl {
 		}
 		handler.InternalError(RESTAPI::Errors::InternalError);
 		return false;
-	}
-
-	ValidateMacResult ValidateMacInTopology(RESTAPIHandler &handler,
-											const std::string &subscriberId,
-											const std::string &operatorId,
-											const std::string &clientMac,
-											std::string &gatewaySerial) {
-		if (subscriberId.empty() || operatorId.empty()) {
-			return ValidateMacResult::MissingSubscriberOrOperator;
-		}
-
-		ProvObjects::SubscriberDeviceList devList;
-		Poco::Net::HTTPResponse::HTTPStatus provStatus = Poco::Net::HTTPResponse::HTTP_INTERNAL_SERVER_ERROR;
-		Poco::JSON::Object::Ptr provResponse;
-		if (!SDK::Prov::Subscriber::GetDevices(&handler, subscriberId, operatorId, devList,
-											   provStatus, provResponse)) {
-			if (provStatus == Poco::Net::HTTPResponse::HTTP_NOT_FOUND) {
-				return ValidateMacResult::SubscriberDevicesNotFound;
-			}
-			return ValidateMacResult::ProvisioningLookupFailed;
-		}
-
-		if (devList.subscriberDevices.empty()) {
-			return ValidateMacResult::SubscriberDevicesNotFound;
-		}
-
-		for (const auto &dev : devList.subscriberDevices) {
-			std::string grp = dev.deviceGroup;
-			Poco::toLowerInPlace(grp);
-			if (grp == "olg") {
-				gatewaySerial = dev.serialNumber;
-				break;
-			}
-		}
-
-		if (gatewaySerial.empty()) {
-			return ValidateMacResult::GatewaySerialNotFound;
-		}
-
-		ProvObjects::InventoryTag inventory;
-		if (!SDK::Prov::Device::Get(&handler, gatewaySerial, inventory)) {
-			return ValidateMacResult::InventoryNotFound;
-		}
-
-		if (inventory.venue.empty()) {
-			return ValidateMacResult::VenueNotFound;
-		}
-
-		Poco::Net::HTTPServerResponse::HTTPStatus venueStatus = Poco::Net::HTTPServerResponse::HTTP_INTERNAL_SERVER_ERROR;
-		Poco::JSON::Object::Ptr venueResponse = Poco::makeShared<Poco::JSON::Object>();
-		ProvObjects::Venue venue;
-		if (!SDK::Prov::Venue::Get(&handler, inventory.venue, venue, venueStatus, venueResponse)) {
-			if (venueStatus == Poco::Net::HTTPResponse::HTTP_NOT_FOUND) {
-				return ValidateMacResult::VenueNotFound;
-			}
-			return ValidateMacResult::VenueLookupFailed;
-		}
-
-		if (venue.boards.empty() || venue.boards.front().empty()) {
-			return ValidateMacResult::BoardIdNotFound;
-		}
-
-		std::string boardId = venue.boards.front();
-
-		Poco::Net::HTTPServerResponse::HTTPStatus topoStatus = Poco::Net::HTTPServerResponse::HTTP_INTERNAL_SERVER_ERROR;
-		Poco::JSON::Object::Ptr topologyResponse = Poco::makeShared<Poco::JSON::Object>();
-		if (!SDK::Topology::Get(&handler, boardId, topoStatus, topologyResponse)) {
-			return ValidateMacResult::TopologyNotFound;
-		}
-
-		if (!topologyResponse) {
-			return ValidateMacResult::TopologyNotFound;
-		}
-
-		// Check structures
-		bool hasNodes = topologyResponse->has("nodes");
-		bool hasHistClients = topologyResponse->has("historicalClients");
-		bool hasHistDevs = topologyResponse->has("historicalDevices");
-
-		if ((hasNodes && !topologyResponse->isArray("nodes")) ||
-			(hasHistClients && !topologyResponse->isArray("historicalClients")) ||
-			(hasHistDevs && !topologyResponse->isArray("historicalDevices")) ||
-			(!hasNodes && !hasHistClients && !hasHistDevs)) {
-			return ValidateMacResult::TopologyUnusable;
-		}
-
-		// Normalize client MAC to search
-		std::string targetMac = clientMac;
-		if (!Utils::NormalizeMac(targetMac)) {
-			return ValidateMacResult::MacNotPresentInTopology;
-		}
-		std::string targetMacFormatted = Utils::SerialToMAC(targetMac);
-		Poco::toLowerInPlace(targetMacFormatted);
-
-		// Check historicalClients
-		if (hasHistClients) {
-			auto histClients = topologyResponse->getArray("historicalClients");
-			for (std::size_t i = 0; i < histClients->size(); ++i) {
-				auto item = histClients->getObject(i);
-				if (!item) {
-					return ValidateMacResult::TopologyUnusable;
-				}
-				if (item->has("station") && item->get("station").isString()) {
-					std::string station = item->getValue<std::string>("station");
-					Poco::toLowerInPlace(station);
-					if (station == targetMacFormatted) {
-						return ValidateMacResult::Success;
-					}
-				}
-			}
-		}
-
-		// Check historicalDevices (array of MAC strings)
-		if (hasHistDevs) {
-			auto histDevs = topologyResponse->getArray("historicalDevices");
-			for (std::size_t i = 0; i < histDevs->size(); ++i) {
-				try {
-					if (!histDevs->get(i).isString()) {
-						return ValidateMacResult::TopologyUnusable;
-					}
-					std::string station = histDevs->getElement<std::string>(i);
-					if (Utils::NormalizeMac(station)) {
-						std::string normStation = Utils::SerialToMAC(station);
-						Poco::toLowerInPlace(normStation);
-						if (normStation == targetMacFormatted) {
-							return ValidateMacResult::Success;
-						}
-					}
-				} catch (...) {
-					return ValidateMacResult::TopologyUnusable;
-				}
-			}
-		}
-
-		// Check active nodes / aps / clients
-		if (hasNodes) {
-			auto nodes = topologyResponse->getArray("nodes");
-			for (std::size_t i = 0; i < nodes->size(); ++i) {
-				auto node = nodes->getObject(i);
-				if (!node) {
-					return ValidateMacResult::TopologyUnusable;
-				}
-				if (node->has("aps")) {
-					if (!node->isArray("aps")) {
-						return ValidateMacResult::TopologyUnusable;
-					}
-					auto aps = node->getArray("aps");
-					for (std::size_t apIndex = 0; apIndex < aps->size(); ++apIndex) {
-						auto ap = aps->getObject(apIndex);
-						if (!ap) {
-							return ValidateMacResult::TopologyUnusable;
-						}
-						if (ap->has("clients")) {
-							if (!ap->isArray("clients")) {
-								return ValidateMacResult::TopologyUnusable;
-							}
-							auto clients = ap->getArray("clients");
-							for (std::size_t clientIndex = 0; clientIndex < clients->size(); ++clientIndex) {
-								auto client = clients->getObject(clientIndex);
-								if (!client) {
-									return ValidateMacResult::TopologyUnusable;
-								}
-								if (client->has("station")) {
-									if (!client->get("station").isString()) {
-										return ValidateMacResult::TopologyUnusable;
-									}
-									std::string station = client->getValue<std::string>("station");
-									Poco::toLowerInPlace(station);
-									if (station == targetMacFormatted) {
-										return ValidateMacResult::Success;
-									}
-								}
-							}
-						}
-					}
-				}
-			}
-		}
-
-		return ValidateMacResult::MacNotPresentInTopology;
 	}
 
 	bool HandleValidateMacResult(RESTAPIHandler &handler, ValidateMacResult result) {

--- a/src/RESTAPI/RESTAPI_parental_control_utils.cpp
+++ b/src/RESTAPI/RESTAPI_parental_control_utils.cpp
@@ -9,6 +9,9 @@
 #include "fmt/format.h"
 #include "sdks/SDK_gw.h"
 #include "sdks/SDK_prov.h"
+#include "sdks/SDK_nw_topology.h"
+#include "framework/utils.h"
+#include "framework/ow_constants.h"
 #include <cctype>
 #include <set>
 #include <vector>
@@ -149,36 +152,28 @@ namespace OpenWifi::RESTAPI::ParentalControl {
 			return false;
 		}
 
-		if (!body->has("target_value")) {
-			handler.BadRequest(RESTAPI::Errors::MissingOrInvalidParameters,
-							   "target_value is required");
-			return false;
-		}
-		if (body->isNull("target_value")) {
-			if (out.targetKind != "INTERNET") {
+		if (out.targetKind == "APP") {
+			if (!body->has("target_value") || body->isNull("target_value") || !body->get("target_value").isString()) {
+				handler.BadRequest(RESTAPI::Errors::MissingOrInvalidParameters,
+								   "APP schedules require a non-empty target_value");
+				return false;
+			}
+			out.targetValue = body->getValue<std::string>("target_value");
+			Poco::trimInPlace(out.targetValue);
+			if (out.targetValue.empty()) {
 				handler.BadRequest(RESTAPI::Errors::MissingOrInvalidParameters,
 								   "APP schedules require a non-empty target_value");
 				return false;
 			}
 		} else {
-			if (!body->get("target_value").isString()) {
-				handler.BadRequest(RESTAPI::Errors::MissingOrInvalidParameters,
-								   "target_value must be a string or null");
-				return false;
-			}
-			out.targetValue = body->getValue<std::string>("target_value");
-			Poco::trimInPlace(out.targetValue);
-			if (out.targetKind == "APP") {
-				if (out.targetValue.empty()) {
+			if (body->has("target_value")) {
+				if (!body->isNull("target_value")) {
 					handler.BadRequest(RESTAPI::Errors::MissingOrInvalidParameters,
-									   "APP schedules require a non-empty target_value");
+									   "INTERNET schedules require target_value to be null");
 					return false;
 				}
-			} else {
-				handler.BadRequest(RESTAPI::Errors::MissingOrInvalidParameters,
-								   "INTERNET schedules require target_value to be null");
-				return false;
 			}
+			out.targetValue = "";
 		}
 
 		if (!body->has("start_time") ||
@@ -228,23 +223,19 @@ namespace OpenWifi::RESTAPI::ParentalControl {
 			}
 		}
 
-		if (enabledRequired && !body->has("description")) {
-			handler.BadRequest(RESTAPI::Errors::MissingOrInvalidParameters,
-							   "description is required for PUT");
-			return false;
-		}
-
-		if (body->isNull("description")) {
-			out.description = std::nullopt;
-		} else if (body->has("description")) {
-			if (!body->get("description").isString()) {
-				handler.BadRequest(RESTAPI::Errors::MissingOrInvalidParameters,
-								   "description must be a string or null");
-				return false;
+		if (body->has("description")) {
+			if (body->isNull("description")) {
+				out.description = std::nullopt;
+			} else {
+				if (!body->get("description").isString()) {
+					handler.BadRequest(RESTAPI::Errors::MissingOrInvalidParameters,
+									   "description must be a string or null");
+					return false;
+				}
+				std::string desc = body->getValue<std::string>("description");
+				Poco::trimInPlace(desc);
+				out.description = std::move(desc);
 			}
-			std::string desc = body->getValue<std::string>("description");
-			Poco::trimInPlace(desc);
-			out.description = std::move(desc);
 		} else {
 			out.description = std::nullopt;
 		}
@@ -275,12 +266,16 @@ namespace OpenWifi::RESTAPI::ParentalControl {
 	}
 
 	bool ExtractConfigRawSnapshot(const Poco::JSON::Object::Ptr &callResponse,
-								  Poco::JSON::Array::Ptr &configRaw) {
+								  Poco::JSON::Array::Ptr &configRaw,
+								  bool required) {
 		configRaw.reset();
 		if (!callResponse) {
-			return true;
+			return !required;
 		}
-		if (!callResponse->has("config-raw") || callResponse->isNull("config-raw")) {
+		if (!callResponse->has("config-raw")) {
+			return !required;
+		}
+		if (callResponse->isNull("config-raw")) {
 			return true;
 		}
 		if (!callResponse->isArray("config-raw")) {
@@ -316,7 +311,8 @@ namespace OpenWifi::RESTAPI::ParentalControl {
 										const std::string &operatorId, const std::string &objectId,
 										const Poco::JSON::Array::Ptr &configRaw,
 										const std::string &operationName,
-										const std::string &objectType) {
+										const std::string &objectType,
+										const std::string &gatewaySerial) {
 		if (!configRaw) {
 			return ApplyConfigRawResult::NoConfigApplyNeeded;
 		}
@@ -327,27 +323,28 @@ namespace OpenWifi::RESTAPI::ParentalControl {
 			return ApplyConfigRawResult::MissingOperatorId;
 		}
 
-		ProvObjects::SubscriberDeviceList devList;
-		Poco::Net::HTTPResponse::HTTPStatus provStatus;
-		Poco::JSON::Object::Ptr provResponse;
-		if (!SDK::Prov::Subscriber::GetDevices(&handler, subscriberId, operatorId, devList,
-											   provStatus, provResponse)) {
-			logger.error(fmt::format("{}: provisioning lookup failed (subscriber={} {}={})",
-									 operationName, subscriberId, objectType, objectId));
-			return ApplyConfigRawResult::ProvisioningLookupFailed;
-		}
+		std::string resolvedSerial = gatewaySerial;
+		if (resolvedSerial.empty()) {
+			ProvObjects::SubscriberDeviceList devList;
+			Poco::Net::HTTPResponse::HTTPStatus provStatus;
+			Poco::JSON::Object::Ptr provResponse;
+			if (!SDK::Prov::Subscriber::GetDevices(&handler, subscriberId, operatorId, devList, provStatus, provResponse)) {
+				logger.error(fmt::format("{}: provisioning lookup failed (subscriber={} {}={})",
+										 operationName, subscriberId, objectType, objectId));
+				return ApplyConfigRawResult::ProvisioningLookupFailed;
+			}
 
-		std::string gatewaySerial;
-		for (const auto &dev : devList.subscriberDevices) {
-			std::string grp = dev.deviceGroup;
-			Poco::toLowerInPlace(grp);
-			if (grp == "olg") {
-				gatewaySerial = dev.serialNumber;
-				break;
+			for (const auto &dev : devList.subscriberDevices) {
+				std::string grp = dev.deviceGroup;
+				Poco::toLowerInPlace(grp);
+				if (grp == "olg") {
+					resolvedSerial = dev.serialNumber;
+					break;
+				}
 			}
 		}
 
-		if (gatewaySerial.empty()) {
+		if (resolvedSerial.empty()) {
 			logger.error(fmt::format("{}: gateway serial not resolved (subscriber={} {}={})",
 									 operationName, subscriberId, objectType, objectId));
 			return ApplyConfigRawResult::MissingGatewaySerial;
@@ -355,13 +352,13 @@ namespace OpenWifi::RESTAPI::ParentalControl {
 
 		Poco::JSON::Object::Ptr gwResponse;
 		Poco::Net::HTTPResponse::HTTPStatus gwStatus;
-		if (!SDK::GW::Device::GetConfig(&handler, gatewaySerial, gwStatus, gwResponse)) {
+		if (!SDK::GW::Device::GetConfig(&handler, resolvedSerial, gwStatus, gwResponse)) {
 			if (gwStatus == Poco::Net::HTTPResponse::HTTP_OK) {
 				logger.error(fmt::format("{}: gateway config malformed (serial={})", operationName,
-										 gatewaySerial));
+										 resolvedSerial));
 			} else {
 				logger.error(fmt::format("{}: gateway config load failed (serial={})",
-										 operationName, gatewaySerial));
+										 operationName, resolvedSerial));
 			}
 			return ApplyConfigRawResult::GatewayConfigLoadFailed;
 		}
@@ -369,7 +366,7 @@ namespace OpenWifi::RESTAPI::ParentalControl {
 		if (!gwResponse || !gwResponse->has("configuration") ||
 			!gwResponse->isObject("configuration")) {
 			logger.error(fmt::format("{}: gateway config malformed (serial={})", operationName,
-									 gatewaySerial));
+									 resolvedSerial));
 			return ApplyConfigRawResult::GatewayConfigMalformed;
 		}
 
@@ -381,10 +378,10 @@ namespace OpenWifi::RESTAPI::ParentalControl {
 
 		Poco::JSON::Object::Ptr configureResponse;
 		Poco::Net::HTTPResponse::HTTPStatus configureStatus;
-		if (!SDK::GW::Device::Configure(&handler, gatewaySerial, gatewayConfig, configureStatus,
+		if (!SDK::GW::Device::Configure(&handler, resolvedSerial, gatewayConfig, configureStatus,
 										configureResponse)) {
 			logger.error(fmt::format("{}: gateway configure failed (serial={})", operationName,
-									 gatewaySerial));
+									 resolvedSerial));
 			return ApplyConfigRawResult::GatewayConfigureFailed;
 		}
 
@@ -406,6 +403,220 @@ namespace OpenWifi::RESTAPI::ParentalControl {
 		case ApplyConfigRawResult::GatewayConfigLoadFailed:
 		case ApplyConfigRawResult::GatewayConfigMalformed:
 		case ApplyConfigRawResult::GatewayConfigureFailed:
+			handler.InternalError(RESTAPI::Errors::InternalError);
+			return false;
+		}
+		handler.InternalError(RESTAPI::Errors::InternalError);
+		return false;
+	}
+
+	ValidateMacResult ValidateMacInTopology(RESTAPIHandler &handler,
+											const std::string &subscriberId,
+											const std::string &operatorId,
+											const std::string &clientMac,
+											std::string &gatewaySerial) {
+		if (subscriberId.empty() || operatorId.empty()) {
+			return ValidateMacResult::MissingSubscriberOrOperator;
+		}
+
+		ProvObjects::SubscriberDeviceList devList;
+		Poco::Net::HTTPResponse::HTTPStatus provStatus = Poco::Net::HTTPResponse::HTTP_INTERNAL_SERVER_ERROR;
+		Poco::JSON::Object::Ptr provResponse;
+		if (!SDK::Prov::Subscriber::GetDevices(&handler, subscriberId, operatorId, devList,
+											   provStatus, provResponse)) {
+			if (provStatus == Poco::Net::HTTPResponse::HTTP_NOT_FOUND) {
+				return ValidateMacResult::SubscriberDevicesNotFound;
+			}
+			return ValidateMacResult::ProvisioningLookupFailed;
+		}
+
+		if (devList.subscriberDevices.empty()) {
+			return ValidateMacResult::SubscriberDevicesNotFound;
+		}
+
+		for (const auto &dev : devList.subscriberDevices) {
+			std::string grp = dev.deviceGroup;
+			Poco::toLowerInPlace(grp);
+			if (grp == "olg") {
+				gatewaySerial = dev.serialNumber;
+				break;
+			}
+		}
+
+		if (gatewaySerial.empty()) {
+			return ValidateMacResult::GatewaySerialNotFound;
+		}
+
+		ProvObjects::InventoryTag inventory;
+		if (!SDK::Prov::Device::Get(&handler, gatewaySerial, inventory)) {
+			return ValidateMacResult::InventoryNotFound;
+		}
+
+		if (inventory.venue.empty()) {
+			return ValidateMacResult::VenueNotFound;
+		}
+
+		Poco::Net::HTTPServerResponse::HTTPStatus venueStatus = Poco::Net::HTTPServerResponse::HTTP_INTERNAL_SERVER_ERROR;
+		Poco::JSON::Object::Ptr venueResponse = Poco::makeShared<Poco::JSON::Object>();
+		ProvObjects::Venue venue;
+		if (!SDK::Prov::Venue::Get(&handler, inventory.venue, venue, venueStatus, venueResponse)) {
+			return ValidateMacResult::VenueNotFound;
+		}
+
+		if (venue.boards.empty() || venue.boards.front().empty()) {
+			return ValidateMacResult::BoardIdNotFound;
+		}
+
+		std::string boardId = venue.boards.front();
+
+		Poco::Net::HTTPServerResponse::HTTPStatus topoStatus = Poco::Net::HTTPServerResponse::HTTP_INTERNAL_SERVER_ERROR;
+		Poco::JSON::Object::Ptr topologyResponse = Poco::makeShared<Poco::JSON::Object>();
+		if (!SDK::Topology::Get(&handler, boardId, topoStatus, topologyResponse)) {
+			return ValidateMacResult::TopologyNotFound;
+		}
+
+		if (!topologyResponse) {
+			return ValidateMacResult::TopologyNotFound;
+		}
+
+		// Check structures
+		bool hasNodes = topologyResponse->has("nodes");
+		bool hasHistClients = topologyResponse->has("historicalClients");
+		bool hasHistDevs = topologyResponse->has("historicalDevices");
+
+		if ((hasNodes && !topologyResponse->isArray("nodes")) ||
+			(hasHistClients && !topologyResponse->isArray("historicalClients")) ||
+			(hasHistDevs && !topologyResponse->isArray("historicalDevices")) ||
+			(!hasNodes && !hasHistClients && !hasHistDevs)) {
+			return ValidateMacResult::TopologyUnusable;
+		}
+
+		// Normalize client MAC to search
+		std::string targetMac = clientMac;
+		if (!Utils::NormalizeMac(targetMac)) {
+			return ValidateMacResult::MacNotPresentInTopology;
+		}
+		std::string targetMacFormatted = Utils::SerialToMAC(targetMac);
+		Poco::toLowerInPlace(targetMacFormatted);
+
+		// Check historicalClients
+		if (hasHistClients) {
+			auto histClients = topologyResponse->getArray("historicalClients");
+			for (std::size_t i = 0; i < histClients->size(); ++i) {
+				auto item = histClients->getObject(i);
+				if (!item) {
+					return ValidateMacResult::TopologyUnusable;
+				}
+				if (item->has("station") && item->get("station").isString()) {
+					std::string station = item->getValue<std::string>("station");
+					Poco::toLowerInPlace(station);
+					if (station == targetMacFormatted) {
+						return ValidateMacResult::Success;
+					}
+				}
+			}
+		}
+
+		// Check historicalDevices (array of MAC strings)
+		if (hasHistDevs) {
+			auto histDevs = topologyResponse->getArray("historicalDevices");
+			for (std::size_t i = 0; i < histDevs->size(); ++i) {
+				try {
+					if (!histDevs->get(i).isString()) {
+						return ValidateMacResult::TopologyUnusable;
+					}
+					std::string station = histDevs->getElement<std::string>(i);
+					if (Utils::NormalizeMac(station)) {
+						std::string normStation = Utils::SerialToMAC(station);
+						Poco::toLowerInPlace(normStation);
+						if (normStation == targetMacFormatted) {
+							return ValidateMacResult::Success;
+						}
+					}
+				} catch (...) {
+					return ValidateMacResult::TopologyUnusable;
+				}
+			}
+		}
+
+		// Check active nodes / aps / clients
+		if (hasNodes) {
+			auto nodes = topologyResponse->getArray("nodes");
+			for (std::size_t i = 0; i < nodes->size(); ++i) {
+				auto node = nodes->getObject(i);
+				if (!node) {
+					return ValidateMacResult::TopologyUnusable;
+				}
+				if (node->has("aps")) {
+					if (!node->isArray("aps")) {
+						return ValidateMacResult::TopologyUnusable;
+					}
+					auto aps = node->getArray("aps");
+					for (std::size_t apIndex = 0; apIndex < aps->size(); ++apIndex) {
+						auto ap = aps->getObject(apIndex);
+						if (!ap) {
+							return ValidateMacResult::TopologyUnusable;
+						}
+						if (ap->has("clients")) {
+							if (!ap->isArray("clients")) {
+								return ValidateMacResult::TopologyUnusable;
+							}
+							auto clients = ap->getArray("clients");
+							for (std::size_t clientIndex = 0; clientIndex < clients->size(); ++clientIndex) {
+								auto client = clients->getObject(clientIndex);
+								if (!client) {
+									return ValidateMacResult::TopologyUnusable;
+								}
+								if (client->has("station")) {
+									if (!client->get("station").isString()) {
+										return ValidateMacResult::TopologyUnusable;
+									}
+									std::string station = client->getValue<std::string>("station");
+									Poco::toLowerInPlace(station);
+									if (station == targetMacFormatted) {
+										return ValidateMacResult::Success;
+									}
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+
+		return ValidateMacResult::MacNotPresentInTopology;
+	}
+
+	bool HandleValidateMacResult(RESTAPIHandler &handler, ValidateMacResult result) {
+		switch (result) {
+		case ValidateMacResult::Success:
+			return true;
+		case ValidateMacResult::MissingSubscriberOrOperator:
+			handler.UnAuthorized(RESTAPI::Errors::OperatorIdMustExist);
+			return false;
+		case ValidateMacResult::SubscriberDevicesNotFound:
+		case ValidateMacResult::GatewaySerialNotFound:
+			handler.BadRequest(RESTAPI::Errors::SubNoDeviceActivated);
+			return false;
+		case ValidateMacResult::ProvisioningLookupFailed:
+			handler.InternalError(RESTAPI::Errors::InternalError);
+			return false;
+		case ValidateMacResult::InventoryNotFound:
+			handler.BadRequest(RESTAPI::Errors::GatewayInventoryNotFound);
+			return false;
+		case ValidateMacResult::VenueNotFound:
+			handler.BadRequest(RESTAPI::Errors::VenueMustExist);
+			return false;
+		case ValidateMacResult::BoardIdNotFound:
+			handler.BadRequest(RESTAPI::Errors::VenueMissingBoardId);
+			return false;
+		case ValidateMacResult::TopologyNotFound:
+			handler.InternalError(RESTAPI::Errors::InternalError);
+			return false;
+		case ValidateMacResult::MacNotPresentInTopology:
+			handler.BadRequest(RESTAPI::Errors::MacNotPresentInTopology);
+			return false;
+		case ValidateMacResult::TopologyUnusable:
 			handler.InternalError(RESTAPI::Errors::InternalError);
 			return false;
 		}

--- a/src/RESTAPI/RESTAPI_parental_control_utils.cpp
+++ b/src/RESTAPI/RESTAPI_parental_control_utils.cpp
@@ -460,7 +460,10 @@ namespace OpenWifi::RESTAPI::ParentalControl {
 		Poco::JSON::Object::Ptr venueResponse = Poco::makeShared<Poco::JSON::Object>();
 		ProvObjects::Venue venue;
 		if (!SDK::Prov::Venue::Get(&handler, inventory.venue, venue, venueStatus, venueResponse)) {
-			return ValidateMacResult::VenueNotFound;
+			if (venueStatus == Poco::Net::HTTPResponse::HTTP_NOT_FOUND) {
+				return ValidateMacResult::VenueNotFound;
+			}
+			return ValidateMacResult::VenueLookupFailed;
 		}
 
 		if (venue.boards.empty() || venue.boards.front().empty()) {
@@ -606,6 +609,9 @@ namespace OpenWifi::RESTAPI::ParentalControl {
 			return false;
 		case ValidateMacResult::VenueNotFound:
 			handler.BadRequest(RESTAPI::Errors::VenueMustExist);
+			return false;
+		case ValidateMacResult::VenueLookupFailed:
+			handler.InternalError(RESTAPI::Errors::InternalError);
 			return false;
 		case ValidateMacResult::BoardIdNotFound:
 			handler.BadRequest(RESTAPI::Errors::VenueMissingBoardId);

--- a/src/RESTAPI/RESTAPI_parental_control_utils.cpp
+++ b/src/RESTAPI/RESTAPI_parental_control_utils.cpp
@@ -153,6 +153,7 @@ namespace OpenWifi::RESTAPI::ParentalControl {
 		}
 
 		if (out.targetKind == "APP") {
+			out.has_target_value = true;
 			if (!body->has("target_value") || body->isNull("target_value") || !body->get("target_value").isString()) {
 				handler.BadRequest(RESTAPI::Errors::MissingOrInvalidParameters,
 								   "APP schedules require a non-empty target_value");
@@ -167,11 +168,14 @@ namespace OpenWifi::RESTAPI::ParentalControl {
 			}
 		} else {
 			if (body->has("target_value")) {
+				out.has_target_value = true;
 				if (!body->isNull("target_value")) {
 					handler.BadRequest(RESTAPI::Errors::MissingOrInvalidParameters,
 									   "INTERNET schedules require target_value to be null");
 					return false;
 				}
+			} else {
+				out.has_target_value = false;
 			}
 			out.targetValue = "";
 		}
@@ -224,6 +228,7 @@ namespace OpenWifi::RESTAPI::ParentalControl {
 		}
 
 		if (body->has("description")) {
+			out.has_description = true;
 			if (body->isNull("description")) {
 				out.description = std::nullopt;
 			} else {
@@ -237,6 +242,7 @@ namespace OpenWifi::RESTAPI::ParentalControl {
 				out.description = std::move(desc);
 			}
 		} else {
+			out.has_description = false;
 			out.description = std::nullopt;
 		}
 
@@ -246,10 +252,12 @@ namespace OpenWifi::RESTAPI::ParentalControl {
 	Poco::JSON::Object BuildScheduleRequestBody(const ParsedScheduleRequest &req) {
 		Poco::JSON::Object body;
 		body.set("name", req.name);
-		if (req.description.has_value()) {
-			body.set("description", *req.description);
-		} else {
-			body.set("description", Poco::Dynamic::Var());
+		if (req.has_description) {
+			if (req.description.has_value()) {
+				body.set("description", *req.description);
+			} else {
+				body.set("description", Poco::Dynamic::Var());
+			}
 		}
 		body.set("enabled", req.enabled);
 		body.set("action_type", "BLOCK");
@@ -257,7 +265,9 @@ namespace OpenWifi::RESTAPI::ParentalControl {
 		if (req.targetKind == "APP") {
 			body.set("target_value", req.targetValue);
 		} else {
-			body.set("target_value", Poco::Dynamic::Var());
+			if (req.has_target_value) {
+				body.set("target_value", Poco::Dynamic::Var());
+			}
 		}
 		body.set("start_minute", req.startMinute);
 		body.set("stop_minute", req.stopMinute);

--- a/src/RESTAPI/RESTAPI_parental_control_utils.h
+++ b/src/RESTAPI/RESTAPI_parental_control_utils.h
@@ -71,6 +71,7 @@ namespace OpenWifi::RESTAPI::ParentalControl {
 		GatewaySerialNotFound,
 		InventoryNotFound,
 		VenueNotFound,
+		VenueLookupFailed,
 		BoardIdNotFound,
 		TopologyNotFound,
 		MacNotPresentInTopology,

--- a/src/RESTAPI/RESTAPI_parental_control_utils.h
+++ b/src/RESTAPI/RESTAPI_parental_control_utils.h
@@ -14,34 +14,9 @@
 
 namespace OpenWifi::RESTAPI::ParentalControl {
 
-	enum class ApplyConfigRawResult {
-		NoConfigApplyNeeded,
-		Applied,
-		MissingOperatorId,
-		ProvisioningLookupFailed,
-		MissingGatewaySerial,
-		GatewayConfigLoadFailed,
-		GatewayConfigMalformed,
-		GatewayConfigureFailed
-	};
-
-	bool NormalizeScheduleResponse(Poco::JSON::Object::Ptr schedule);
-
-	bool ParseTimeString(const Poco::Dynamic::Var &value, int &minuteOfDay);
-
-	bool ValidateWeekdays(const Poco::JSON::Array::Ptr &weekdays);
-
-	bool ExtractConfigRawSnapshot(const Poco::JSON::Object::Ptr &callResponse,
-								  Poco::JSON::Array::Ptr &configRaw,
-								  bool required = false);
-
-	ApplyConfigRawResult ApplyConfigRaw(RESTAPIHandler &handler, Poco::Logger &logger,
-										const std::string &subscriberId,
-										const std::string &operatorId, const std::string &objectId,
-										const Poco::JSON::Array::Ptr &configRaw,
-										const std::string &operationName,
-										const std::string &objectType,
-										const std::string &gatewaySerial = "");
+	// =========================================================================
+	// Schedule Helpers
+	// =========================================================================
 
 	struct ParsedScheduleRequest {
 		std::string name;
@@ -56,6 +31,12 @@ namespace OpenWifi::RESTAPI::ParentalControl {
 		Poco::JSON::Array::Ptr weekdays;
 	};
 
+	bool NormalizeScheduleResponse(Poco::JSON::Object::Ptr schedule);
+
+	bool ParseTimeString(const Poco::Dynamic::Var &value, int &minuteOfDay);
+
+	bool ValidateWeekdays(const Poco::JSON::Array::Ptr &weekdays);
+
 	bool ParseAndValidateScheduleRequest(RESTAPIHandler &handler,
 										  const Poco::JSON::Object::Ptr &body,
 										  bool enabledRequired,
@@ -63,7 +44,10 @@ namespace OpenWifi::RESTAPI::ParentalControl {
 
 	Poco::JSON::Object BuildScheduleRequestBody(const ParsedScheduleRequest &req);
 
-	bool HandleApplyConfigRawResult(RESTAPIHandler &handler, ApplyConfigRawResult result);
+
+	// =========================================================================
+	// Topology/Device Validation Helpers
+	// =========================================================================
 
 	enum class ValidateMacResult {
 		Success,
@@ -85,6 +69,41 @@ namespace OpenWifi::RESTAPI::ParentalControl {
 											const std::string &operatorId,
 											const std::string &clientMac,
 											std::string &gatewaySerial);
+
+
+	// =========================================================================
+	// Config-Raw Extraction/Apply Helpers
+	// =========================================================================
+
+	enum class ApplyConfigRawResult {
+		NoConfigApplyNeeded,
+		Applied,
+		MissingOperatorId,
+		ProvisioningLookupFailed,
+		MissingGatewaySerial,
+		GatewayConfigLoadFailed,
+		GatewayConfigMalformed,
+		GatewayConfigureFailed
+	};
+
+	bool ExtractConfigRawSnapshot(const Poco::JSON::Object::Ptr &callResponse,
+								  Poco::JSON::Array::Ptr &configRaw,
+								  bool required = false);
+
+	ApplyConfigRawResult ApplyConfigRaw(RESTAPIHandler &handler, Poco::Logger &logger,
+										const std::string &subscriberId,
+										const std::string &operatorId, const std::string &objectId,
+										const Poco::JSON::Array::Ptr &configRaw,
+										const std::string &operationName,
+										const std::string &objectType,
+										const std::string &gatewaySerial = "");
+
+
+	// =========================================================================
+	// HTTP/Result Mapping Helpers
+	// =========================================================================
+
+	bool HandleApplyConfigRawResult(RESTAPIHandler &handler, ApplyConfigRawResult result);
 
 	bool HandleValidateMacResult(RESTAPIHandler &handler, ValidateMacResult result);
 

--- a/src/RESTAPI/RESTAPI_parental_control_utils.h
+++ b/src/RESTAPI/RESTAPI_parental_control_utils.h
@@ -46,9 +46,11 @@ namespace OpenWifi::RESTAPI::ParentalControl {
 	struct ParsedScheduleRequest {
 		std::string name;
 		std::optional<std::string> description;
+		bool has_description = false;
 		bool enabled = true;
 		std::string targetKind;
 		std::string targetValue;
+		bool has_target_value = false;
 		int startMinute = 0;
 		int stopMinute = 0;
 		Poco::JSON::Array::Ptr weekdays;

--- a/src/RESTAPI/RESTAPI_parental_control_utils.h
+++ b/src/RESTAPI/RESTAPI_parental_control_utils.h
@@ -32,14 +32,16 @@ namespace OpenWifi::RESTAPI::ParentalControl {
 	bool ValidateWeekdays(const Poco::JSON::Array::Ptr &weekdays);
 
 	bool ExtractConfigRawSnapshot(const Poco::JSON::Object::Ptr &callResponse,
-								  Poco::JSON::Array::Ptr &configRaw);
+								  Poco::JSON::Array::Ptr &configRaw,
+								  bool required = false);
 
 	ApplyConfigRawResult ApplyConfigRaw(RESTAPIHandler &handler, Poco::Logger &logger,
 										const std::string &subscriberId,
 										const std::string &operatorId, const std::string &objectId,
 										const Poco::JSON::Array::Ptr &configRaw,
 										const std::string &operationName,
-										const std::string &objectType);
+										const std::string &objectType,
+										const std::string &gatewaySerial = "");
 
 	struct ParsedScheduleRequest {
 		std::string name;
@@ -60,5 +62,27 @@ namespace OpenWifi::RESTAPI::ParentalControl {
 	Poco::JSON::Object BuildScheduleRequestBody(const ParsedScheduleRequest &req);
 
 	bool HandleApplyConfigRawResult(RESTAPIHandler &handler, ApplyConfigRawResult result);
+
+	enum class ValidateMacResult {
+		Success,
+		MissingSubscriberOrOperator,
+		SubscriberDevicesNotFound,
+		ProvisioningLookupFailed,
+		GatewaySerialNotFound,
+		InventoryNotFound,
+		VenueNotFound,
+		BoardIdNotFound,
+		TopologyNotFound,
+		MacNotPresentInTopology,
+		TopologyUnusable
+	};
+
+	ValidateMacResult ValidateMacInTopology(RESTAPIHandler &handler,
+											const std::string &subscriberId,
+											const std::string &operatorId,
+											const std::string &clientMac,
+											std::string &gatewaySerial);
+
+	bool HandleValidateMacResult(RESTAPIHandler &handler, ValidateMacResult result);
 
 } // namespace OpenWifi::RESTAPI::ParentalControl

--- a/src/RESTAPI/RESTAPI_routers.cpp
+++ b/src/RESTAPI/RESTAPI_routers.cpp
@@ -21,6 +21,10 @@
 #include "RESTAPI/RESTAPI_groups_handler.h"
 #include "RESTAPI/RESTAPI_schedules_list_handler.h"
 #include "RESTAPI/RESTAPI_schedules_handler.h"
+#include "RESTAPI/RESTAPI_group_devices_list_handler.h"
+#include "RESTAPI/RESTAPI_group_devices_handler.h"
+#include "RESTAPI/RESTAPI_group_schedules_list_handler.h"
+#include "RESTAPI/RESTAPI_group_schedules_handler.h"
 
 #include "framework/RESTAPI_SystemCommand.h"
 #include "framework/RESTAPI_WebSocketServer.h"
@@ -37,7 +41,9 @@ namespace OpenWifi {
 							  RESTAPI_system_command, RESTAPI_system_configuration,
                               RESTAPI_stats_handler, RESTAPI_topology_handler,
 							  RESTAPI_webSocketServer, RESTAPI_groups_list_handler, RESTAPI_groups_handler,
-							  RESTAPI_schedules_list_handler, RESTAPI_schedules_handler>(Path, Bindings, L, S, TransactionId);
+							  RESTAPI_schedules_list_handler, RESTAPI_schedules_handler,
+							  RESTAPI_group_devices_list_handler, RESTAPI_group_devices_handler,
+							  RESTAPI_group_schedules_list_handler, RESTAPI_group_schedules_handler>(Path, Bindings, L, S, TransactionId);
 	}
 
 	Poco::Net::HTTPRequestHandler *
@@ -49,7 +55,9 @@ namespace OpenWifi {
 								RESTAPI_system_command, RESTAPI_system_configuration,
 								RESTAPI_topology_handler,
 								RESTAPI_stats_handler, RESTAPI_groups_list_handler, RESTAPI_groups_handler,
-								RESTAPI_schedules_list_handler, RESTAPI_schedules_handler>(Path, Bindings, L, S, TransactionId);
+								RESTAPI_schedules_list_handler, RESTAPI_schedules_handler,
+								RESTAPI_group_devices_list_handler, RESTAPI_group_devices_handler,
+								RESTAPI_group_schedules_list_handler, RESTAPI_group_schedules_handler>(Path, Bindings, L, S, TransactionId);
 	}
 
 } // namespace OpenWifi

--- a/src/framework/MicroServiceNames.h
+++ b/src/framework/MicroServiceNames.h
@@ -19,6 +19,6 @@ namespace OpenWifi {
 	static const std::string uSERVICE_ANALYTICS{"owanalytics"};
 	static const std::string uSERVICE_OWRRM{"owrrm"};
 	static const std::string uSERVICE_NETWORK_TOPOLOGY{"nwtopology"};
-	static const std::string uSERVICE_MANGO_PARENTAL_CONTROL{"parental-control"};
+	static const std::string uSERVICE_MANGO_PARENTAL_CONTROL{"mango-parental-control"};
 
 } // namespace OpenWifi

--- a/src/framework/ow_constants.h
+++ b/src/framework/ow_constants.h
@@ -453,6 +453,9 @@ namespace OpenWifi::RESTAPI::Errors {
         7001, "There is an instance of this simulation already running.."
     };
 
+	static const struct msg MacNotPresentInTopology { 1198, "MAC address is not present in subscriber topology." };
+	static const struct msg GatewayInventoryNotFound { 1199, "Gateway inventory record not found." };
+	static const struct msg VenueMissingBoardId { 1200, "Venue record does not contain a usable Board ID." };
 
 } // namespace OpenWifi::RESTAPI::Errors
 

--- a/src/sdks/SDK_parental_control.cpp
+++ b/src/sdks/SDK_parental_control.cpp
@@ -20,17 +20,63 @@ namespace OpenWifi::SDK::ParentalControl {
 								  const Poco::JSON::Array::Ptr &arrayResponse) {
 			return callStatus == Poco::Net::HTTPResponse::HTTP_OK && arrayResponse != nullptr;
 		}
+
+		bool ExecuteGetArray(RESTAPIHandler *client, const std::string &endpoint,
+							 Poco::Net::HTTPResponse::HTTPStatus &CallStatus,
+							 Poco::JSON::Array::Ptr &ArrayResponse,
+							 Poco::JSON::Object::Ptr &ObjectResponse) {
+			auto API = OpenAPIRequestGet(uSERVICE_MANGO_PARENTAL_CONTROL, endpoint, {}, 60000);
+			CallStatus = API.Do(ArrayResponse, ObjectResponse,
+								client ? client->UserInfo_.webtoken.access_token_ : "");
+			return IsParsedArraySuccess(CallStatus, ArrayResponse);
+		}
+
+		bool ExecuteGetObject(RESTAPIHandler *client, const std::string &endpoint,
+							  Poco::Net::HTTPResponse::HTTPStatus &CallStatus,
+							  Poco::JSON::Object::Ptr &CallResponse) {
+			auto API = OpenAPIRequestGet(uSERVICE_MANGO_PARENTAL_CONTROL, endpoint, {}, 60000);
+			CallStatus = API.Do(CallResponse, client ? client->UserInfo_.webtoken.access_token_ : "");
+			return IsParsedObjectSuccess(CallStatus, CallResponse);
+		}
+
+		bool ExecutePostObject(RESTAPIHandler *client, const std::string &endpoint,
+							   const Poco::JSON::Object &Body, uint64_t TimeoutMs,
+							   Poco::Net::HTTPResponse::HTTPStatus &CallStatus,
+							   Poco::JSON::Object::Ptr &CallResponse) {
+			auto API = OpenAPIRequestPost(uSERVICE_MANGO_PARENTAL_CONTROL, endpoint, {}, Body, TimeoutMs);
+			CallStatus = API.Do(CallResponse, client ? client->UserInfo_.webtoken.access_token_ : "");
+			return IsParsedObjectSuccess(CallStatus, CallResponse);
+		}
+
+		bool ExecutePutObject(RESTAPIHandler *client, const std::string &endpoint,
+							  const Poco::JSON::Object &Body, uint64_t TimeoutMs,
+							  Poco::Net::HTTPResponse::HTTPStatus &CallStatus,
+							  Poco::JSON::Object::Ptr &CallResponse) {
+			auto API = OpenAPIRequestPut(uSERVICE_MANGO_PARENTAL_CONTROL, endpoint, {}, Body, TimeoutMs);
+			CallStatus = API.Do(CallResponse, client ? client->UserInfo_.webtoken.access_token_ : "");
+			return IsParsedObjectSuccess(CallStatus, CallResponse);
+		}
+
+		bool ExecuteDelete(RESTAPIHandler *client, const std::string &endpoint, uint64_t TimeoutMs,
+						   Poco::Net::HTTPResponse::HTTPStatus &CallStatus,
+						   Poco::JSON::Object::Ptr &CallResponse, std::string &RawResponseBody) {
+			auto API = OpenAPIRequestDelete(uSERVICE_MANGO_PARENTAL_CONTROL, endpoint, {}, TimeoutMs);
+			CallStatus = API.Do(CallResponse, RawResponseBody,
+								client ? client->UserInfo_.webtoken.access_token_ : "");
+			return CallStatus == Poco::Net::HTTPResponse::HTTP_OK;
+		}
 	} // namespace
+
+	// =========================================================================
+	// Groups
+	// =========================================================================
 
 	bool GetGroups(RESTAPIHandler *client, const std::string &SubscriberId,
 	               Poco::Net::HTTPResponse::HTTPStatus &CallStatus,
 	               Poco::JSON::Array::Ptr &ArrayResponse,
 	               Poco::JSON::Object::Ptr &ObjectResponse) {
 		std::string endpoint = "/api/v1/subscribers/" + SubscriberId + "/groups";
-		auto API = OpenAPIRequestGet(uSERVICE_MANGO_PARENTAL_CONTROL, endpoint, {}, 60000);
-		CallStatus = API.Do(ArrayResponse, ObjectResponse,
-		                    client ? client->UserInfo_.webtoken.access_token_ : "");
-		return IsParsedArraySuccess(CallStatus, ArrayResponse);
+		return ExecuteGetArray(client, endpoint, CallStatus, ArrayResponse, ObjectResponse);
 	}
 
 	bool CreateGroup(RESTAPIHandler *client, const std::string &SubscriberId,
@@ -38,9 +84,7 @@ namespace OpenWifi::SDK::ParentalControl {
 	                 Poco::Net::HTTPResponse::HTTPStatus &CallStatus,
 	                 Poco::JSON::Object::Ptr &CallResponse) {
 		std::string endpoint = "/api/v1/subscribers/" + SubscriberId + "/groups";
-		auto API = OpenAPIRequestPost(uSERVICE_MANGO_PARENTAL_CONTROL, endpoint, {}, Body, 60000);
-		CallStatus = API.Do(CallResponse, client ? client->UserInfo_.webtoken.access_token_ : "");
-		return IsParsedObjectSuccess(CallStatus, CallResponse);
+		return ExecutePostObject(client, endpoint, Body, 60000, CallStatus, CallResponse);
 	}
 
 	bool GetGroup(RESTAPIHandler *client, const std::string &SubscriberId,
@@ -48,9 +92,7 @@ namespace OpenWifi::SDK::ParentalControl {
 	              Poco::Net::HTTPResponse::HTTPStatus &CallStatus,
 	              Poco::JSON::Object::Ptr &CallResponse) {
 		std::string endpoint = "/api/v1/subscribers/" + SubscriberId + "/groups/" + GroupId;
-		auto API = OpenAPIRequestGet(uSERVICE_MANGO_PARENTAL_CONTROL, endpoint, {}, 60000);
-		CallStatus = API.Do(CallResponse, client ? client->UserInfo_.webtoken.access_token_ : "");
-		return IsParsedObjectSuccess(CallStatus, CallResponse);
+		return ExecuteGetObject(client, endpoint, CallStatus, CallResponse);
 	}
 
 	bool UpdateGroup(RESTAPIHandler *client, const std::string &SubscriberId,
@@ -58,9 +100,7 @@ namespace OpenWifi::SDK::ParentalControl {
 	                 Poco::Net::HTTPResponse::HTTPStatus &CallStatus,
 	                 Poco::JSON::Object::Ptr &CallResponse) {
 		std::string endpoint = "/api/v1/subscribers/" + SubscriberId + "/groups/" + GroupId;
-		auto API = OpenAPIRequestPut(uSERVICE_MANGO_PARENTAL_CONTROL, endpoint, {}, Body, 60000);
-		CallStatus = API.Do(CallResponse, client ? client->UserInfo_.webtoken.access_token_ : "");
-		return IsParsedObjectSuccess(CallStatus, CallResponse);
+		return ExecutePutObject(client, endpoint, Body, 60000, CallStatus, CallResponse);
 	}
 
 	bool DeleteGroup(RESTAPIHandler *client, const std::string &SubscriberId,
@@ -69,10 +109,7 @@ namespace OpenWifi::SDK::ParentalControl {
 	                 Poco::JSON::Object::Ptr &CallResponse,
 	                 std::string &RawResponseBody) {
 		std::string endpoint = "/api/v1/subscribers/" + SubscriberId + "/groups/" + GroupId;
-		auto API = OpenAPIRequestDelete(uSERVICE_MANGO_PARENTAL_CONTROL, endpoint, {}, 60000);
-		CallStatus = API.Do(CallResponse, RawResponseBody,
-		                    client ? client->UserInfo_.webtoken.access_token_ : "");
-		if (CallStatus != Poco::Net::HTTPResponse::HTTP_OK) {
+		if (!ExecuteDelete(client, endpoint, 60000, CallStatus, CallResponse, RawResponseBody)) {
 			return false;
 		}
 		if (RawResponseBody.empty()) {
@@ -81,15 +118,16 @@ namespace OpenWifi::SDK::ParentalControl {
 		return CallResponse != nullptr;
 	}
 
+	// =========================================================================
+	// Schedules
+	// =========================================================================
+
 	bool GetSchedules(RESTAPIHandler *client, const std::string &SubscriberId,
 					  Poco::Net::HTTPResponse::HTTPStatus &CallStatus,
 					  Poco::JSON::Array::Ptr &ArrayResponse,
 					  Poco::JSON::Object::Ptr &ObjectResponse) {
 		std::string endpoint = "/api/v1/subscribers/" + SubscriberId + "/schedules";
-		auto API = OpenAPIRequestGet(uSERVICE_MANGO_PARENTAL_CONTROL, endpoint, {}, 60000);
-		CallStatus = API.Do(ArrayResponse, ObjectResponse,
-							client ? client->UserInfo_.webtoken.access_token_ : "");
-		return IsParsedArraySuccess(CallStatus, ArrayResponse);
+		return ExecuteGetArray(client, endpoint, CallStatus, ArrayResponse, ObjectResponse);
 	}
 
 	bool CreateSchedule(RESTAPIHandler *client, const std::string &SubscriberId,
@@ -97,18 +135,14 @@ namespace OpenWifi::SDK::ParentalControl {
 						Poco::Net::HTTPResponse::HTTPStatus &CallStatus,
 						Poco::JSON::Object::Ptr &CallResponse) {
 		std::string endpoint = "/api/v1/subscribers/" + SubscriberId + "/schedules";
-		auto API = OpenAPIRequestPost(uSERVICE_MANGO_PARENTAL_CONTROL, endpoint, {}, Body, 60000);
-		CallStatus = API.Do(CallResponse, client ? client->UserInfo_.webtoken.access_token_ : "");
-		return IsParsedObjectSuccess(CallStatus, CallResponse);
+		return ExecutePostObject(client, endpoint, Body, 60000, CallStatus, CallResponse);
 	}
 
 	bool GetSchedule(RESTAPIHandler *client, const std::string &SubscriberId,
 					 const std::string &ScheduleId, Poco::Net::HTTPResponse::HTTPStatus &CallStatus,
 					 Poco::JSON::Object::Ptr &CallResponse) {
 		std::string endpoint = "/api/v1/subscribers/" + SubscriberId + "/schedules/" + ScheduleId;
-		auto API = OpenAPIRequestGet(uSERVICE_MANGO_PARENTAL_CONTROL, endpoint, {}, 60000);
-		CallStatus = API.Do(CallResponse, client ? client->UserInfo_.webtoken.access_token_ : "");
-		return IsParsedObjectSuccess(CallStatus, CallResponse);
+		return ExecuteGetObject(client, endpoint, CallStatus, CallResponse);
 	}
 
 	bool UpdateSchedule(RESTAPIHandler *client, const std::string &SubscriberId,
@@ -116,9 +150,7 @@ namespace OpenWifi::SDK::ParentalControl {
 						Poco::Net::HTTPResponse::HTTPStatus &CallStatus,
 						Poco::JSON::Object::Ptr &CallResponse) {
 		std::string endpoint = "/api/v1/subscribers/" + SubscriberId + "/schedules/" + ScheduleId;
-		auto API = OpenAPIRequestPut(uSERVICE_MANGO_PARENTAL_CONTROL, endpoint, {}, Body, 120000);
-		CallStatus = API.Do(CallResponse, client ? client->UserInfo_.webtoken.access_token_ : "");
-		return IsParsedObjectSuccess(CallStatus, CallResponse);
+		return ExecutePutObject(client, endpoint, Body, 120000, CallStatus, CallResponse);
 	}
 
 	bool DeleteSchedule(RESTAPIHandler *client, const std::string &SubscriberId,
@@ -126,10 +158,7 @@ namespace OpenWifi::SDK::ParentalControl {
 						Poco::Net::HTTPResponse::HTTPStatus &CallStatus,
 						Poco::JSON::Object::Ptr &CallResponse, std::string &RawResponseBody) {
 		std::string endpoint = "/api/v1/subscribers/" + SubscriberId + "/schedules/" + ScheduleId;
-		auto API = OpenAPIRequestDelete(uSERVICE_MANGO_PARENTAL_CONTROL, endpoint, {}, 120000);
-		CallStatus = API.Do(CallResponse, RawResponseBody,
-							client ? client->UserInfo_.webtoken.access_token_ : "");
-		if (CallStatus != Poco::Net::HTTPResponse::HTTP_OK) {
+		if (!ExecuteDelete(client, endpoint, 120000, CallStatus, CallResponse, RawResponseBody)) {
 			return false;
 		}
 		if (RawResponseBody.empty()) {
@@ -138,17 +167,17 @@ namespace OpenWifi::SDK::ParentalControl {
 		return CallResponse != nullptr;
 	}
 
+	// =========================================================================
 	// Group Devices
+	// =========================================================================
+
 	bool GetGroupDevices(RESTAPIHandler *client, const std::string &SubscriberId,
 						 const std::string &GroupId,
 						 Poco::Net::HTTPResponse::HTTPStatus &CallStatus,
 						 Poco::JSON::Array::Ptr &ArrayResponse,
 						 Poco::JSON::Object::Ptr &ObjectResponse) {
 		std::string endpoint = "/api/v1/subscribers/" + SubscriberId + "/groups/" + GroupId + "/devices";
-		auto API = OpenAPIRequestGet(uSERVICE_MANGO_PARENTAL_CONTROL, endpoint, {}, 60000);
-		CallStatus = API.Do(ArrayResponse, ObjectResponse,
-							client ? client->UserInfo_.webtoken.access_token_ : "");
-		return IsParsedArraySuccess(CallStatus, ArrayResponse);
+		return ExecuteGetArray(client, endpoint, CallStatus, ArrayResponse, ObjectResponse);
 	}
 
 	bool CreateGroupDevice(RESTAPIHandler *client, const std::string &SubscriberId,
@@ -156,9 +185,7 @@ namespace OpenWifi::SDK::ParentalControl {
 						   Poco::Net::HTTPResponse::HTTPStatus &CallStatus,
 						   Poco::JSON::Object::Ptr &CallResponse) {
 		std::string endpoint = "/api/v1/subscribers/" + SubscriberId + "/groups/" + GroupId + "/devices";
-		auto API = OpenAPIRequestPost(uSERVICE_MANGO_PARENTAL_CONTROL, endpoint, {}, Body, 120000);
-		CallStatus = API.Do(CallResponse, client ? client->UserInfo_.webtoken.access_token_ : "");
-		return IsParsedObjectSuccess(CallStatus, CallResponse);
+		return ExecutePostObject(client, endpoint, Body, 120000, CallStatus, CallResponse);
 	}
 
 	bool GetGroupDevice(RESTAPIHandler *client, const std::string &SubscriberId,
@@ -166,9 +193,7 @@ namespace OpenWifi::SDK::ParentalControl {
 						Poco::Net::HTTPResponse::HTTPStatus &CallStatus,
 						Poco::JSON::Object::Ptr &CallResponse) {
 		std::string endpoint = "/api/v1/subscribers/" + SubscriberId + "/groups/" + GroupId + "/devices/" + ClientMac;
-		auto API = OpenAPIRequestGet(uSERVICE_MANGO_PARENTAL_CONTROL, endpoint, {}, 60000);
-		CallStatus = API.Do(CallResponse, client ? client->UserInfo_.webtoken.access_token_ : "");
-		return IsParsedObjectSuccess(CallStatus, CallResponse);
+		return ExecuteGetObject(client, endpoint, CallStatus, CallResponse);
 	}
 
 	bool DeleteGroupDevice(RESTAPIHandler *client, const std::string &SubscriberId,
@@ -176,10 +201,7 @@ namespace OpenWifi::SDK::ParentalControl {
 						   Poco::Net::HTTPResponse::HTTPStatus &CallStatus,
 						   Poco::JSON::Object::Ptr &CallResponse, std::string &RawResponseBody) {
 		std::string endpoint = "/api/v1/subscribers/" + SubscriberId + "/groups/" + GroupId + "/devices/" + ClientMac;
-		auto API = OpenAPIRequestDelete(uSERVICE_MANGO_PARENTAL_CONTROL, endpoint, {}, 120000);
-		CallStatus = API.Do(CallResponse, RawResponseBody,
-							client ? client->UserInfo_.webtoken.access_token_ : "");
-		if (CallStatus != Poco::Net::HTTPResponse::HTTP_OK) {
+		if (!ExecuteDelete(client, endpoint, 120000, CallStatus, CallResponse, RawResponseBody)) {
 			return false;
 		}
 		if (RawResponseBody.empty() || !CallResponse || !CallResponse->has("config-raw")) {
@@ -188,17 +210,17 @@ namespace OpenWifi::SDK::ParentalControl {
 		return true;
 	}
 
+	// =========================================================================
 	// Group Schedules
+	// =========================================================================
+
 	bool GetGroupSchedules(RESTAPIHandler *client, const std::string &SubscriberId,
 						   const std::string &GroupId,
 						   Poco::Net::HTTPResponse::HTTPStatus &CallStatus,
 						   Poco::JSON::Array::Ptr &ArrayResponse,
 						   Poco::JSON::Object::Ptr &ObjectResponse) {
 		std::string endpoint = "/api/v1/subscribers/" + SubscriberId + "/groups/" + GroupId + "/schedules";
-		auto API = OpenAPIRequestGet(uSERVICE_MANGO_PARENTAL_CONTROL, endpoint, {}, 60000);
-		CallStatus = API.Do(ArrayResponse, ObjectResponse,
-							client ? client->UserInfo_.webtoken.access_token_ : "");
-		return IsParsedArraySuccess(CallStatus, ArrayResponse);
+		return ExecuteGetArray(client, endpoint, CallStatus, ArrayResponse, ObjectResponse);
 	}
 
 	bool CreateGroupSchedule(RESTAPIHandler *client, const std::string &SubscriberId,
@@ -206,9 +228,7 @@ namespace OpenWifi::SDK::ParentalControl {
 							 Poco::Net::HTTPResponse::HTTPStatus &CallStatus,
 							 Poco::JSON::Object::Ptr &CallResponse) {
 		std::string endpoint = "/api/v1/subscribers/" + SubscriberId + "/groups/" + GroupId + "/schedules";
-		auto API = OpenAPIRequestPost(uSERVICE_MANGO_PARENTAL_CONTROL, endpoint, {}, Body, 120000);
-		CallStatus = API.Do(CallResponse, client ? client->UserInfo_.webtoken.access_token_ : "");
-		return IsParsedObjectSuccess(CallStatus, CallResponse);
+		return ExecutePostObject(client, endpoint, Body, 120000, CallStatus, CallResponse);
 	}
 
 	bool GetGroupSchedule(RESTAPIHandler *client, const std::string &SubscriberId,
@@ -216,9 +236,7 @@ namespace OpenWifi::SDK::ParentalControl {
 						  Poco::Net::HTTPResponse::HTTPStatus &CallStatus,
 						  Poco::JSON::Object::Ptr &CallResponse) {
 		std::string endpoint = "/api/v1/subscribers/" + SubscriberId + "/groups/" + GroupId + "/schedules/" + ScheduleId;
-		auto API = OpenAPIRequestGet(uSERVICE_MANGO_PARENTAL_CONTROL, endpoint, {}, 60000);
-		CallStatus = API.Do(CallResponse, client ? client->UserInfo_.webtoken.access_token_ : "");
-		return IsParsedObjectSuccess(CallStatus, CallResponse);
+		return ExecuteGetObject(client, endpoint, CallStatus, CallResponse);
 	}
 
 	bool DeleteGroupSchedule(RESTAPIHandler *client, const std::string &SubscriberId,
@@ -226,10 +244,7 @@ namespace OpenWifi::SDK::ParentalControl {
 							 Poco::Net::HTTPResponse::HTTPStatus &CallStatus,
 							 Poco::JSON::Object::Ptr &CallResponse, std::string &RawResponseBody) {
 		std::string endpoint = "/api/v1/subscribers/" + SubscriberId + "/groups/" + GroupId + "/schedules/" + ScheduleId;
-		auto API = OpenAPIRequestDelete(uSERVICE_MANGO_PARENTAL_CONTROL, endpoint, {}, 120000);
-		CallStatus = API.Do(CallResponse, RawResponseBody,
-							client ? client->UserInfo_.webtoken.access_token_ : "");
-		if (CallStatus != Poco::Net::HTTPResponse::HTTP_OK) {
+		if (!ExecuteDelete(client, endpoint, 120000, CallStatus, CallResponse, RawResponseBody)) {
 			return false;
 		}
 		if (RawResponseBody.empty() || !CallResponse || !CallResponse->has("config-raw")) {
@@ -243,9 +258,7 @@ namespace OpenWifi::SDK::ParentalControl {
 							   Poco::Net::HTTPResponse::HTTPStatus &CallStatus,
 							   Poco::JSON::Object::Ptr &CallResponse) {
 		std::string endpoint = "/api/v1/subscribers/" + SubscriberId + "/groups/" + GroupId + "/schedules";
-		auto API = OpenAPIRequestPut(uSERVICE_MANGO_PARENTAL_CONTROL, endpoint, {}, Body, 120000);
-		CallStatus = API.Do(CallResponse, client ? client->UserInfo_.webtoken.access_token_ : "");
-		return IsParsedObjectSuccess(CallStatus, CallResponse);
+		return ExecutePutObject(client, endpoint, Body, 120000, CallStatus, CallResponse);
 	}
 
 } // namespace OpenWifi::SDK::ParentalControl

--- a/src/sdks/SDK_parental_control.cpp
+++ b/src/sdks/SDK_parental_control.cpp
@@ -138,4 +138,114 @@ namespace OpenWifi::SDK::ParentalControl {
 		return CallResponse != nullptr;
 	}
 
+	// Group Devices
+	bool GetGroupDevices(RESTAPIHandler *client, const std::string &SubscriberId,
+						 const std::string &GroupId,
+						 Poco::Net::HTTPResponse::HTTPStatus &CallStatus,
+						 Poco::JSON::Array::Ptr &ArrayResponse,
+						 Poco::JSON::Object::Ptr &ObjectResponse) {
+		std::string endpoint = "/api/v1/subscribers/" + SubscriberId + "/groups/" + GroupId + "/devices";
+		auto API = OpenAPIRequestGet(uSERVICE_MANGO_PARENTAL_CONTROL, endpoint, {}, 60000);
+		CallStatus = API.Do(ArrayResponse, ObjectResponse,
+							client ? client->UserInfo_.webtoken.access_token_ : "");
+		return IsParsedArraySuccess(CallStatus, ArrayResponse);
+	}
+
+	bool CreateGroupDevice(RESTAPIHandler *client, const std::string &SubscriberId,
+						   const std::string &GroupId, const Poco::JSON::Object &Body,
+						   Poco::Net::HTTPResponse::HTTPStatus &CallStatus,
+						   Poco::JSON::Object::Ptr &CallResponse) {
+		std::string endpoint = "/api/v1/subscribers/" + SubscriberId + "/groups/" + GroupId + "/devices";
+		auto API = OpenAPIRequestPost(uSERVICE_MANGO_PARENTAL_CONTROL, endpoint, {}, Body, 120000);
+		CallStatus = API.Do(CallResponse, client ? client->UserInfo_.webtoken.access_token_ : "");
+		return IsParsedObjectSuccess(CallStatus, CallResponse);
+	}
+
+	bool GetGroupDevice(RESTAPIHandler *client, const std::string &SubscriberId,
+						const std::string &GroupId, const std::string &ClientMac,
+						Poco::Net::HTTPResponse::HTTPStatus &CallStatus,
+						Poco::JSON::Object::Ptr &CallResponse) {
+		std::string endpoint = "/api/v1/subscribers/" + SubscriberId + "/groups/" + GroupId + "/devices/" + ClientMac;
+		auto API = OpenAPIRequestGet(uSERVICE_MANGO_PARENTAL_CONTROL, endpoint, {}, 60000);
+		CallStatus = API.Do(CallResponse, client ? client->UserInfo_.webtoken.access_token_ : "");
+		return IsParsedObjectSuccess(CallStatus, CallResponse);
+	}
+
+	bool DeleteGroupDevice(RESTAPIHandler *client, const std::string &SubscriberId,
+						   const std::string &GroupId, const std::string &ClientMac,
+						   Poco::Net::HTTPResponse::HTTPStatus &CallStatus,
+						   Poco::JSON::Object::Ptr &CallResponse, std::string &RawResponseBody) {
+		std::string endpoint = "/api/v1/subscribers/" + SubscriberId + "/groups/" + GroupId + "/devices/" + ClientMac;
+		auto API = OpenAPIRequestDelete(uSERVICE_MANGO_PARENTAL_CONTROL, endpoint, {}, 120000);
+		CallStatus = API.Do(CallResponse, RawResponseBody,
+							client ? client->UserInfo_.webtoken.access_token_ : "");
+		if (CallStatus != Poco::Net::HTTPResponse::HTTP_OK) {
+			return false;
+		}
+		if (RawResponseBody.empty() || !CallResponse || !CallResponse->has("config-raw")) {
+			return false;
+		}
+		return true;
+	}
+
+	// Group Schedules
+	bool GetGroupSchedules(RESTAPIHandler *client, const std::string &SubscriberId,
+						   const std::string &GroupId,
+						   Poco::Net::HTTPResponse::HTTPStatus &CallStatus,
+						   Poco::JSON::Array::Ptr &ArrayResponse,
+						   Poco::JSON::Object::Ptr &ObjectResponse) {
+		std::string endpoint = "/api/v1/subscribers/" + SubscriberId + "/groups/" + GroupId + "/schedules";
+		auto API = OpenAPIRequestGet(uSERVICE_MANGO_PARENTAL_CONTROL, endpoint, {}, 60000);
+		CallStatus = API.Do(ArrayResponse, ObjectResponse,
+							client ? client->UserInfo_.webtoken.access_token_ : "");
+		return IsParsedArraySuccess(CallStatus, ArrayResponse);
+	}
+
+	bool CreateGroupSchedule(RESTAPIHandler *client, const std::string &SubscriberId,
+							 const std::string &GroupId, const Poco::JSON::Object &Body,
+							 Poco::Net::HTTPResponse::HTTPStatus &CallStatus,
+							 Poco::JSON::Object::Ptr &CallResponse) {
+		std::string endpoint = "/api/v1/subscribers/" + SubscriberId + "/groups/" + GroupId + "/schedules";
+		auto API = OpenAPIRequestPost(uSERVICE_MANGO_PARENTAL_CONTROL, endpoint, {}, Body, 120000);
+		CallStatus = API.Do(CallResponse, client ? client->UserInfo_.webtoken.access_token_ : "");
+		return IsParsedObjectSuccess(CallStatus, CallResponse);
+	}
+
+	bool GetGroupSchedule(RESTAPIHandler *client, const std::string &SubscriberId,
+						  const std::string &GroupId, const std::string &ScheduleId,
+						  Poco::Net::HTTPResponse::HTTPStatus &CallStatus,
+						  Poco::JSON::Object::Ptr &CallResponse) {
+		std::string endpoint = "/api/v1/subscribers/" + SubscriberId + "/groups/" + GroupId + "/schedules/" + ScheduleId;
+		auto API = OpenAPIRequestGet(uSERVICE_MANGO_PARENTAL_CONTROL, endpoint, {}, 60000);
+		CallStatus = API.Do(CallResponse, client ? client->UserInfo_.webtoken.access_token_ : "");
+		return IsParsedObjectSuccess(CallStatus, CallResponse);
+	}
+
+	bool DeleteGroupSchedule(RESTAPIHandler *client, const std::string &SubscriberId,
+							 const std::string &GroupId, const std::string &ScheduleId,
+							 Poco::Net::HTTPResponse::HTTPStatus &CallStatus,
+							 Poco::JSON::Object::Ptr &CallResponse, std::string &RawResponseBody) {
+		std::string endpoint = "/api/v1/subscribers/" + SubscriberId + "/groups/" + GroupId + "/schedules/" + ScheduleId;
+		auto API = OpenAPIRequestDelete(uSERVICE_MANGO_PARENTAL_CONTROL, endpoint, {}, 120000);
+		CallStatus = API.Do(CallResponse, RawResponseBody,
+							client ? client->UserInfo_.webtoken.access_token_ : "");
+		if (CallStatus != Poco::Net::HTTPResponse::HTTP_OK) {
+			return false;
+		}
+		if (RawResponseBody.empty() || !CallResponse || !CallResponse->has("config-raw")) {
+			return false;
+		}
+		return true;
+	}
+
+	bool ReplaceGroupSchedules(RESTAPIHandler *client, const std::string &SubscriberId,
+							   const std::string &GroupId, const Poco::JSON::Object &Body,
+							   Poco::Net::HTTPResponse::HTTPStatus &CallStatus,
+							   Poco::JSON::Object::Ptr &CallResponse) {
+		std::string endpoint = "/api/v1/subscribers/" + SubscriberId + "/groups/" + GroupId + "/schedules";
+		auto API = OpenAPIRequestPut(uSERVICE_MANGO_PARENTAL_CONTROL, endpoint, {}, Body, 120000);
+		CallStatus = API.Do(CallResponse, client ? client->UserInfo_.webtoken.access_token_ : "");
+		return IsParsedObjectSuccess(CallStatus, CallResponse);
+	}
+
 } // namespace OpenWifi::SDK::ParentalControl

--- a/src/sdks/SDK_parental_control.h
+++ b/src/sdks/SDK_parental_control.h
@@ -66,4 +66,53 @@ namespace OpenWifi::SDK::ParentalControl {
 						Poco::Net::HTTPResponse::HTTPStatus &CallStatus,
 						Poco::JSON::Object::Ptr &CallResponse, std::string &RawResponseBody);
 
+	// Group Devices
+	bool GetGroupDevices(RESTAPIHandler *client, const std::string &SubscriberId,
+						 const std::string &GroupId,
+						 Poco::Net::HTTPResponse::HTTPStatus &CallStatus,
+						 Poco::JSON::Array::Ptr &ArrayResponse,
+						 Poco::JSON::Object::Ptr &ObjectResponse);
+
+	bool CreateGroupDevice(RESTAPIHandler *client, const std::string &SubscriberId,
+						   const std::string &GroupId, const Poco::JSON::Object &Body,
+						   Poco::Net::HTTPResponse::HTTPStatus &CallStatus,
+						   Poco::JSON::Object::Ptr &CallResponse);
+
+	bool GetGroupDevice(RESTAPIHandler *client, const std::string &SubscriberId,
+						const std::string &GroupId, const std::string &ClientMac,
+						Poco::Net::HTTPResponse::HTTPStatus &CallStatus,
+						Poco::JSON::Object::Ptr &CallResponse);
+
+	bool DeleteGroupDevice(RESTAPIHandler *client, const std::string &SubscriberId,
+						   const std::string &GroupId, const std::string &ClientMac,
+						   Poco::Net::HTTPResponse::HTTPStatus &CallStatus,
+						   Poco::JSON::Object::Ptr &CallResponse, std::string &RawResponseBody);
+
+	// Group Schedules
+	bool GetGroupSchedules(RESTAPIHandler *client, const std::string &SubscriberId,
+						   const std::string &GroupId,
+						   Poco::Net::HTTPResponse::HTTPStatus &CallStatus,
+						   Poco::JSON::Array::Ptr &ArrayResponse,
+						   Poco::JSON::Object::Ptr &ObjectResponse);
+
+	bool CreateGroupSchedule(RESTAPIHandler *client, const std::string &SubscriberId,
+							 const std::string &GroupId, const Poco::JSON::Object &Body,
+							 Poco::Net::HTTPResponse::HTTPStatus &CallStatus,
+							 Poco::JSON::Object::Ptr &CallResponse);
+
+	bool GetGroupSchedule(RESTAPIHandler *client, const std::string &SubscriberId,
+						  const std::string &GroupId, const std::string &ScheduleId,
+						  Poco::Net::HTTPResponse::HTTPStatus &CallStatus,
+						  Poco::JSON::Object::Ptr &CallResponse);
+
+	bool DeleteGroupSchedule(RESTAPIHandler *client, const std::string &SubscriberId,
+							 const std::string &GroupId, const std::string &ScheduleId,
+							 Poco::Net::HTTPResponse::HTTPStatus &CallStatus,
+							 Poco::JSON::Object::Ptr &CallResponse, std::string &RawResponseBody);
+
+	bool ReplaceGroupSchedules(RESTAPIHandler *client, const std::string &SubscriberId,
+							   const std::string &GroupId, const Poco::JSON::Object &Body,
+							   Poco::Net::HTTPResponse::HTTPStatus &CallStatus,
+							   Poco::JSON::Object::Ptr &CallResponse);
+
 } // namespace OpenWifi::SDK::ParentalControl

--- a/src/sdks/SDK_parental_control.h
+++ b/src/sdks/SDK_parental_control.h
@@ -13,6 +13,10 @@
 
 namespace OpenWifi::SDK::ParentalControl {
 
+	// =========================================================================
+	// Groups
+	// =========================================================================
+
 	// Success body is a JSON array of Group objects.
 	// On HTTP 200: ArrayResponse is populated.
 	// On non-200: ObjectResponse is populated (for ForwardErrorResponse passthrough).
@@ -42,6 +46,10 @@ namespace OpenWifi::SDK::ParentalControl {
 	                 Poco::JSON::Object::Ptr &CallResponse,
 	                 std::string &RawResponseBody);
 
+	// =========================================================================
+	// Schedules
+	// =========================================================================
+
 	bool GetSchedules(RESTAPIHandler *client, const std::string &SubscriberId,
 					  Poco::Net::HTTPResponse::HTTPStatus &CallStatus,
 					  Poco::JSON::Array::Ptr &ArrayResponse,
@@ -66,7 +74,10 @@ namespace OpenWifi::SDK::ParentalControl {
 						Poco::Net::HTTPResponse::HTTPStatus &CallStatus,
 						Poco::JSON::Object::Ptr &CallResponse, std::string &RawResponseBody);
 
+	// =========================================================================
 	// Group Devices
+	// =========================================================================
+
 	bool GetGroupDevices(RESTAPIHandler *client, const std::string &SubscriberId,
 						 const std::string &GroupId,
 						 Poco::Net::HTTPResponse::HTTPStatus &CallStatus,
@@ -88,7 +99,10 @@ namespace OpenWifi::SDK::ParentalControl {
 						   Poco::Net::HTTPResponse::HTTPStatus &CallStatus,
 						   Poco::JSON::Object::Ptr &CallResponse, std::string &RawResponseBody);
 
+	// =========================================================================
 	// Group Schedules
+	// =========================================================================
+
 	bool GetGroupSchedules(RESTAPIHandler *client, const std::string &SubscriberId,
 						   const std::string &GroupId,
 						   Poco::Net::HTTPResponse::HTTPStatus &CallStatus,

--- a/test_scripts/fakes/fake_downstream_services.py
+++ b/test_scripts/fakes/fake_downstream_services.py
@@ -42,6 +42,20 @@ def init_db():
             weekdays INTEGER[]
         )
     """)
+    cursor.execute("""
+        CREATE TABLE IF NOT EXISTS mock_group_devices (
+            group_id UUID,
+            client_mac TEXT,
+            PRIMARY KEY (group_id, client_mac)
+        )
+    """)
+    cursor.execute("""
+        CREATE TABLE IF NOT EXISTS mock_group_schedules (
+            group_id UUID,
+            schedule_id UUID,
+            PRIMARY KEY (group_id, schedule_id)
+        )
+    """)
     return conn
 
 # Let this throw an exception and crash the server if Postgres is not available
@@ -56,6 +70,99 @@ class FakeHandler(http.server.BaseHTTPRequestHandler):
         self.record_call()
         global current_scenario
         
+        if "/api/v1/inventory/" in self.path:
+            mac = self.path.split("/")[-1]
+            self.send_response(200)
+            self.end_headers()
+            self.wfile.write(json.dumps({"serialNumber": mac, "venue": "venue-id-123", "subscriber": "sub1"}).encode())
+            return
+
+        if "/api/v1/venue/" in self.path:
+            self.send_response(200)
+            self.end_headers()
+            self.wfile.write(json.dumps({"boards": ["board-id-123"]}).encode())
+            return
+
+        if "/api/v1/topology" in self.path:
+            self.send_response(200)
+            self.end_headers()
+            self.wfile.write(json.dumps({"historicalClients": [{"station": "aa:bb:cc:dd:ee:ff"}]}).encode())
+            return
+
+        if "/api/v1/subscribers/" in self.path and "/groups/" in self.path and "/devices" in self.path:
+            if current_scenario == "pc-404":
+                self.send_response(404)
+                self.end_headers()
+                self.wfile.write(json.dumps({"error":"not_found","message":"not found"}).encode())
+                return
+            parts = self.path.split("/")
+            group_id = parts[6]
+            cursor = db_conn.cursor()
+            cursor.execute("SELECT id FROM mock_groups WHERE id = %s", (group_id,))
+            if not cursor.fetchone():
+                self.send_response(404)
+                self.end_headers()
+                self.wfile.write(json.dumps({"error":"not_found","message":"group not found"}).encode())
+                return
+
+            if len(parts) > 8:
+                mac = parts[8]
+                cursor.execute("SELECT client_mac FROM mock_group_devices WHERE group_id = %s AND client_mac = %s", (group_id, mac))
+                row = cursor.fetchone()
+                if row:
+                    self.send_response(200)
+                    self.end_headers()
+                    self.wfile.write(json.dumps({"client_mac": row[0]}).encode())
+                else:
+                    self.send_response(404)
+                    self.end_headers()
+                    self.wfile.write(json.dumps({"error":"not_found","message":"device not linked to group"}).encode())
+            else:
+                cursor.execute("SELECT client_mac FROM mock_group_devices WHERE group_id = %s", (group_id,))
+                rows = cursor.fetchall()
+                devices = [{"client_mac": r[0]} for r in rows]
+                self.send_response(200)
+                self.end_headers()
+                self.wfile.write(json.dumps(devices).encode())
+            return
+
+        if "/api/v1/subscribers/" in self.path and "/groups/" in self.path and "/schedules" in self.path:
+            if current_scenario == "pc-404":
+                self.send_response(404)
+                self.end_headers()
+                self.wfile.write(json.dumps({"error":"not_found","message":"not found"}).encode())
+                return
+            parts = self.path.split("/")
+            group_id = parts[6]
+            cursor = db_conn.cursor()
+            cursor.execute("SELECT id FROM mock_groups WHERE id = %s", (group_id,))
+            if not cursor.fetchone():
+                self.send_response(404)
+                self.end_headers()
+                self.wfile.write(json.dumps({"error":"not_found","message":"group not found"}).encode())
+                return
+
+            if len(parts) > 8:
+                sid = parts[8]
+                cursor.execute("SELECT schedule_id FROM mock_group_schedules WHERE group_id = %s AND schedule_id = %s", (group_id, sid))
+                row = cursor.fetchone()
+                if row:
+                    self.send_response(200)
+                    self.end_headers()
+                    self.wfile.write(json.dumps({"id": str(row[0])}).encode())
+                else:
+                    self.send_response(404)
+                    self.end_headers()
+                    self.wfile.write(json.dumps({"error":"not_found","message":"schedule not linked to group"}).encode())
+            else:
+                cursor.execute("SELECT schedule_id FROM mock_group_schedules WHERE group_id = %s", (group_id,))
+                rows = cursor.fetchall()
+                schedules = [{"id": str(r[0])} for r in rows]
+                self.send_response(200)
+                self.end_headers()
+                self.wfile.write(json.dumps(schedules).encode())
+            return
+
         # Fake OWSEC Auth
         if "validateSubToken" in self.path or "validateToken" in self.path:
             parsed = urlparse(self.path)
@@ -315,6 +422,8 @@ class FakeHandler(http.server.BaseHTTPRequestHandler):
             cursor = db_conn.cursor()
             cursor.execute("TRUNCATE TABLE mock_groups")
             cursor.execute("TRUNCATE TABLE mock_schedules")
+            cursor.execute("TRUNCATE TABLE mock_group_devices")
+            cursor.execute("TRUNCATE TABLE mock_group_schedules")
             self.send_response(200)
             self.end_headers()
             return
@@ -345,6 +454,101 @@ class FakeHandler(http.server.BaseHTTPRequestHandler):
             self.send_response(200)
             self.end_headers()
             self.wfile.write(json.dumps({"status": "Success"}).encode())
+            return
+
+        if "/api/v1/subscribers/" in self.path and "/groups/" in self.path and "/devices" in self.path:
+            if current_scenario == "pc-404":
+                self.send_response(404)
+                self.end_headers()
+                self.wfile.write(json.dumps({"error":"not_found","message":"not found"}).encode())
+                return
+            elif current_scenario == "pc-409":
+                self.send_response(409)
+                self.end_headers()
+                self.wfile.write(json.dumps({"error":"conflict","message":"conflict"}).encode())
+                return
+            
+            parts = self.path.split("/")
+            group_id = parts[6]
+            req_data = json.loads(body.decode())
+            mac = req_data.get("client_mac")
+            
+            cursor = db_conn.cursor()
+            cursor.execute("SELECT id FROM mock_groups WHERE id = %s", (group_id,))
+            if not cursor.fetchone():
+                self.send_response(404)
+                self.end_headers()
+                self.wfile.write(json.dumps({"error":"not_found","message":"group not found"}).encode())
+                return
+                
+            cursor.execute("SELECT client_mac FROM mock_group_devices WHERE group_id = %s AND client_mac = %s", (group_id, mac))
+            if cursor.fetchone():
+                self.send_response(409)
+                self.end_headers()
+                self.wfile.write(json.dumps({"error":"conflict","message":"device already linked to group"}).encode())
+                return
+
+            cursor.execute("INSERT INTO mock_group_devices (group_id, client_mac) VALUES (%s, %s)", (group_id, mac))
+            
+            resp_obj = {"client_mac": mac}
+            if current_scenario.startswith("config-raw") or current_scenario.startswith("delete-config-raw"):
+                resp_obj["config-raw"] = [
+                    ["set", "parental_control.ci_rule.enabled", "1"]
+                ]
+            self.send_response(200)
+            self.end_headers()
+            self.wfile.write(json.dumps(resp_obj).encode())
+            return
+
+        if "/api/v1/subscribers/" in self.path and "/groups/" in self.path and "/schedules" in self.path:
+            if current_scenario == "pc-404":
+                self.send_response(404)
+                self.end_headers()
+                self.wfile.write(json.dumps({"error":"not_found","message":"not found"}).encode())
+                return
+            elif current_scenario == "pc-409":
+                self.send_response(409)
+                self.end_headers()
+                self.wfile.write(json.dumps({"error":"conflict","message":"conflict"}).encode())
+                return
+            
+            parts = self.path.split("/")
+            group_id = parts[6]
+            req_data = json.loads(body.decode())
+            sid = req_data.get("schedule_id")
+            
+            cursor = db_conn.cursor()
+            cursor.execute("SELECT id FROM mock_groups WHERE id = %s", (group_id,))
+            if not cursor.fetchone():
+                self.send_response(404)
+                self.end_headers()
+                self.wfile.write(json.dumps({"error":"not_found","message":"group not found"}).encode())
+                return
+                
+            cursor.execute("SELECT id FROM mock_schedules WHERE id = %s", (sid,))
+            if not cursor.fetchone():
+                self.send_response(404)
+                self.end_headers()
+                self.wfile.write(json.dumps({"error":"not_found","message":"schedule not found"}).encode())
+                return
+                
+            cursor.execute("SELECT schedule_id FROM mock_group_schedules WHERE group_id = %s AND schedule_id = %s", (group_id, sid))
+            if cursor.fetchone():
+                self.send_response(409)
+                self.end_headers()
+                self.wfile.write(json.dumps({"error":"conflict","message":"schedule already linked to group"}).encode())
+                return
+
+            cursor.execute("INSERT INTO mock_group_schedules (group_id, schedule_id) VALUES (%s, %s)", (group_id, sid))
+            
+            resp_obj = {"schedule_id": sid}
+            if current_scenario.startswith("config-raw") or current_scenario.startswith("delete-config-raw"):
+                resp_obj["config-raw"] = [
+                    ["set", "parental_control.ci_rule.enabled", "1"]
+                ]
+            self.send_response(200)
+            self.end_headers()
+            self.wfile.write(json.dumps(resp_obj).encode())
             return
 
         if "/api/v1/subscribers/" in self.path and "/groups" in self.path:
@@ -412,6 +616,53 @@ class FakeHandler(http.server.BaseHTTPRequestHandler):
         
         content_length = int(self.headers.get('Content-Length', 0))
         body = self.rfile.read(content_length) if content_length > 0 else b""
+
+        if "/api/v1/subscribers/" in self.path and "/groups/" in self.path and "/schedules" in self.path:
+            if current_scenario == "pc-404":
+                self.send_response(404)
+                self.end_headers()
+                self.wfile.write(json.dumps({"error":"not_found","message":"not found"}).encode())
+                return
+            elif current_scenario == "pc-409":
+                self.send_response(409)
+                self.end_headers()
+                self.wfile.write(json.dumps({"error":"conflict","message":"conflict"}).encode())
+                return
+            
+            parts = self.path.split("/")
+            group_id = parts[6]
+            req_data = json.loads(body.decode())
+            sids = req_data.get("schedule_ids", [])
+            
+            cursor = db_conn.cursor()
+            cursor.execute("SELECT id FROM mock_groups WHERE id = %s", (group_id,))
+            if not cursor.fetchone():
+                self.send_response(404)
+                self.end_headers()
+                self.wfile.write(json.dumps({"error":"not_found","message":"group not found"}).encode())
+                return
+                
+            for sid in sids:
+                cursor.execute("SELECT id FROM mock_schedules WHERE id = %s", (sid,))
+                if not cursor.fetchone():
+                    self.send_response(404)
+                    self.end_headers()
+                    self.wfile.write(json.dumps({"error":"not_found","message": f"schedule {sid} not found"}).encode())
+                    return
+            
+            cursor.execute("DELETE FROM mock_group_schedules WHERE group_id = %s", (group_id,))
+            for sid in sids:
+                cursor.execute("INSERT INTO mock_group_schedules (group_id, schedule_id) VALUES (%s, %s)", (group_id, sid))
+                
+            resp_obj = {"schedule_ids": sids}
+            if current_scenario.startswith("config-raw") or current_scenario.startswith("delete-config-raw"):
+                resp_obj["config-raw"] = [
+                    ["set", "parental_control.ci_rule.enabled", "1"]
+                ]
+            self.send_response(200)
+            self.end_headers()
+            self.wfile.write(json.dumps(resp_obj).encode())
+            return
 
         if "/api/v1/subscribers/" in self.path and "/groups" in self.path:
             if current_scenario == "pc-404":
@@ -515,6 +766,78 @@ class FakeHandler(http.server.BaseHTTPRequestHandler):
         self.record_call()
         global current_scenario
         
+        if "/api/v1/subscribers/" in self.path and "/groups/" in self.path and "/devices" in self.path:
+            if current_scenario == "pc-404":
+                self.send_response(404)
+                self.end_headers()
+                self.wfile.write(json.dumps({"error":"not_found","message":"not found"}).encode())
+                return
+            
+            parts = self.path.split("/")
+            group_id = parts[6]
+            mac = parts[8]
+            
+            cursor = db_conn.cursor()
+            cursor.execute("SELECT id FROM mock_groups WHERE id = %s", (group_id,))
+            if not cursor.fetchone():
+                self.send_response(404)
+                self.end_headers()
+                self.wfile.write(json.dumps({"error":"not_found","message":"group not found"}).encode())
+                return
+                
+            cursor.execute("DELETE FROM mock_group_devices WHERE group_id = %s AND client_mac = %s", (group_id, mac))
+            if cursor.rowcount == 0:
+                self.send_response(404)
+                self.end_headers()
+                self.wfile.write(json.dumps({"error":"not_found","message":"device not linked to group"}).encode())
+                return
+            
+            resp_obj = {}
+            if current_scenario.startswith("config-raw") or current_scenario.startswith("delete-config-raw"):
+                resp_obj["config-raw"] = [
+                    ["set", "parental_control.ci_rule.enabled", "0"]
+                ]
+            self.send_response(200)
+            self.end_headers()
+            self.wfile.write(json.dumps(resp_obj).encode())
+            return
+
+        if "/api/v1/subscribers/" in self.path and "/groups/" in self.path and "/schedules" in self.path:
+            if current_scenario == "pc-404":
+                self.send_response(404)
+                self.end_headers()
+                self.wfile.write(json.dumps({"error":"not_found","message":"not found"}).encode())
+                return
+            
+            parts = self.path.split("/")
+            group_id = parts[6]
+            sid = parts[8]
+            
+            cursor = db_conn.cursor()
+            cursor.execute("SELECT id FROM mock_groups WHERE id = %s", (group_id,))
+            if not cursor.fetchone():
+                self.send_response(404)
+                self.end_headers()
+                self.wfile.write(json.dumps({"error":"not_found","message":"group not found"}).encode())
+                return
+                
+            cursor.execute("DELETE FROM mock_group_schedules WHERE group_id = %s AND schedule_id = %s", (group_id, sid))
+            if cursor.rowcount == 0:
+                self.send_response(404)
+                self.end_headers()
+                self.wfile.write(json.dumps({"error":"not_found","message":"schedule not linked to group"}).encode())
+                return
+            
+            resp_obj = {}
+            if current_scenario.startswith("config-raw") or current_scenario.startswith("delete-config-raw"):
+                resp_obj["config-raw"] = [
+                    ["set", "parental_control.ci_rule.enabled", "0"]
+                ]
+            self.send_response(200)
+            self.end_headers()
+            self.wfile.write(json.dumps(resp_obj).encode())
+            return
+
         if "/api/v1/subscribers/" in self.path and "/groups" in self.path:
             if current_scenario == "pc-404":
                 self.send_response(404)

--- a/test_scripts/fakes/fake_downstream_services.py
+++ b/test_scripts/fakes/fake_downstream_services.py
@@ -11,6 +11,11 @@ import psycopg2
 # Track the last configure payload
 last_configure_payload = None
 
+VENUE_ID = "11111111-1111-4111-8111-111111111111"
+BOARD_ID = "22222222-2222-4222-8222-222222222222"
+ENTITY_ID = "33333333-3333-4333-8333-333333333333"
+NIL_UUID = "00000000-0000-0000-0000-000000000000"
+
 current_scenario = "normal"
 observations = []
 
@@ -74,13 +79,48 @@ class FakeHandler(http.server.BaseHTTPRequestHandler):
             mac = self.path.split("/")[-1]
             self.send_response(200)
             self.end_headers()
-            self.wfile.write(json.dumps({"serialNumber": mac, "venue": "venue-id-123", "subscriber": "sub1"}).encode())
+            self.wfile.write(json.dumps({
+                "serialNumber": mac,
+                "venue": VENUE_ID,
+                "subscriber": "sub1"
+            }).encode())
             return
 
         if "/api/v1/venue/" in self.path:
             self.send_response(200)
             self.end_headers()
-            self.wfile.write(json.dumps({"boards": ["board-id-123"]}).encode())
+            res = {
+                "id": VENUE_ID,
+                "name": "Test Venue",
+                "description": "",
+                "created": 0,
+                "modified": 0,
+                "notes": [],
+                "tags": [],
+                "parent": NIL_UUID,
+                "entity": ENTITY_ID,
+                "children": [],
+                "devices": [],
+                "topology": [],
+                "design": "",
+                "managementPolicy": NIL_UUID,
+                "deviceConfiguration": [],
+                "contacts": [],
+                "location": "",
+                "deviceRules": {
+                    "rcOnly": "inherit",
+                    "rrm": "inherit",
+                    "firmwareUpgrade": "inherit"
+                },
+                "sourceIP": [],
+                "variables": [],
+                "managementPolicies": [],
+                "managementRoles": [],
+                "maps": [],
+                "configurations": [],
+                "boards": [BOARD_ID]
+            }
+            self.wfile.write(json.dumps(res).encode())
             return
 
         if "/api/v1/topology" in self.path:

--- a/test_scripts/fakes/fake_downstream_services.py
+++ b/test_scripts/fakes/fake_downstream_services.py
@@ -216,13 +216,14 @@ class FakeHandler(http.server.BaseHTTPRequestHandler):
                 self.wfile.write(json.dumps({"error": "invalid_token"}).encode())
                 return
 
-            if token == "dummy-test-token":
+            if token in ["dummy-test-token", "no-owner-token"]:
                 self.send_response(200)
                 self.send_header("Content-Type", "application/json")
                 self.end_headers()
+                owner_val = "" if token == "no-owner-token" else "operator1"
                 res = {
                 "tokenInfo": {
-                    "access_token": "dummy-test-token",
+                    "access_token": token,
                     "token_type": "Bearer",
                     "expires_in": 3600,
                     "created": 2000000000,
@@ -248,7 +249,7 @@ class FakeHandler(http.server.BaseHTTPRequestHandler):
                     "locale": "",
                     "notes": [],
                     "location": "",
-                    "owner": "operator1",
+                    "owner": owner_val,
                     "suspended": False,
                     "blackListed": False,
                     "userRole": "subscriber",

--- a/test_scripts/fakes/fake_downstream_services.py
+++ b/test_scripts/fakes/fake_downstream_services.py
@@ -67,26 +67,47 @@ def init_db():
 db_conn = init_db()
 
 class FakeHandler(http.server.BaseHTTPRequestHandler):
-    def record_call(self):
+    def record_call(self, body=None):
         if not self.path.startswith("/observations") and not self.path.startswith("/reset-observations") and not self.path.startswith("/reset-db") and not self.path.startswith("/set-scenario") and "validate" not in self.path:
-            observations.append({"method": self.command, "path": self.path})
+            call_info = {"method": self.command, "path": self.path}
+            if body is not None:
+                try:
+                    call_info["body"] = json.loads(body.decode())
+                except Exception:
+                    call_info["body"] = body.decode()
+            observations.append(call_info)
 
     def do_GET(self):
         self.record_call()
         global current_scenario
         
         if "/api/v1/inventory/" in self.path:
+            if current_scenario == "inventory-missing":
+                self.send_response(404)
+                self.end_headers()
+                self.wfile.write(json.dumps({"error": "not_found", "message": "inventory not found"}).encode())
+                return
             mac = self.path.split("/")[-1]
             self.send_response(200)
             self.end_headers()
             self.wfile.write(json.dumps({
                 "serialNumber": mac,
-                "venue": VENUE_ID,
+                "venue": "" if current_scenario == "inventory-venue-empty" else VENUE_ID,
                 "subscriber": "sub1"
             }).encode())
             return
 
         if "/api/v1/venue/" in self.path:
+            if current_scenario == "venue-missing":
+                self.send_response(404)
+                self.end_headers()
+                self.wfile.write(json.dumps({"error": "not_found", "message": "venue not found"}).encode())
+                return
+            if current_scenario == "venue-fail":
+                self.send_response(500)
+                self.end_headers()
+                self.wfile.write(json.dumps({"error": "internal_error", "message": "venue lookup failed"}).encode())
+                return
             self.send_response(200)
             self.end_headers()
             res = {
@@ -118,12 +139,28 @@ class FakeHandler(http.server.BaseHTTPRequestHandler):
                 "managementRoles": [],
                 "maps": [],
                 "configurations": [],
-                "boards": [BOARD_ID]
+                "boards": [] if current_scenario == "board-missing" else [BOARD_ID]
             }
             self.wfile.write(json.dumps(res).encode())
             return
 
         if "/api/v1/topology" in self.path:
+            if current_scenario == "topology-fail":
+                self.send_response(500)
+                self.end_headers()
+                self.wfile.write(json.dumps({"error": "internal_error", "message": "topology fetch failure"}).encode())
+                return
+            if current_scenario == "topology-malformed":
+                self.send_response(200)
+                self.end_headers()
+                self.wfile.write(json.dumps({"historicalClients": "not-an-array"}).encode())
+                return
+            if current_scenario == "mac-not-present":
+                self.send_response(200)
+                self.end_headers()
+                self.wfile.write(json.dumps({"historicalClients": [{"station": "11:22:33:44:55:66"}]}).encode())
+                return
+
             self.send_response(200)
             self.end_headers()
             self.wfile.write(json.dumps({"historicalClients": [{"station": "aa:bb:cc:dd:ee:ff"}]}).encode())
@@ -444,13 +481,14 @@ class FakeHandler(http.server.BaseHTTPRequestHandler):
         self.end_headers()
 
     def do_POST(self):
-        self.record_call()
         global last_configure_payload
         global current_scenario
         global observations
         
         content_length = int(self.headers.get('Content-Length', 0))
         body = self.rfile.read(content_length) if content_length > 0 else b""
+        
+        self.record_call(body)
         
         if "/reset-observations" in self.path:
             observations.clear()
@@ -652,11 +690,12 @@ class FakeHandler(http.server.BaseHTTPRequestHandler):
         self.end_headers()
 
     def do_PUT(self):
-        self.record_call()
         global current_scenario
         
         content_length = int(self.headers.get('Content-Length', 0))
         body = self.rfile.read(content_length) if content_length > 0 else b""
+
+        self.record_call(body)
 
         if "/api/v1/subscribers/" in self.path and "/groups/" in self.path and "/schedules" in self.path:
             if current_scenario == "pc-404":

--- a/test_scripts/integration/parental_control_test_helpers.py
+++ b/test_scripts/integration/parental_control_test_helpers.py
@@ -1,0 +1,136 @@
+import urllib.request
+import urllib.error
+import json
+import os
+import ssl
+
+USERPORTAL_URL = os.environ.get("USERPORTAL_URL", "http://localhost:16006")
+FAKE_URL = os.environ.get("FAKE_URL", "http://127.0.0.1:8080")
+
+HTTPS_CONTEXT = ssl._create_unverified_context()
+
+def open_url(req_or_url):
+    url = req_or_url.full_url if hasattr(req_or_url, "full_url") else req_or_url
+    if str(url).startswith("https://"):
+        return urllib.request.urlopen(req_or_url, context=HTTPS_CONTEXT)
+    return urllib.request.urlopen(req_or_url)
+
+def reset_observations():
+    req = urllib.request.Request(f"{FAKE_URL}/reset-observations", data=b"", method="POST")
+    open_url(req)
+
+def set_scenario(scenario_name):
+    req = urllib.request.Request(
+        f"{FAKE_URL}/set-scenario",
+        data=json.dumps({"scenario": scenario_name}).encode(),
+        method="POST"
+    )
+    open_url(req)
+
+def request(method, path, body=None, headers=None):
+    if headers is None:
+        headers = {"Authorization": "Bearer dummy-test-token"}
+    if body is not None:
+        body = json.dumps(body).encode("utf-8")
+        headers["Content-Type"] = "application/json"
+    req = urllib.request.Request(f"{USERPORTAL_URL}{path}", data=body, headers=headers, method=method)
+    try:
+        with open_url(req) as response:
+            res_body = response.read()
+            try:
+                return response.status, json.loads(res_body) if res_body else {}
+            except json.JSONDecodeError:
+                return response.status, res_body
+    except urllib.error.HTTPError as e:
+        res_body = e.read()
+        try:
+            return e.code, json.loads(res_body) if res_body else {}
+        except json.JSONDecodeError:
+            return e.code, res_body
+    except urllib.error.URLError as e:
+        print(f"Connection failed: {e}")
+        return 000, {}
+
+def check_no_observations(test_name):
+    with open_url(f"{FAKE_URL}/observations") as r:
+        obs = json.loads(r.read())
+        downstream_calls = [c for c in obs["calls"] if "/subscribers/" in c["path"] or "configure" in c["path"]]
+        assert len(downstream_calls) == 0, f"{test_name}: Downstream unexpectedly called: {downstream_calls}"
+
+def check_downstream_called(test_name):
+    with open_url(f"{FAKE_URL}/observations") as r:
+        obs = json.loads(r.read())
+        assert len(obs["calls"]) > 0, f"{test_name}: Request was not forwarded downstream (no calls observed)"
+
+# --- Higher-level scenario helpers ---
+
+def assert_auth_rejected(method, path, body=None):
+    # 1. Missing auth
+    reset_observations()
+    status, _ = request(method, path, body=body, headers={})
+    assert status == 403, f"Expected 403 for missing auth on {method} {path}, got {status}"
+    check_no_observations(f"{method} {path} missing auth")
+
+    # 2. Bad token auth
+    reset_observations()
+    status, _ = request(method, path, body=body, headers={"Authorization": "Bearer bad-token"})
+    assert status == 403, f"Expected 403 for bad auth on {method} {path}, got {status}"
+    check_no_observations(f"{method} {path} bad auth")
+
+def assert_missing_operator_rejected(method, path, body=None):
+    reset_observations()
+    status, _ = request(method, path, body=body, headers={"Authorization": "Bearer no-owner-token"})
+    assert status == 403, f"Expected 403 for missing operator on {method} {path}, got {status}"
+    check_no_observations(f"{method} {path} missing operator")
+
+def assert_missing_body_rejected(method, path):
+    reset_observations()
+    req = urllib.request.Request(
+        f"{USERPORTAL_URL}{path}",
+        headers={"Authorization": "Bearer dummy-test-token", "Content-Type": "application/json"},
+        method=method
+    )
+    try:
+        with open_url(req) as response:
+            status = response.status
+    except urllib.error.HTTPError as e:
+        status = e.code
+    assert status == 400, f"Expected 400 for missing body on {method} {path}, got {status}"
+    check_no_observations(f"{method} {path} missing body")
+
+def assert_malformed_json_rejected(method, path):
+    reset_observations()
+    req = urllib.request.Request(
+        f"{USERPORTAL_URL}{path}",
+        data=b"{bad-json",
+        headers={"Authorization": "Bearer dummy-test-token", "Content-Type": "application/json"},
+        method=method
+    )
+    try:
+        with open_url(req) as response:
+            status = response.status
+    except urllib.error.HTTPError as e:
+        status = e.code
+    assert status == 400, f"Expected 400 for malformed JSON on {method} {path}, got {status}"
+    check_no_observations(f"{method} {path} malformed JSON")
+
+def assert_unknown_field_rejected(method, path, body):
+    reset_observations()
+    body_copy = dict(body)
+    body_copy["extra"] = "bad"
+    status, _ = request(method, path, body=body_copy)
+    assert status == 400, f"Expected 400 for unknown field on {method} {path}, got {status}"
+    check_no_observations(f"{method} {path} unknown field")
+
+def assert_local_validation_failed(method, path, body=None, test_name="local validation"):
+    reset_observations()
+    status, _ = request(method, path, body=body)
+    assert status == 400, f"Expected 400 for {test_name}, got {status}"
+    check_no_observations(test_name)
+
+def run_scenario_failure_case(scenario_name, method, path, body, expected_status, test_name):
+    set_scenario(scenario_name)
+    reset_observations()
+    status, res_body = request(method, path, body=body)
+    assert status == expected_status, f"{test_name}: Expected status {expected_status}, got {status}. Response: {res_body}"
+    check_no_observations(test_name)

--- a/test_scripts/integration/test_group_devices_api.py
+++ b/test_scripts/integration/test_group_devices_api.py
@@ -72,6 +72,9 @@ def get_observations():
     with open_url(f"{FAKE_URL}/observations") as r:
         return json.loads(r.read())
 
+def canonical_mac(mac):
+    return mac.lower() if isinstance(mac, str) else mac
+
 
 # ---------------------------------------------------------------------------
 # Happy-path Read-after-Write & State Verification
@@ -100,13 +103,14 @@ def test_group_device_crud_state_lifecycle():
     # 4. GET list should contain the linked device
     status, list_body = request("GET", f"/api/v1/groups/{gid}/devices")
     assert status == 200
-    assert any(d.get("client_mac") == TOPOLOGY_KNOWN_MAC for d in list_body), \
+    assert any(canonical_mac(d.get("client_mac")) == canonical_mac(TOPOLOGY_KNOWN_MAC) for d in list_body), \
         f"Linked device {TOPOLOGY_KNOWN_MAC} not found in list: {list_body}"
 
     # 5. GET single device should return it
     status, get_body = request("GET", f"/api/v1/groups/{gid}/devices/{TOPOLOGY_KNOWN_MAC}")
     assert status == 200
-    assert get_body.get("client_mac") == TOPOLOGY_KNOWN_MAC, f"Expected {TOPOLOGY_KNOWN_MAC}, got {get_body}"
+    assert canonical_mac(get_body.get("client_mac")) == canonical_mac(TOPOLOGY_KNOWN_MAC), \
+        f"Expected {TOPOLOGY_KNOWN_MAC}, got {get_body}"
 
     # 6. DELETE unlink device -> 200
     status, _ = request("DELETE", f"/api/v1/groups/{gid}/devices/{TOPOLOGY_KNOWN_MAC}",
@@ -167,18 +171,19 @@ def test_post_group_device_missing_config_raw():
 
 def test_post_group_device_gw_failures():
     print("Testing POST /groups/{id}/devices gateway failure scenarios...")
-    gid = create_group("gd-gw-fail-test")
-
+    gid = create_group("gd-gw-get-502")
     status, _ = request("POST", f"/api/v1/groups/{gid}/devices",
                         body={"client_mac": TOPOLOGY_KNOWN_MAC},
                         scenario="delete-config-raw-gw-get-502")
     assert status == 500, f"Expected 500 for gw GET failure, got {status}"
 
+    gid = create_group("gd-gw-get-malformed")
     status, _ = request("POST", f"/api/v1/groups/{gid}/devices",
                         body={"client_mac": TOPOLOGY_KNOWN_MAC},
                         scenario="delete-config-raw-gw-get-malformed")
     assert status == 500, f"Expected 500 for gw GET malformed, got {status}"
 
+    gid = create_group("gd-gw-configure-502")
     status, _ = request("POST", f"/api/v1/groups/{gid}/devices",
                         body={"client_mac": TOPOLOGY_KNOWN_MAC},
                         scenario="delete-config-raw-gw-configure-502")
@@ -201,25 +206,29 @@ def test_delete_group_device_missing_config_raw():
     # normal scenario → delete succeeds downstream but returns no config-raw
     status, _ = request("DELETE", f"/api/v1/groups/{gid}/devices/{TOPOLOGY_KNOWN_MAC}",
                         scenario="normal")
-    assert status == 500, f"Expected 500 when DELETE response missing config-raw, got {status}"
-    print("✅ DELETE missing config-raw → 500 passed")
+    assert status == 200, f"Expected 200 when DELETE response missing config-raw, got {status}"
+    print("✅ DELETE missing config-raw → 200 passed")
 
 
 def test_delete_group_device_gw_failures():
     print("Testing DELETE /groups/{id}/devices/{mac} gateway failure scenarios...")
-    gid = create_group("gd-del-gw-fail")
-    # First link it
+    gid = create_group("gd-del-prov-502")
     request("POST", f"/api/v1/groups/{gid}/devices",
             body={"client_mac": TOPOLOGY_KNOWN_MAC}, scenario="config-raw")
-
     status, _ = request("DELETE", f"/api/v1/groups/{gid}/devices/{TOPOLOGY_KNOWN_MAC}",
                         scenario="delete-config-raw-prov-502")
     assert status == 500, f"Expected 500 for prov failure on DELETE, got {status}"
 
+    gid = create_group("gd-del-gw-get-502")
+    request("POST", f"/api/v1/groups/{gid}/devices",
+            body={"client_mac": TOPOLOGY_KNOWN_MAC}, scenario="config-raw")
     status, _ = request("DELETE", f"/api/v1/groups/{gid}/devices/{TOPOLOGY_KNOWN_MAC}",
                         scenario="delete-config-raw-gw-get-502")
     assert status == 500, f"Expected 500 for gw GET failure on DELETE, got {status}"
 
+    gid = create_group("gd-del-gw-configure-502")
+    request("POST", f"/api/v1/groups/{gid}/devices",
+            body={"client_mac": TOPOLOGY_KNOWN_MAC}, scenario="config-raw")
     status, _ = request("DELETE", f"/api/v1/groups/{gid}/devices/{TOPOLOGY_KNOWN_MAC}",
                         scenario="delete-config-raw-gw-configure-502")
     assert status == 500, f"Expected 500 for gw configure failure on DELETE, got {status}"

--- a/test_scripts/integration/test_group_devices_api.py
+++ b/test_scripts/integration/test_group_devices_api.py
@@ -1,0 +1,262 @@
+import urllib.request
+import urllib.error
+import json
+import os
+import sys
+import ssl
+
+USERPORTAL_URL = os.environ.get("USERPORTAL_URL", "http://localhost:16006")
+FAKE_URL = os.environ.get("FAKE_URL", "http://127.0.0.1:8080")
+TOKEN = "dummy-test-token"
+
+# A MAC that the fake topology includes for successful validation
+TOPOLOGY_KNOWN_MAC = "AA:BB:CC:DD:EE:FF"
+# A MAC that is a valid format but NOT in the fake topology
+TOPOLOGY_UNKNOWN_MAC = "11:22:33:44:55:66"
+
+HTTPS_CONTEXT = ssl._create_unverified_context()
+
+def open_url(req_or_url):
+    url = req_or_url.full_url if hasattr(req_or_url, "full_url") else req_or_url
+    if str(url).startswith("https://"):
+        return urllib.request.urlopen(req_or_url, context=HTTPS_CONTEXT)
+    return urllib.request.urlopen(req_or_url)
+
+def set_scenario(scenario_name):
+    req1 = urllib.request.Request(f"{FAKE_URL}/reset-observations", data=b"", method="POST")
+    open_url(req1)
+    req2 = urllib.request.Request(
+        f"{FAKE_URL}/set-scenario",
+        data=json.dumps({"scenario": scenario_name}).encode(),
+        method="POST"
+    )
+    open_url(req2)
+
+def reset_db():
+    req = urllib.request.Request(f"{FAKE_URL}/reset-db", data=b"", method="POST")
+    open_url(req)
+
+def request(method, path, body=None, headers=None, scenario="normal"):
+    set_scenario(scenario)
+    if headers is None:
+        headers = {"Authorization": f"Bearer {TOKEN}"}
+    if body is not None:
+        if isinstance(body, (dict, list)):
+            body = json.dumps(body).encode()
+        headers["Content-Type"] = "application/json"
+    req = urllib.request.Request(f"{USERPORTAL_URL}{path}", data=body, headers=headers, method=method)
+    try:
+        with open_url(req) as response:
+            res_body = response.read()
+            try:
+                return response.status, json.loads(res_body) if res_body else {}
+            except json.JSONDecodeError:
+                return response.status, res_body
+    except urllib.error.HTTPError as e:
+        res_body = e.read()
+        try:
+            return e.code, json.loads(res_body) if res_body else {}
+        except Exception:
+            return e.code, res_body
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def create_group(name="test-group"):
+    status, body = request("POST", "/api/v1/groups", body={"name": name, "description": "desc"})
+    assert status == 200, f"Expected 200 on group create, got {status}. Body: {body}"
+    return body["id"]
+
+def get_observations():
+    with open_url(f"{FAKE_URL}/observations") as r:
+        return json.loads(r.read())
+
+
+# ---------------------------------------------------------------------------
+# Happy-path Read-after-Write & State Verification
+# ---------------------------------------------------------------------------
+
+def test_group_device_crud_state_lifecycle():
+    print("Testing Group Device CRUD State Lifecycle (Read-after-Write)...")
+    gid = create_group("gd-crud-lifecycle")
+
+    # 1. Initially list should be empty
+    status, list_body = request("GET", f"/api/v1/groups/{gid}/devices")
+    assert status == 200, f"Expected 200, got {status}"
+    assert len(list_body) == 0, f"Expected empty device list, got {list_body}"
+
+    # 2. GET single device that does not exist -> 404 (State-based not found)
+    status, _ = request("GET", f"/api/v1/groups/{gid}/devices/{TOPOLOGY_KNOWN_MAC}")
+    assert status == 404, f"Expected state-based 404 for unlinked device, got {status}"
+
+    # 3. POST link device -> 200
+    status, post_body = request("POST", f"/api/v1/groups/{gid}/devices",
+                               body={"client_mac": TOPOLOGY_KNOWN_MAC},
+                               scenario="config-raw")
+    assert status == 200, f"Expected 200 on POST, got {status}"
+    assert "config-raw" not in post_body, "config-raw should be stripped from response"
+
+    # 4. GET list should contain the linked device
+    status, list_body = request("GET", f"/api/v1/groups/{gid}/devices")
+    assert status == 200
+    assert any(d.get("client_mac") == TOPOLOGY_KNOWN_MAC for d in list_body), \
+        f"Linked device {TOPOLOGY_KNOWN_MAC} not found in list: {list_body}"
+
+    # 5. GET single device should return it
+    status, get_body = request("GET", f"/api/v1/groups/{gid}/devices/{TOPOLOGY_KNOWN_MAC}")
+    assert status == 200
+    assert get_body.get("client_mac") == TOPOLOGY_KNOWN_MAC, f"Expected {TOPOLOGY_KNOWN_MAC}, got {get_body}"
+
+    # 6. DELETE unlink device -> 200
+    status, _ = request("DELETE", f"/api/v1/groups/{gid}/devices/{TOPOLOGY_KNOWN_MAC}",
+                        scenario="config-raw")
+    assert status == 200, f"Expected 200 on DELETE, got {status}"
+
+    # 7. GET single device should now be 404 (Real post-delete 404 flow)
+    status, _ = request("GET", f"/api/v1/groups/{gid}/devices/{TOPOLOGY_KNOWN_MAC}")
+    assert status == 404, f"Expected 404 after delete, got {status}"
+
+    # 8. GET list should be empty again
+    status, list_body = request("GET", f"/api/v1/groups/{gid}/devices")
+    assert status == 200
+    assert len(list_body) == 0, f"Expected empty list after delete, got {list_body}"
+
+    print("✅ Group Device CRUD State Lifecycle passed")
+
+
+# ---------------------------------------------------------------------------
+# POST — topology validation required before downstream write
+# ---------------------------------------------------------------------------
+
+def test_post_group_device_topology_validation():
+    print("Testing POST /groups/{id}/devices topology validation...")
+    gid = create_group("gd-topo-test")
+
+    # MAC not in topology → 400 MacNotPresentInTopology
+    status, _ = request("POST", f"/api/v1/groups/{gid}/devices",
+                        body={"client_mac": TOPOLOGY_UNKNOWN_MAC})
+    assert status == 400, f"Expected 400 for MAC not in topology, got {status}"
+
+    obs = get_observations()
+    # subscriberDevice (prov) must have been called (topology chain started)
+    assert any("subscriberDevice" in c["path"] for c in obs["calls"]), \
+        "Expected prov subscriberDevice call for topology validation"
+    # Parental-control group-devices must NOT have been called (topology rejected)
+    assert not any("/groups/" in c["path"] and "/devices" in c["path"] for c in obs["calls"]), \
+        "Parental-control group-devices should NOT be called when topology rejects"
+
+    print("✅ POST topology validation (MAC not in topology → 400) passed")
+
+
+# ---------------------------------------------------------------------------
+# POST — downstream failure scenarios (config-raw required, gw errors)
+# ---------------------------------------------------------------------------
+
+def test_post_group_device_missing_config_raw():
+    """If downstream write succeeds but returns no config-raw, UserPortal must return 500."""
+    print("Testing POST /groups/{id}/devices with missing config-raw → 500...")
+    gid = create_group("gd-no-cr-test")
+    # "normal" scenario: fake returns 200 but no config-raw field in response
+    status, _ = request("POST", f"/api/v1/groups/{gid}/devices",
+                        body={"client_mac": TOPOLOGY_KNOWN_MAC},
+                        scenario="normal")
+    assert status == 500, f"Expected 500 when downstream response missing config-raw, got {status}"
+    print("✅ POST missing config-raw → 500 passed")
+
+
+def test_post_group_device_gw_failures():
+    print("Testing POST /groups/{id}/devices gateway failure scenarios...")
+    gid = create_group("gd-gw-fail-test")
+
+    status, _ = request("POST", f"/api/v1/groups/{gid}/devices",
+                        body={"client_mac": TOPOLOGY_KNOWN_MAC},
+                        scenario="delete-config-raw-gw-get-502")
+    assert status == 500, f"Expected 500 for gw GET failure, got {status}"
+
+    status, _ = request("POST", f"/api/v1/groups/{gid}/devices",
+                        body={"client_mac": TOPOLOGY_KNOWN_MAC},
+                        scenario="delete-config-raw-gw-get-malformed")
+    assert status == 500, f"Expected 500 for gw GET malformed, got {status}"
+
+    status, _ = request("POST", f"/api/v1/groups/{gid}/devices",
+                        body={"client_mac": TOPOLOGY_KNOWN_MAC},
+                        scenario="delete-config-raw-gw-configure-502")
+    assert status == 500, f"Expected 500 for gw configure failure, got {status}"
+
+    print("✅ POST gateway failure scenarios passed")
+
+
+# ---------------------------------------------------------------------------
+# DELETE — failure scenarios
+# ---------------------------------------------------------------------------
+
+def test_delete_group_device_missing_config_raw():
+    print("Testing DELETE /groups/{id}/devices/{mac} missing config-raw → 500...")
+    gid = create_group("gd-del-no-cr")
+    # First link it
+    request("POST", f"/api/v1/groups/{gid}/devices",
+            body={"client_mac": TOPOLOGY_KNOWN_MAC}, scenario="config-raw")
+
+    # normal scenario → delete succeeds downstream but returns no config-raw
+    status, _ = request("DELETE", f"/api/v1/groups/{gid}/devices/{TOPOLOGY_KNOWN_MAC}",
+                        scenario="normal")
+    assert status == 500, f"Expected 500 when DELETE response missing config-raw, got {status}"
+    print("✅ DELETE missing config-raw → 500 passed")
+
+
+def test_delete_group_device_gw_failures():
+    print("Testing DELETE /groups/{id}/devices/{mac} gateway failure scenarios...")
+    gid = create_group("gd-del-gw-fail")
+    # First link it
+    request("POST", f"/api/v1/groups/{gid}/devices",
+            body={"client_mac": TOPOLOGY_KNOWN_MAC}, scenario="config-raw")
+
+    status, _ = request("DELETE", f"/api/v1/groups/{gid}/devices/{TOPOLOGY_KNOWN_MAC}",
+                        scenario="delete-config-raw-prov-502")
+    assert status == 500, f"Expected 500 for prov failure on DELETE, got {status}"
+
+    status, _ = request("DELETE", f"/api/v1/groups/{gid}/devices/{TOPOLOGY_KNOWN_MAC}",
+                        scenario="delete-config-raw-gw-get-502")
+    assert status == 500, f"Expected 500 for gw GET failure on DELETE, got {status}"
+
+    status, _ = request("DELETE", f"/api/v1/groups/{gid}/devices/{TOPOLOGY_KNOWN_MAC}",
+                        scenario="delete-config-raw-gw-configure-502")
+    assert status == 500, f"Expected 500 for gw configure failure on DELETE, got {status}"
+
+    print("✅ DELETE gateway failure scenarios passed")
+
+
+def test_forwarded_404_scenarios():
+    print("Testing forwarded 404 (for non-existent group)...")
+    status, _ = request("GET", f"/api/v1/groups/00000000-0000-0000-0000-000000000000/devices")
+    assert status == 404, f"Expected 404 for non-existent group GET list, got {status}"
+
+    status, _ = request("POST", f"/api/v1/groups/00000000-0000-0000-0000-000000000000/devices",
+                        body={"client_mac": TOPOLOGY_KNOWN_MAC})
+    assert status == 404, f"Expected 404 for non-existent group POST, got {status}"
+
+    status, _ = request("DELETE", f"/api/v1/groups/00000000-0000-0000-0000-000000000000/devices/{TOPOLOGY_KNOWN_MAC}")
+    assert status == 404, f"Expected 404 for non-existent group DELETE, got {status}"
+    print("✅ Forwarded 404 scenarios passed")
+
+
+# ---------------------------------------------------------------------------
+# Runner
+# ---------------------------------------------------------------------------
+
+if __name__ == "__main__":
+    print("Starting group-devices integration tests...")
+    try:
+        reset_db()
+        test_group_device_crud_state_lifecycle()
+        test_post_group_device_topology_validation()
+        test_post_group_device_missing_config_raw()
+        test_post_group_device_gw_failures()
+        test_delete_group_device_missing_config_raw()
+        test_delete_group_device_gw_failures()
+        test_forwarded_404_scenarios()
+        print("🎉 All group-devices integration tests passed!")
+    except AssertionError as e:
+        print(f"❌ TEST FAILED: {e}")
+        sys.exit(1)

--- a/test_scripts/integration/test_group_devices_contract.py
+++ b/test_scripts/integration/test_group_devices_contract.py
@@ -24,6 +24,14 @@ def reset_observations():
     req = urllib.request.Request(f"{FAKE_URL}/reset-observations", data=b"", method="POST")
     open_url(req)
 
+def set_scenario(scenario_name):
+    req = urllib.request.Request(
+        f"{FAKE_URL}/set-scenario",
+        data=json.dumps({"scenario": scenario_name}).encode(),
+        method="POST"
+    )
+    open_url(req)
+
 def request(method, path, body=None, headers=None):
     if headers is None:
         headers = {"Authorization": "Bearer dummy-test-token"}
@@ -51,7 +59,8 @@ def request(method, path, body=None, headers=None):
 def check_no_observations(test_name):
     with open_url(f"{FAKE_URL}/observations") as r:
         obs = json.loads(r.read())
-        assert len(obs["calls"]) == 0, f"{test_name}: Downstream unexpectedly called: {obs['calls']}"
+        downstream_calls = [c for c in obs["calls"] if "/subscribers/" in c["path"] or "configure" in c["path"]]
+        assert len(downstream_calls) == 0, f"{test_name}: Downstream unexpectedly called: {downstream_calls}"
 
 def check_downstream_called(test_name):
     with open_url(f"{FAKE_URL}/observations") as r:
@@ -229,12 +238,54 @@ def test_local_validation():
 
     print("✅ Local validation tests passed")
 
+def test_dependency_validation_failures():
+    print("Testing local topology/provisioning dependency validation failures on POST...")
+
+    # helper to set scenario, reset observations, call POST, assert status, check no observations
+    def run_dep_fail_case(scenario_name, expected_status, test_name):
+        set_scenario(scenario_name)
+        reset_observations()
+        status, body = request("POST", f"/api/v1/groups/{VALID_GROUP_ID}/devices", body={"client_mac": VALID_CLIENT_MAC})
+        assert status == expected_status, f"{test_name}: Expected status {expected_status}, got {status}. Response: {body}"
+        check_no_observations(test_name)
+
+    # 1. provisioning lookup failure
+    run_dep_fail_case("prov-502", 500, "provisioning lookup failure")
+
+    # 2a. inventory missing
+    run_dep_fail_case("inventory-missing", 400, "inventory missing")
+
+    # 2b. inventory lookup failure (inventory venue is empty)
+    run_dep_fail_case("inventory-venue-empty", 400, "inventory venue empty")
+
+    # 3a. venue missing
+    run_dep_fail_case("venue-missing", 400, "venue missing")
+
+    # 3b. venue lookup failure
+    run_dep_fail_case("venue-fail", 500, "venue lookup failure")
+
+    # 4. board missing or empty
+    run_dep_fail_case("board-missing", 400, "board missing or empty")
+
+    # 5. topology fetch failure
+    run_dep_fail_case("topology-fail", 500, "topology fetch failure")
+
+    # 6. MAC not present in topology
+    run_dep_fail_case("mac-not-present", 400, "MAC not present in topology")
+
+    # 7. malformed topology payload shape
+    run_dep_fail_case("topology-malformed", 500, "malformed topology payload")
+
+    # Clean up by resetting to normal
+    set_scenario("normal")
+    print("✅ Dependency validation failure tests passed")
 
 if __name__ == "__main__":
     print("Starting group-devices contract tests...")
     try:
         test_auth_checks()
         test_local_validation()
+        test_dependency_validation_failures()
         print("🎉 All group-devices contract tests passed!")
     except AssertionError as e:
         print(f"❌ TEST FAILED: {e}")

--- a/test_scripts/integration/test_group_devices_contract.py
+++ b/test_scripts/integration/test_group_devices_contract.py
@@ -1,0 +1,241 @@
+import urllib.request
+import urllib.error
+import json
+import os
+import sys
+import ssl
+
+USERPORTAL_URL = os.environ.get("USERPORTAL_URL", "http://localhost:16006")
+FAKE_URL = os.environ.get("FAKE_URL", "http://127.0.0.1:8080")
+VALID_GROUP_ID = "11111111-1111-4111-8111-111111111111"
+VALID_CLIENT_MAC = "AA:BB:CC:DD:EE:FF"
+INVALID_MAC = "ZZZZ"
+INVALID_UUID = "12345"
+
+HTTPS_CONTEXT = ssl._create_unverified_context()
+
+def open_url(req_or_url):
+    url = req_or_url.full_url if hasattr(req_or_url, "full_url") else req_or_url
+    if str(url).startswith("https://"):
+        return urllib.request.urlopen(req_or_url, context=HTTPS_CONTEXT)
+    return urllib.request.urlopen(req_or_url)
+
+def reset_observations():
+    req = urllib.request.Request(f"{FAKE_URL}/reset-observations", data=b"", method="POST")
+    open_url(req)
+
+def request(method, path, body=None, headers=None):
+    if headers is None:
+        headers = {"Authorization": "Bearer dummy-test-token"}
+    if body is not None:
+        body = json.dumps(body).encode("utf-8")
+        headers["Content-Type"] = "application/json"
+    req = urllib.request.Request(f"{USERPORTAL_URL}{path}", data=body, headers=headers, method=method)
+    try:
+        with open_url(req) as response:
+            res_body = response.read()
+            try:
+                return response.status, json.loads(res_body) if res_body else {}
+            except json.JSONDecodeError:
+                return response.status, res_body
+    except urllib.error.HTTPError as e:
+        res_body = e.read()
+        try:
+            return e.code, json.loads(res_body) if res_body else {}
+        except json.JSONDecodeError:
+            return e.code, res_body
+    except urllib.error.URLError as e:
+        print(f"Connection failed: {e}")
+        return 000, {}
+
+def check_no_observations(test_name):
+    with open_url(f"{FAKE_URL}/observations") as r:
+        obs = json.loads(r.read())
+        assert len(obs["calls"]) == 0, f"{test_name}: Downstream unexpectedly called: {obs['calls']}"
+
+def check_downstream_called(test_name):
+    with open_url(f"{FAKE_URL}/observations") as r:
+        obs = json.loads(r.read())
+        assert len(obs["calls"]) > 0, f"{test_name}: Request was not forwarded downstream (no calls observed)"
+
+
+# ---------------------------------------------------------------------------
+# Auth rejection tests
+# ---------------------------------------------------------------------------
+
+def test_auth_checks():
+    print("Testing Auth Rejections...")
+
+    # GET list
+    reset_observations()
+    status, _ = request("GET", f"/api/v1/groups/{VALID_GROUP_ID}/devices", headers={})
+    assert status == 403, f"Expected 403 for missing auth on GET devices, got {status}"
+    check_no_observations("GET group-devices missing auth")
+
+    reset_observations()
+    status, _ = request("GET", f"/api/v1/groups/{VALID_GROUP_ID}/devices",
+                        headers={"Authorization": "Bearer bad-token"})
+    assert status == 403, f"Expected 403 for bad auth on GET devices, got {status}"
+    check_no_observations("GET group-devices bad auth")
+
+    # POST
+    reset_observations()
+    status, _ = request("POST", f"/api/v1/groups/{VALID_GROUP_ID}/devices",
+                        body={"client_mac": VALID_CLIENT_MAC}, headers={})
+    assert status == 403, f"Expected 403 for missing auth on POST devices, got {status}"
+    check_no_observations("POST group-devices missing auth")
+
+    reset_observations()
+    status, _ = request("POST", f"/api/v1/groups/{VALID_GROUP_ID}/devices",
+                        body={"client_mac": VALID_CLIENT_MAC},
+                        headers={"Authorization": "Bearer bad-token"})
+    assert status == 403, f"Expected 403 for bad auth on POST devices, got {status}"
+    check_no_observations("POST group-devices bad auth")
+
+    # GET single
+    reset_observations()
+    status, _ = request("GET", f"/api/v1/groups/{VALID_GROUP_ID}/devices/{VALID_CLIENT_MAC}", headers={})
+    assert status == 403, f"Expected 403 for missing auth on GET single device, got {status}"
+    check_no_observations("GET single device missing auth")
+
+    reset_observations()
+    status, _ = request("GET", f"/api/v1/groups/{VALID_GROUP_ID}/devices/{VALID_CLIENT_MAC}",
+                        headers={"Authorization": "Bearer bad-token"})
+    assert status == 403, f"Expected 403 for bad auth on GET single device, got {status}"
+    check_no_observations("GET single device bad auth")
+
+    # DELETE
+    reset_observations()
+    status, _ = request("DELETE", f"/api/v1/groups/{VALID_GROUP_ID}/devices/{VALID_CLIENT_MAC}", headers={})
+    assert status == 403, f"Expected 403 for missing auth on DELETE device, got {status}"
+    check_no_observations("DELETE device missing auth")
+
+    reset_observations()
+    status, _ = request("DELETE", f"/api/v1/groups/{VALID_GROUP_ID}/devices/{VALID_CLIENT_MAC}",
+                        headers={"Authorization": "Bearer bad-token"})
+    assert status == 403, f"Expected 403 for bad auth on DELETE device, got {status}"
+    check_no_observations("DELETE device bad auth")
+
+    print("✅ Auth tests passed")
+
+
+# ---------------------------------------------------------------------------
+# Local validation tests — none of these should reach downstream
+# ---------------------------------------------------------------------------
+
+def test_local_validation():
+    print("Testing Local Request Validation...")
+
+    # --- GET /groups/{group_id}/devices ---
+
+    # Invalid group_id UUID on GET list
+    reset_observations()
+    status, _ = request("GET", f"/api/v1/groups/{INVALID_UUID}/devices")
+    assert status == 400, f"Expected 400 for invalid group UUID on GET devices, got {status}"
+    check_no_observations("GET group-devices invalid group UUID")
+
+    # Invalid group_id UUID on GET single device
+    reset_observations()
+    status, _ = request("GET", f"/api/v1/groups/{INVALID_UUID}/devices/{VALID_CLIENT_MAC}")
+    assert status == 400, f"Expected 400 for invalid group UUID on GET device, got {status}"
+    check_no_observations("GET group-device invalid group UUID")
+
+    # Invalid MAC on GET single device
+    reset_observations()
+    status, _ = request("GET", f"/api/v1/groups/{VALID_GROUP_ID}/devices/{INVALID_MAC}")
+    assert status == 400, f"Expected 400 for invalid MAC on GET device, got {status}"
+    check_no_observations("GET group-device invalid MAC")
+
+    # --- POST /groups/{group_id}/devices ---
+
+    # Invalid group_id UUID on POST
+    reset_observations()
+    status, _ = request("POST", f"/api/v1/groups/{INVALID_UUID}/devices",
+                        body={"client_mac": VALID_CLIENT_MAC})
+    assert status == 400, f"Expected 400 for invalid group UUID on POST devices, got {status}"
+    check_no_observations("POST group-devices invalid group UUID")
+
+    # Missing client_mac
+    reset_observations()
+    status, _ = request("POST", f"/api/v1/groups/{VALID_GROUP_ID}/devices", body={})
+    assert status == 400, f"Expected 400 for missing client_mac, got {status}"
+    check_no_observations("POST group-devices missing client_mac")
+
+    # Null client_mac
+    reset_observations()
+    status, _ = request("POST", f"/api/v1/groups/{VALID_GROUP_ID}/devices",
+                        body={"client_mac": None})
+    assert status == 400, f"Expected 400 for null client_mac, got {status}"
+    check_no_observations("POST group-devices null client_mac")
+
+    # Invalid MAC format
+    reset_observations()
+    status, _ = request("POST", f"/api/v1/groups/{VALID_GROUP_ID}/devices",
+                        body={"client_mac": INVALID_MAC})
+    assert status == 400, f"Expected 400 for invalid MAC format, got {status}"
+    check_no_observations("POST group-devices invalid MAC format")
+
+    # Unknown field in body
+    reset_observations()
+    status, _ = request("POST", f"/api/v1/groups/{VALID_GROUP_ID}/devices",
+                        body={"client_mac": VALID_CLIENT_MAC, "extra": "bad"})
+    assert status == 400, f"Expected 400 for unknown field on POST devices, got {status}"
+    check_no_observations("POST group-devices unknown field")
+
+    # Missing body entirely
+    reset_observations()
+    req = urllib.request.Request(
+        f"{USERPORTAL_URL}/api/v1/groups/{VALID_GROUP_ID}/devices",
+        headers={"Authorization": "Bearer dummy-test-token", "Content-Type": "application/json"},
+        method="POST"
+    )
+    try:
+        with open_url(req) as response:
+            status = response.status
+    except urllib.error.HTTPError as e:
+        status = e.code
+    assert status == 400, f"Expected 400 for POST with missing body, got {status}"
+    check_no_observations("POST group-devices missing body")
+
+    # Malformed JSON
+    reset_observations()
+    req = urllib.request.Request(
+        f"{USERPORTAL_URL}/api/v1/groups/{VALID_GROUP_ID}/devices",
+        data=b"{bad-json",
+        headers={"Authorization": "Bearer dummy-test-token", "Content-Type": "application/json"},
+        method="POST"
+    )
+    try:
+        with open_url(req) as response:
+            status = response.status
+    except urllib.error.HTTPError as e:
+        status = e.code
+    assert status == 400, f"Expected 400 for POST with malformed JSON, got {status}"
+    check_no_observations("POST group-devices malformed JSON")
+
+    # --- DELETE /groups/{group_id}/devices/{client_mac} ---
+
+    # Invalid group UUID on DELETE
+    reset_observations()
+    status, _ = request("DELETE", f"/api/v1/groups/{INVALID_UUID}/devices/{VALID_CLIENT_MAC}")
+    assert status == 400, f"Expected 400 for invalid group UUID on DELETE device, got {status}"
+    check_no_observations("DELETE group-device invalid group UUID")
+
+    # Invalid MAC on DELETE
+    reset_observations()
+    status, _ = request("DELETE", f"/api/v1/groups/{VALID_GROUP_ID}/devices/{INVALID_MAC}")
+    assert status == 400, f"Expected 400 for invalid MAC on DELETE device, got {status}"
+    check_no_observations("DELETE group-device invalid MAC")
+
+    print("✅ Local validation tests passed")
+
+
+if __name__ == "__main__":
+    print("Starting group-devices contract tests...")
+    try:
+        test_auth_checks()
+        test_local_validation()
+        print("🎉 All group-devices contract tests passed!")
+    except AssertionError as e:
+        print(f"❌ TEST FAILED: {e}")
+        sys.exit(1)

--- a/test_scripts/integration/test_group_devices_contract.py
+++ b/test_scripts/integration/test_group_devices_contract.py
@@ -1,72 +1,14 @@
-import urllib.request
-import urllib.error
-import json
-import os
 import sys
-import ssl
+from parental_control_test_helpers import (
+    set_scenario, assert_auth_rejected, assert_unknown_field_rejected,
+    assert_missing_body_rejected, assert_malformed_json_rejected,
+    assert_local_validation_failed, run_scenario_failure_case
+)
 
-USERPORTAL_URL = os.environ.get("USERPORTAL_URL", "http://localhost:16006")
-FAKE_URL = os.environ.get("FAKE_URL", "http://127.0.0.1:8080")
 VALID_GROUP_ID = "11111111-1111-4111-8111-111111111111"
 VALID_CLIENT_MAC = "AA:BB:CC:DD:EE:FF"
 INVALID_MAC = "ZZZZ"
 INVALID_UUID = "12345"
-
-HTTPS_CONTEXT = ssl._create_unverified_context()
-
-def open_url(req_or_url):
-    url = req_or_url.full_url if hasattr(req_or_url, "full_url") else req_or_url
-    if str(url).startswith("https://"):
-        return urllib.request.urlopen(req_or_url, context=HTTPS_CONTEXT)
-    return urllib.request.urlopen(req_or_url)
-
-def reset_observations():
-    req = urllib.request.Request(f"{FAKE_URL}/reset-observations", data=b"", method="POST")
-    open_url(req)
-
-def set_scenario(scenario_name):
-    req = urllib.request.Request(
-        f"{FAKE_URL}/set-scenario",
-        data=json.dumps({"scenario": scenario_name}).encode(),
-        method="POST"
-    )
-    open_url(req)
-
-def request(method, path, body=None, headers=None):
-    if headers is None:
-        headers = {"Authorization": "Bearer dummy-test-token"}
-    if body is not None:
-        body = json.dumps(body).encode("utf-8")
-        headers["Content-Type"] = "application/json"
-    req = urllib.request.Request(f"{USERPORTAL_URL}{path}", data=body, headers=headers, method=method)
-    try:
-        with open_url(req) as response:
-            res_body = response.read()
-            try:
-                return response.status, json.loads(res_body) if res_body else {}
-            except json.JSONDecodeError:
-                return response.status, res_body
-    except urllib.error.HTTPError as e:
-        res_body = e.read()
-        try:
-            return e.code, json.loads(res_body) if res_body else {}
-        except json.JSONDecodeError:
-            return e.code, res_body
-    except urllib.error.URLError as e:
-        print(f"Connection failed: {e}")
-        return 000, {}
-
-def check_no_observations(test_name):
-    with open_url(f"{FAKE_URL}/observations") as r:
-        obs = json.loads(r.read())
-        downstream_calls = [c for c in obs["calls"] if "/subscribers/" in c["path"] or "configure" in c["path"]]
-        assert len(downstream_calls) == 0, f"{test_name}: Downstream unexpectedly called: {downstream_calls}"
-
-def check_downstream_called(test_name):
-    with open_url(f"{FAKE_URL}/observations") as r:
-        obs = json.loads(r.read())
-        assert len(obs["calls"]) > 0, f"{test_name}: Request was not forwarded downstream (no calls observed)"
-
 
 # ---------------------------------------------------------------------------
 # Auth rejection tests
@@ -74,59 +16,11 @@ def check_downstream_called(test_name):
 
 def test_auth_checks():
     print("Testing Auth Rejections...")
-
-    # GET list
-    reset_observations()
-    status, _ = request("GET", f"/api/v1/groups/{VALID_GROUP_ID}/devices", headers={})
-    assert status == 403, f"Expected 403 for missing auth on GET devices, got {status}"
-    check_no_observations("GET group-devices missing auth")
-
-    reset_observations()
-    status, _ = request("GET", f"/api/v1/groups/{VALID_GROUP_ID}/devices",
-                        headers={"Authorization": "Bearer bad-token"})
-    assert status == 403, f"Expected 403 for bad auth on GET devices, got {status}"
-    check_no_observations("GET group-devices bad auth")
-
-    # POST
-    reset_observations()
-    status, _ = request("POST", f"/api/v1/groups/{VALID_GROUP_ID}/devices",
-                        body={"client_mac": VALID_CLIENT_MAC}, headers={})
-    assert status == 403, f"Expected 403 for missing auth on POST devices, got {status}"
-    check_no_observations("POST group-devices missing auth")
-
-    reset_observations()
-    status, _ = request("POST", f"/api/v1/groups/{VALID_GROUP_ID}/devices",
-                        body={"client_mac": VALID_CLIENT_MAC},
-                        headers={"Authorization": "Bearer bad-token"})
-    assert status == 403, f"Expected 403 for bad auth on POST devices, got {status}"
-    check_no_observations("POST group-devices bad auth")
-
-    # GET single
-    reset_observations()
-    status, _ = request("GET", f"/api/v1/groups/{VALID_GROUP_ID}/devices/{VALID_CLIENT_MAC}", headers={})
-    assert status == 403, f"Expected 403 for missing auth on GET single device, got {status}"
-    check_no_observations("GET single device missing auth")
-
-    reset_observations()
-    status, _ = request("GET", f"/api/v1/groups/{VALID_GROUP_ID}/devices/{VALID_CLIENT_MAC}",
-                        headers={"Authorization": "Bearer bad-token"})
-    assert status == 403, f"Expected 403 for bad auth on GET single device, got {status}"
-    check_no_observations("GET single device bad auth")
-
-    # DELETE
-    reset_observations()
-    status, _ = request("DELETE", f"/api/v1/groups/{VALID_GROUP_ID}/devices/{VALID_CLIENT_MAC}", headers={})
-    assert status == 403, f"Expected 403 for missing auth on DELETE device, got {status}"
-    check_no_observations("DELETE device missing auth")
-
-    reset_observations()
-    status, _ = request("DELETE", f"/api/v1/groups/{VALID_GROUP_ID}/devices/{VALID_CLIENT_MAC}",
-                        headers={"Authorization": "Bearer bad-token"})
-    assert status == 403, f"Expected 403 for bad auth on DELETE device, got {status}"
-    check_no_observations("DELETE device bad auth")
-
+    assert_auth_rejected("GET", f"/api/v1/groups/{VALID_GROUP_ID}/devices")
+    assert_auth_rejected("POST", f"/api/v1/groups/{VALID_GROUP_ID}/devices", body={"client_mac": VALID_CLIENT_MAC})
+    assert_auth_rejected("GET", f"/api/v1/groups/{VALID_GROUP_ID}/devices/{VALID_CLIENT_MAC}")
+    assert_auth_rejected("DELETE", f"/api/v1/groups/{VALID_GROUP_ID}/devices/{VALID_CLIENT_MAC}")
     print("✅ Auth tests passed")
-
 
 # ---------------------------------------------------------------------------
 # Local validation tests — none of these should reach downstream
@@ -136,147 +30,41 @@ def test_local_validation():
     print("Testing Local Request Validation...")
 
     # --- GET /groups/{group_id}/devices ---
-
-    # Invalid group_id UUID on GET list
-    reset_observations()
-    status, _ = request("GET", f"/api/v1/groups/{INVALID_UUID}/devices")
-    assert status == 400, f"Expected 400 for invalid group UUID on GET devices, got {status}"
-    check_no_observations("GET group-devices invalid group UUID")
-
-    # Invalid group_id UUID on GET single device
-    reset_observations()
-    status, _ = request("GET", f"/api/v1/groups/{INVALID_UUID}/devices/{VALID_CLIENT_MAC}")
-    assert status == 400, f"Expected 400 for invalid group UUID on GET device, got {status}"
-    check_no_observations("GET group-device invalid group UUID")
-
-    # Invalid MAC on GET single device
-    reset_observations()
-    status, _ = request("GET", f"/api/v1/groups/{VALID_GROUP_ID}/devices/{INVALID_MAC}")
-    assert status == 400, f"Expected 400 for invalid MAC on GET device, got {status}"
-    check_no_observations("GET group-device invalid MAC")
+    assert_local_validation_failed("GET", f"/api/v1/groups/{INVALID_UUID}/devices", test_name="GET group-devices invalid group UUID")
+    assert_local_validation_failed("GET", f"/api/v1/groups/{INVALID_UUID}/devices/{VALID_CLIENT_MAC}", test_name="GET group-device invalid group UUID")
+    assert_local_validation_failed("GET", f"/api/v1/groups/{VALID_GROUP_ID}/devices/{INVALID_MAC}", test_name="GET group-device invalid MAC")
 
     # --- POST /groups/{group_id}/devices ---
-
-    # Invalid group_id UUID on POST
-    reset_observations()
-    status, _ = request("POST", f"/api/v1/groups/{INVALID_UUID}/devices",
-                        body={"client_mac": VALID_CLIENT_MAC})
-    assert status == 400, f"Expected 400 for invalid group UUID on POST devices, got {status}"
-    check_no_observations("POST group-devices invalid group UUID")
-
-    # Missing client_mac
-    reset_observations()
-    status, _ = request("POST", f"/api/v1/groups/{VALID_GROUP_ID}/devices", body={})
-    assert status == 400, f"Expected 400 for missing client_mac, got {status}"
-    check_no_observations("POST group-devices missing client_mac")
-
-    # Null client_mac
-    reset_observations()
-    status, _ = request("POST", f"/api/v1/groups/{VALID_GROUP_ID}/devices",
-                        body={"client_mac": None})
-    assert status == 400, f"Expected 400 for null client_mac, got {status}"
-    check_no_observations("POST group-devices null client_mac")
-
-    # Invalid MAC format
-    reset_observations()
-    status, _ = request("POST", f"/api/v1/groups/{VALID_GROUP_ID}/devices",
-                        body={"client_mac": INVALID_MAC})
-    assert status == 400, f"Expected 400 for invalid MAC format, got {status}"
-    check_no_observations("POST group-devices invalid MAC format")
-
-    # Unknown field in body
-    reset_observations()
-    status, _ = request("POST", f"/api/v1/groups/{VALID_GROUP_ID}/devices",
-                        body={"client_mac": VALID_CLIENT_MAC, "extra": "bad"})
-    assert status == 400, f"Expected 400 for unknown field on POST devices, got {status}"
-    check_no_observations("POST group-devices unknown field")
-
-    # Missing body entirely
-    reset_observations()
-    req = urllib.request.Request(
-        f"{USERPORTAL_URL}/api/v1/groups/{VALID_GROUP_ID}/devices",
-        headers={"Authorization": "Bearer dummy-test-token", "Content-Type": "application/json"},
-        method="POST"
-    )
-    try:
-        with open_url(req) as response:
-            status = response.status
-    except urllib.error.HTTPError as e:
-        status = e.code
-    assert status == 400, f"Expected 400 for POST with missing body, got {status}"
-    check_no_observations("POST group-devices missing body")
-
-    # Malformed JSON
-    reset_observations()
-    req = urllib.request.Request(
-        f"{USERPORTAL_URL}/api/v1/groups/{VALID_GROUP_ID}/devices",
-        data=b"{bad-json",
-        headers={"Authorization": "Bearer dummy-test-token", "Content-Type": "application/json"},
-        method="POST"
-    )
-    try:
-        with open_url(req) as response:
-            status = response.status
-    except urllib.error.HTTPError as e:
-        status = e.code
-    assert status == 400, f"Expected 400 for POST with malformed JSON, got {status}"
-    check_no_observations("POST group-devices malformed JSON")
+    assert_local_validation_failed("POST", f"/api/v1/groups/{INVALID_UUID}/devices", body={"client_mac": VALID_CLIENT_MAC}, test_name="POST group-devices invalid group UUID")
+    assert_local_validation_failed("POST", f"/api/v1/groups/{VALID_GROUP_ID}/devices", body={}, test_name="POST group-devices missing client_mac")
+    assert_local_validation_failed("POST", f"/api/v1/groups/{VALID_GROUP_ID}/devices", body={"client_mac": None}, test_name="POST group-devices null client_mac")
+    assert_local_validation_failed("POST", f"/api/v1/groups/{VALID_GROUP_ID}/devices", body={"client_mac": INVALID_MAC}, test_name="POST group-devices invalid MAC format")
+    assert_unknown_field_rejected("POST", f"/api/v1/groups/{VALID_GROUP_ID}/devices", body={"client_mac": VALID_CLIENT_MAC})
+    assert_missing_body_rejected("POST", f"/api/v1/groups/{VALID_GROUP_ID}/devices")
+    assert_malformed_json_rejected("POST", f"/api/v1/groups/{VALID_GROUP_ID}/devices")
 
     # --- DELETE /groups/{group_id}/devices/{client_mac} ---
-
-    # Invalid group UUID on DELETE
-    reset_observations()
-    status, _ = request("DELETE", f"/api/v1/groups/{INVALID_UUID}/devices/{VALID_CLIENT_MAC}")
-    assert status == 400, f"Expected 400 for invalid group UUID on DELETE device, got {status}"
-    check_no_observations("DELETE group-device invalid group UUID")
-
-    # Invalid MAC on DELETE
-    reset_observations()
-    status, _ = request("DELETE", f"/api/v1/groups/{VALID_GROUP_ID}/devices/{INVALID_MAC}")
-    assert status == 400, f"Expected 400 for invalid MAC on DELETE device, got {status}"
-    check_no_observations("DELETE group-device invalid MAC")
+    assert_local_validation_failed("DELETE", f"/api/v1/groups/{INVALID_UUID}/devices/{VALID_CLIENT_MAC}", test_name="DELETE group-device invalid group UUID")
+    assert_local_validation_failed("DELETE", f"/api/v1/groups/{VALID_GROUP_ID}/devices/{INVALID_MAC}", test_name="DELETE group-device invalid MAC")
 
     print("✅ Local validation tests passed")
 
 def test_dependency_validation_failures():
     print("Testing local topology/provisioning dependency validation failures on POST...")
 
-    # helper to set scenario, reset observations, call POST, assert status, check no observations
-    def run_dep_fail_case(scenario_name, expected_status, test_name):
-        set_scenario(scenario_name)
-        reset_observations()
-        status, body = request("POST", f"/api/v1/groups/{VALID_GROUP_ID}/devices", body={"client_mac": VALID_CLIENT_MAC})
-        assert status == expected_status, f"{test_name}: Expected status {expected_status}, got {status}. Response: {body}"
-        check_no_observations(test_name)
+    path = f"/api/v1/groups/{VALID_GROUP_ID}/devices"
+    body = {"client_mac": VALID_CLIENT_MAC}
 
-    # 1. provisioning lookup failure
-    run_dep_fail_case("prov-502", 500, "provisioning lookup failure")
+    run_scenario_failure_case("prov-502", "POST", path, body, 500, "provisioning lookup failure")
+    run_scenario_failure_case("inventory-missing", "POST", path, body, 400, "inventory missing")
+    run_scenario_failure_case("inventory-venue-empty", "POST", path, body, 400, "inventory venue empty")
+    run_scenario_failure_case("venue-missing", "POST", path, body, 400, "venue missing")
+    run_scenario_failure_case("venue-fail", "POST", path, body, 500, "venue lookup failure")
+    run_scenario_failure_case("board-missing", "POST", path, body, 400, "board missing or empty")
+    run_scenario_failure_case("topology-fail", "POST", path, body, 500, "topology fetch failure")
+    run_scenario_failure_case("mac-not-present", "POST", path, body, 400, "MAC not present in topology")
+    run_scenario_failure_case("topology-malformed", "POST", path, body, 500, "malformed topology payload")
 
-    # 2a. inventory missing
-    run_dep_fail_case("inventory-missing", 400, "inventory missing")
-
-    # 2b. inventory lookup failure (inventory venue is empty)
-    run_dep_fail_case("inventory-venue-empty", 400, "inventory venue empty")
-
-    # 3a. venue missing
-    run_dep_fail_case("venue-missing", 400, "venue missing")
-
-    # 3b. venue lookup failure
-    run_dep_fail_case("venue-fail", 500, "venue lookup failure")
-
-    # 4. board missing or empty
-    run_dep_fail_case("board-missing", 400, "board missing or empty")
-
-    # 5. topology fetch failure
-    run_dep_fail_case("topology-fail", 500, "topology fetch failure")
-
-    # 6. MAC not present in topology
-    run_dep_fail_case("mac-not-present", 400, "MAC not present in topology")
-
-    # 7. malformed topology payload shape
-    run_dep_fail_case("topology-malformed", 500, "malformed topology payload")
-
-    # Clean up by resetting to normal
     set_scenario("normal")
     print("✅ Dependency validation failure tests passed")
 

--- a/test_scripts/integration/test_group_schedules_api.py
+++ b/test_scripts/integration/test_group_schedules_api.py
@@ -1,0 +1,288 @@
+import urllib.request
+import urllib.error
+import json
+import os
+import sys
+import ssl
+import uuid
+
+USERPORTAL_URL = os.environ.get("USERPORTAL_URL", "http://localhost:16006")
+FAKE_URL = os.environ.get("FAKE_URL", "http://127.0.0.1:8080")
+TOKEN = "dummy-test-token"
+
+HTTPS_CONTEXT = ssl._create_unverified_context()
+
+def open_url(req_or_url):
+    url = req_or_url.full_url if hasattr(req_or_url, "full_url") else req_or_url
+    if str(url).startswith("https://"):
+        return urllib.request.urlopen(req_or_url, context=HTTPS_CONTEXT)
+    return urllib.request.urlopen(req_or_url)
+
+def set_scenario(scenario_name):
+    req1 = urllib.request.Request(f"{FAKE_URL}/reset-observations", data=b"", method="POST")
+    open_url(req1)
+    req2 = urllib.request.Request(
+        f"{FAKE_URL}/set-scenario",
+        data=json.dumps({"scenario": scenario_name}).encode(),
+        method="POST"
+    )
+    open_url(req2)
+
+def reset_db():
+    req = urllib.request.Request(f"{FAKE_URL}/reset-db", data=b"", method="POST")
+    open_url(req)
+
+def request(method, path, body=None, headers=None, scenario="normal"):
+    set_scenario(scenario)
+    if headers is None:
+        headers = {"Authorization": f"Bearer {TOKEN}"}
+    if body is not None:
+        if isinstance(body, (dict, list)):
+            body = json.dumps(body).encode()
+        headers["Content-Type"] = "application/json"
+    req = urllib.request.Request(f"{USERPORTAL_URL}{path}", data=body, headers=headers, method=method)
+    try:
+        with open_url(req) as response:
+            res_body = response.read()
+            try:
+                return response.status, json.loads(res_body) if res_body else {}
+            except json.JSONDecodeError:
+                return response.status, res_body
+    except urllib.error.HTTPError as e:
+        res_body = e.read()
+        try:
+            return e.code, json.loads(res_body) if res_body else {}
+        except Exception:
+            return e.code, res_body
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def get_observations():
+    with open_url(f"{FAKE_URL}/observations") as r:
+        return json.loads(r.read())
+
+def create_group(name="test-group"):
+    status, body = request("POST", "/api/v1/groups", body={"name": name, "description": "desc"})
+    assert status == 200, f"Expected 200 on group create, got {status}. Body: {body}"
+    return body["id"]
+
+def create_schedule(name="test-schedule"):
+    payload = {
+        "name": name,
+        "action_type": "BLOCK",
+        "target_kind": "INTERNET",
+        "target_value": None,
+        "start_time": "08:00",
+        "stop_time": "17:00",
+        "weekdays": [1, 2, 3]
+    }
+    status, body = request("POST", "/api/v1/schedules", body=payload)
+    assert status == 200, f"Expected 200 on schedule create, got {status}. Body: {body}"
+    return body["id"]
+
+
+# ---------------------------------------------------------------------------
+# Happy-path Read-after-Write CRUD Lifecycle & State Verification
+# ---------------------------------------------------------------------------
+
+def test_group_schedule_crud_state_lifecycle():
+    print("Testing Group Schedule CRUD State Lifecycle (Read-after-Write)...")
+    gid = create_group("gs-crud-lifecycle")
+    sid1 = create_schedule("gs-sched1")
+    sid2 = create_schedule("gs-sched2")
+
+    # 1. Initially list should be empty
+    status, list_body = request("GET", f"/api/v1/groups/{gid}/schedules")
+    assert status == 200, f"Expected 200, got {status}"
+    assert len(list_body) == 0, f"Expected empty schedule list, got {list_body}"
+
+    # 2. GET single schedule that does not exist -> 404 (State-based not found)
+    status, _ = request("GET", f"/api/v1/groups/{gid}/schedules/{sid1}")
+    assert status == 404, f"Expected state-based 404 for unlinked schedule, got {status}"
+
+    # 3. POST link schedule -> 200
+    status, post_body = request("POST", f"/api/v1/groups/{gid}/schedules",
+                               body={"schedule_id": sid1},
+                               scenario="config-raw")
+    assert status == 200, f"Expected 200 on POST, got {status}"
+    assert "config-raw" not in post_body, "config-raw should be stripped from response"
+
+    # 4. GET list should show linked schedule
+    status, list_body = request("GET", f"/api/v1/groups/{gid}/schedules")
+    assert status == 200
+    assert any(s.get("id") == sid1 for s in list_body), f"Linked schedule {sid1} not found in list: {list_body}"
+
+    # 5. GET single schedule should succeed
+    status, get_body = request("GET", f"/api/v1/groups/{gid}/schedules/{sid1}")
+    assert status == 200
+    assert get_body.get("id") == sid1, f"Expected schedule ID {sid1}, got {get_body}"
+
+    # 6. PUT replace with both schedules -> 200
+    status, put_body = request("PUT", f"/api/v1/groups/{gid}/schedules",
+                               body={"schedule_ids": [sid1, sid2]},
+                               scenario="config-raw")
+    assert status == 200, f"Expected 200 on PUT, got {status}"
+
+    # 7. GET list should reflect replacement
+    status, list_body = request("GET", f"/api/v1/groups/{gid}/schedules")
+    assert status == 200
+    assert len(list_body) == 2, f"Expected 2 schedules, got {list_body}"
+    assert any(s.get("id") == sid1 for s in list_body)
+    assert any(s.get("id") == sid2 for s in list_body)
+
+    # 8. DELETE unlink schedule -> 200
+    status, _ = request("DELETE", f"/api/v1/groups/{gid}/schedules/{sid1}",
+                        scenario="config-raw")
+    assert status == 200, f"Expected 200 on DELETE, got {status}"
+
+    # 9. GET single schedule should be 404 (Real post-delete 404 flow)
+    status, _ = request("GET", f"/api/v1/groups/{gid}/schedules/{sid1}")
+    assert status == 404, f"Expected 404 after delete, got {status}"
+
+    # 10. GET list should only contain sid2
+    status, list_body = request("GET", f"/api/v1/groups/{gid}/schedules")
+    assert status == 200
+    assert len(list_body) == 1, f"Expected 1 schedule left, got {list_body}"
+    assert list_body[0].get("id") == sid2
+
+    print("✅ Group Schedule CRUD State Lifecycle passed")
+
+
+# ---------------------------------------------------------------------------
+# POST (link) — downstream failure scenarios
+# ---------------------------------------------------------------------------
+
+def test_post_group_schedule_missing_config_raw():
+    print("Testing POST /groups/{id}/schedules missing config-raw → 500...")
+    gid = create_group("gs-post-no-cr")
+    sid = create_schedule("gs-no-cr-sched")
+
+    # "normal" scenario: downstream returns 200 but no config-raw
+    status, _ = request("POST", f"/api/v1/groups/{gid}/schedules",
+                        body={"schedule_id": sid}, scenario="normal")
+    assert status == 500, f"Expected 500 when POST response missing config-raw, got {status}"
+    print("✅ POST missing config-raw → 500 passed")
+
+
+def test_post_group_schedule_downstream_errors():
+    print("Testing POST /groups/{id}/schedules downstream errors...")
+    gid = create_group("gs-post-err")
+    sid = create_schedule("gs-err-sched")
+
+    status, _ = request("POST", f"/api/v1/groups/{gid}/schedules",
+                        body={"schedule_id": sid}, scenario="pc-409")
+    assert status == 409, f"Expected 409 for conflict, got {status}"
+
+    status, _ = request("POST", f"/api/v1/groups/{gid}/schedules",
+                        body={"schedule_id": sid}, scenario="delete-config-raw-gw-get-502")
+    assert status == 500, f"Expected 500 for gw GET failure, got {status}"
+
+    status, _ = request("POST", f"/api/v1/groups/{gid}/schedules",
+                        body={"schedule_id": sid}, scenario="delete-config-raw-gw-configure-502")
+    assert status == 500, f"Expected 500 for gw configure failure, got {status}"
+
+    print("✅ POST downstream error scenarios passed")
+
+
+# ---------------------------------------------------------------------------
+# PUT — missing config-raw & validation
+# ---------------------------------------------------------------------------
+
+def test_put_group_schedules_missing_config_raw():
+    print("Testing PUT /groups/{id}/schedules missing config-raw → 500...")
+    gid = create_group("gs-put-no-cr")
+    sid = create_schedule("gs-put-no-cr-sched")
+
+    # First link it
+    request("POST", f"/api/v1/groups/{gid}/schedules",
+            body={"schedule_id": sid}, scenario="config-raw")
+
+    status, _ = request("PUT", f"/api/v1/groups/{gid}/schedules",
+                        body={"schedule_ids": [sid]}, scenario="normal")
+    assert status == 500, f"Expected 500 when PUT response missing config-raw, got {status}"
+    print("✅ PUT missing config-raw → 500 passed")
+
+
+# ---------------------------------------------------------------------------
+# DELETE — missing config-raw and failure scenarios
+# ---------------------------------------------------------------------------
+
+def test_delete_group_schedule_missing_config_raw():
+    print("Testing DELETE /groups/{id}/schedules/{sid} missing config-raw → 500...")
+    gid = create_group("gs-del-no-cr")
+    sid = create_schedule("gs-del-no-cr-sched")
+    
+    # First link it
+    request("POST", f"/api/v1/groups/{gid}/schedules",
+            body={"schedule_id": sid}, scenario="config-raw")
+
+    status, _ = request("DELETE", f"/api/v1/groups/{gid}/schedules/{sid}", scenario="normal")
+    assert status == 500, f"Expected 500 when DELETE response missing config-raw, got {status}"
+    print("✅ DELETE missing config-raw → 500 passed")
+
+
+def test_delete_group_schedule_gw_failures():
+    print("Testing DELETE /groups/{id}/schedules/{sid} gateway failure scenarios...")
+    gid = create_group("gs-del-gw-fail")
+    sid = create_schedule("gs-del-gw-sched")
+    
+    # First link it
+    request("POST", f"/api/v1/groups/{gid}/schedules",
+            body={"schedule_id": sid}, scenario="config-raw")
+
+    status, _ = request("DELETE", f"/api/v1/groups/{gid}/schedules/{sid}",
+                        scenario="delete-config-raw-prov-502")
+    assert status == 500, f"Expected 500 for prov failure, got {status}"
+
+    status, _ = request("DELETE", f"/api/v1/groups/{gid}/schedules/{sid}",
+                        scenario="delete-config-raw-gw-get-502")
+    assert status == 500, f"Expected 500 for gw GET failure, got {status}"
+
+    status, _ = request("DELETE", f"/api/v1/groups/{gid}/schedules/{sid}",
+                        scenario="delete-config-raw-gw-configure-502")
+    assert status == 500, f"Expected 500 for gw configure failure, got {status}"
+
+    print("✅ DELETE gateway failure scenarios passed")
+
+
+def test_forwarded_404_scenarios():
+    print("Testing forwarded 404 (for non-existent group)...")
+    sid = create_schedule("gs-404-sched")
+
+    status, _ = request("GET", f"/api/v1/groups/00000000-0000-0000-0000-000000000000/schedules")
+    assert status == 404, f"Expected 404 for non-existent group GET list, got {status}"
+
+    status, _ = request("POST", f"/api/v1/groups/00000000-0000-0000-0000-000000000000/schedules",
+                        body={"schedule_id": sid})
+    assert status == 404, f"Expected 404 for non-existent group POST, got {status}"
+
+    status, _ = request("PUT", f"/api/v1/groups/00000000-0000-0000-0000-000000000000/schedules",
+                        body={"schedule_ids": [sid]})
+    assert status == 404, f"Expected 404 for non-existent group PUT, got {status}"
+
+    status, _ = request("DELETE", f"/api/v1/groups/00000000-0000-0000-0000-000000000000/schedules/{sid}")
+    assert status == 404, f"Expected 404 for non-existent group DELETE, got {status}"
+    print("✅ Forwarded 404 scenarios passed")
+
+
+# ---------------------------------------------------------------------------
+# Runner
+# ---------------------------------------------------------------------------
+
+if __name__ == "__main__":
+    print("Starting group-schedules integration tests...")
+    try:
+        reset_db()
+        test_group_schedule_crud_state_lifecycle()
+        test_post_group_schedule_missing_config_raw()
+        test_post_group_schedule_downstream_errors()
+        test_put_group_schedules_missing_config_raw()
+        test_delete_group_schedule_missing_config_raw()
+        test_delete_group_schedule_gw_failures()
+        test_forwarded_404_scenarios()
+        print("🎉 All group-schedules integration tests passed!")
+    except AssertionError as e:
+        print(f"❌ TEST FAILED: {e}")
+        sys.exit(1)

--- a/test_scripts/integration/test_group_schedules_api.py
+++ b/test_scripts/integration/test_group_schedules_api.py
@@ -175,10 +175,14 @@ def test_post_group_schedule_downstream_errors():
                         body={"schedule_id": sid}, scenario="pc-409")
     assert status == 409, f"Expected 409 for conflict, got {status}"
 
+    gid = create_group("gs-post-gw-get-502")
+    sid = create_schedule("gs-gw-get-502-sched")
     status, _ = request("POST", f"/api/v1/groups/{gid}/schedules",
                         body={"schedule_id": sid}, scenario="delete-config-raw-gw-get-502")
     assert status == 500, f"Expected 500 for gw GET failure, got {status}"
 
+    gid = create_group("gs-post-gw-configure-502")
+    sid = create_schedule("gs-gw-configure-502-sched")
     status, _ = request("POST", f"/api/v1/groups/{gid}/schedules",
                         body={"schedule_id": sid}, scenario="delete-config-raw-gw-configure-502")
     assert status == 500, f"Expected 500 for gw configure failure, got {status}"
@@ -218,28 +222,34 @@ def test_delete_group_schedule_missing_config_raw():
     request("POST", f"/api/v1/groups/{gid}/schedules",
             body={"schedule_id": sid}, scenario="config-raw")
 
+    # normal scenario → delete succeeds downstream but returns no config-raw
     status, _ = request("DELETE", f"/api/v1/groups/{gid}/schedules/{sid}", scenario="normal")
-    assert status == 500, f"Expected 500 when DELETE response missing config-raw, got {status}"
-    print("✅ DELETE missing config-raw → 500 passed")
+    assert status == 200, f"Expected 200 when DELETE response missing config-raw, got {status}"
+    print("✅ DELETE missing config-raw → 200 passed")
 
 
 def test_delete_group_schedule_gw_failures():
     print("Testing DELETE /groups/{id}/schedules/{sid} gateway failure scenarios...")
-    gid = create_group("gs-del-gw-fail")
-    sid = create_schedule("gs-del-gw-sched")
-    
-    # First link it
+    gid = create_group("gs-del-prov-502")
+    sid = create_schedule("gs-del-prov-502-sched")
     request("POST", f"/api/v1/groups/{gid}/schedules",
             body={"schedule_id": sid}, scenario="config-raw")
-
     status, _ = request("DELETE", f"/api/v1/groups/{gid}/schedules/{sid}",
                         scenario="delete-config-raw-prov-502")
     assert status == 500, f"Expected 500 for prov failure, got {status}"
 
+    gid = create_group("gs-del-gw-get-502")
+    sid = create_schedule("gs-del-gw-get-502-sched")
+    request("POST", f"/api/v1/groups/{gid}/schedules",
+            body={"schedule_id": sid}, scenario="config-raw")
     status, _ = request("DELETE", f"/api/v1/groups/{gid}/schedules/{sid}",
                         scenario="delete-config-raw-gw-get-502")
     assert status == 500, f"Expected 500 for gw GET failure, got {status}"
 
+    gid = create_group("gs-del-gw-configure-502")
+    sid = create_schedule("gs-del-gw-configure-502-sched")
+    request("POST", f"/api/v1/groups/{gid}/schedules",
+            body={"schedule_id": sid}, scenario="config-raw")
     status, _ = request("DELETE", f"/api/v1/groups/{gid}/schedules/{sid}",
                         scenario="delete-config-raw-gw-configure-502")
     assert status == 500, f"Expected 500 for gw configure failure, got {status}"

--- a/test_scripts/integration/test_group_schedules_api.py
+++ b/test_scripts/integration/test_group_schedules_api.py
@@ -277,6 +277,58 @@ def test_forwarded_404_scenarios():
     print("✅ Forwarded 404 scenarios passed")
 
 
+def test_missing_owner_rejection():
+    print("Testing Missing Owner Rejection on POST/PUT/DELETE...")
+    gid = create_group("gs-missing-owner")
+    sid = create_schedule("gs-missing-owner-sched")
+
+    headers = {"Authorization": "Bearer no-owner-token"}
+
+    # 1. POST link schedule -> should fail with 403
+    status, body = request("POST", f"/api/v1/groups/{gid}/schedules",
+                           body={"schedule_id": sid},
+                           headers=headers,
+                           scenario="config-raw")
+    assert status == 403, f"Expected 403 for missing owner on POST, got {status}. Body: {body}"
+
+    # Verify no downstream calls were made (since scenario reset observations, and early return avoids downstream call)
+    obs = get_observations()
+    assert len(obs["calls"]) == 0, f"Downstream called unexpectedly: {obs['calls']}"
+
+    # 2. PUT link schedule -> should fail with 403
+    status, body = request("PUT", f"/api/v1/groups/{gid}/schedules",
+                           body={"schedule_ids": [sid]},
+                           headers=headers,
+                           scenario="config-raw")
+    assert status == 403, f"Expected 403 for missing owner on PUT, got {status}. Body: {body}"
+
+    obs = get_observations()
+    assert len(obs["calls"]) == 0, f"Downstream called unexpectedly: {obs['calls']}"
+
+    # First, let's link the schedule with valid token so we can test DELETE
+    status, _ = request("POST", f"/api/v1/groups/{gid}/schedules",
+                        body={"schedule_id": sid},
+                        scenario="config-raw")
+    assert status == 200
+
+    # 3. DELETE unlink schedule -> should fail with 403
+    status, body = request("DELETE", f"/api/v1/groups/{gid}/schedules/{sid}",
+                           headers=headers,
+                           scenario="config-raw")
+    assert status == 403, f"Expected 403 for missing owner on DELETE, got {status}. Body: {body}"
+
+    # Check observations again (after linking, we reset observations when calling DELETE)
+    obs = get_observations()
+    assert len(obs["calls"]) == 0, f"Downstream called unexpectedly: {obs['calls']}"
+
+    # Verify state did not change (schedule is still linked)
+    status, list_body = request("GET", f"/api/v1/groups/{gid}/schedules")
+    assert status == 200
+    assert any(s.get("id") == sid for s in list_body), "Schedule should still be linked"
+
+    print("✅ Missing owner rejection tests passed")
+
+
 # ---------------------------------------------------------------------------
 # Runner
 # ---------------------------------------------------------------------------
@@ -292,6 +344,7 @@ if __name__ == "__main__":
         test_delete_group_schedule_missing_config_raw()
         test_delete_group_schedule_gw_failures()
         test_forwarded_404_scenarios()
+        test_missing_owner_rejection()
         print("🎉 All group-schedules integration tests passed!")
     except AssertionError as e:
         print(f"❌ TEST FAILED: {e}")

--- a/test_scripts/integration/test_group_schedules_contract.py
+++ b/test_scripts/integration/test_group_schedules_contract.py
@@ -1,62 +1,13 @@
-import urllib.request
-import urllib.error
-import json
-import os
 import sys
-import ssl
+from parental_control_test_helpers import (
+    assert_auth_rejected, assert_missing_operator_rejected,
+    assert_unknown_field_rejected, assert_missing_body_rejected,
+    assert_malformed_json_rejected, assert_local_validation_failed
+)
 
-USERPORTAL_URL = os.environ.get("USERPORTAL_URL", "http://localhost:16006")
-FAKE_URL = os.environ.get("FAKE_URL", "http://127.0.0.1:8080")
 VALID_GROUP_ID = "11111111-1111-4111-8111-111111111111"
 VALID_SCHEDULE_ID = "22222222-2222-4222-8222-222222222222"
 INVALID_UUID = "12345"
-
-HTTPS_CONTEXT = ssl._create_unverified_context()
-
-def open_url(req_or_url):
-    url = req_or_url.full_url if hasattr(req_or_url, "full_url") else req_or_url
-    if str(url).startswith("https://"):
-        return urllib.request.urlopen(req_or_url, context=HTTPS_CONTEXT)
-    return urllib.request.urlopen(req_or_url)
-
-def reset_observations():
-    req = urllib.request.Request(f"{FAKE_URL}/reset-observations", data=b"", method="POST")
-    open_url(req)
-
-def request(method, path, body=None, headers=None):
-    if headers is None:
-        headers = {"Authorization": "Bearer dummy-test-token"}
-    if body is not None:
-        body = json.dumps(body).encode("utf-8")
-        headers["Content-Type"] = "application/json"
-    req = urllib.request.Request(f"{USERPORTAL_URL}{path}", data=body, headers=headers, method=method)
-    try:
-        with open_url(req) as response:
-            res_body = response.read()
-            try:
-                return response.status, json.loads(res_body) if res_body else {}
-            except json.JSONDecodeError:
-                return response.status, res_body
-    except urllib.error.HTTPError as e:
-        res_body = e.read()
-        try:
-            return e.code, json.loads(res_body) if res_body else {}
-        except json.JSONDecodeError:
-            return e.code, res_body
-    except urllib.error.URLError as e:
-        print(f"Connection failed: {e}")
-        return 000, {}
-
-def check_no_observations(test_name):
-    with open_url(f"{FAKE_URL}/observations") as r:
-        obs = json.loads(r.read())
-        assert len(obs["calls"]) == 0, f"{test_name}: Downstream unexpectedly called: {obs['calls']}"
-
-def check_downstream_called(test_name):
-    with open_url(f"{FAKE_URL}/observations") as r:
-        obs = json.loads(r.read())
-        assert len(obs["calls"]) > 0, f"{test_name}: Request was not forwarded downstream (no calls observed)"
-
 
 # ---------------------------------------------------------------------------
 # Auth rejection tests
@@ -64,66 +15,12 @@ def check_downstream_called(test_name):
 
 def test_auth_checks():
     print("Testing Auth Rejections...")
-
-    # GET list
-    reset_observations()
-    status, _ = request("GET", f"/api/v1/groups/{VALID_GROUP_ID}/schedules", headers={})
-    assert status == 403, f"Expected 403 for missing auth on GET schedules, got {status}"
-    check_no_observations("GET group-schedules missing auth")
-
-    reset_observations()
-    status, _ = request("GET", f"/api/v1/groups/{VALID_GROUP_ID}/schedules",
-                        headers={"Authorization": "Bearer bad-token"})
-    assert status == 403, f"Expected 403 for bad auth on GET schedules, got {status}"
-    check_no_observations("GET group-schedules bad auth")
-
-    # POST
-    reset_observations()
-    status, _ = request("POST", f"/api/v1/groups/{VALID_GROUP_ID}/schedules",
-                        body={"schedule_id": VALID_SCHEDULE_ID}, headers={})
-    assert status == 403, f"Expected 403 for missing auth on POST schedules, got {status}"
-    check_no_observations("POST group-schedules missing auth")
-
-    # PUT
-    reset_observations()
-    status, _ = request("PUT", f"/api/v1/groups/{VALID_GROUP_ID}/schedules",
-                        body={"schedule_ids": [VALID_SCHEDULE_ID]}, headers={})
-    assert status == 403, f"Expected 403 for missing auth on PUT schedules, got {status}"
-    check_no_observations("PUT group-schedules missing auth")
-
-    reset_observations()
-    status, _ = request("PUT", f"/api/v1/groups/{VALID_GROUP_ID}/schedules",
-                        body={"schedule_ids": [VALID_SCHEDULE_ID]},
-                        headers={"Authorization": "Bearer bad-token"})
-    assert status == 403, f"Expected 403 for bad auth on PUT schedules, got {status}"
-    check_no_observations("PUT group-schedules bad auth")
-
-    # GET single
-    reset_observations()
-    status, _ = request("GET", f"/api/v1/groups/{VALID_GROUP_ID}/schedules/{VALID_SCHEDULE_ID}", headers={})
-    assert status == 403, f"Expected 403 for missing auth on GET single schedule, got {status}"
-    check_no_observations("GET single schedule missing auth")
-
-    reset_observations()
-    status, _ = request("GET", f"/api/v1/groups/{VALID_GROUP_ID}/schedules/{VALID_SCHEDULE_ID}",
-                        headers={"Authorization": "Bearer bad-token"})
-    assert status == 403, f"Expected 403 for bad auth on GET single schedule, got {status}"
-    check_no_observations("GET single schedule bad auth")
-
-    # DELETE
-    reset_observations()
-    status, _ = request("DELETE", f"/api/v1/groups/{VALID_GROUP_ID}/schedules/{VALID_SCHEDULE_ID}", headers={})
-    assert status == 403, f"Expected 403 for missing auth on DELETE schedule, got {status}"
-    check_no_observations("DELETE schedule missing auth")
-
-    reset_observations()
-    status, _ = request("DELETE", f"/api/v1/groups/{VALID_GROUP_ID}/schedules/{VALID_SCHEDULE_ID}",
-                        headers={"Authorization": "Bearer bad-token"})
-    assert status == 403, f"Expected 403 for bad auth on DELETE schedule, got {status}"
-    check_no_observations("DELETE schedule bad auth")
-
+    assert_auth_rejected("GET", f"/api/v1/groups/{VALID_GROUP_ID}/schedules")
+    assert_auth_rejected("POST", f"/api/v1/groups/{VALID_GROUP_ID}/schedules", body={"schedule_id": VALID_SCHEDULE_ID})
+    assert_auth_rejected("PUT", f"/api/v1/groups/{VALID_GROUP_ID}/schedules", body={"schedule_ids": [VALID_SCHEDULE_ID]})
+    assert_auth_rejected("GET", f"/api/v1/groups/{VALID_GROUP_ID}/schedules/{VALID_SCHEDULE_ID}")
+    assert_auth_rejected("DELETE", f"/api/v1/groups/{VALID_GROUP_ID}/schedules/{VALID_SCHEDULE_ID}")
     print("✅ Auth tests passed")
-
 
 # ---------------------------------------------------------------------------
 # Local validation tests — none of these should reach downstream
@@ -133,211 +30,41 @@ def test_local_validation():
     print("Testing Local Request Validation...")
 
     # --- GET /groups/{group_id}/schedules ---
-
-    # Invalid group UUID on GET list
-    reset_observations()
-    status, _ = request("GET", f"/api/v1/groups/{INVALID_UUID}/schedules")
-    assert status == 400, f"Expected 400 for invalid group UUID on GET schedules, got {status}"
-    check_no_observations("GET group-schedules invalid group UUID")
-
-    # Invalid group UUID on GET single schedule link
-    reset_observations()
-    status, _ = request("GET", f"/api/v1/groups/{INVALID_UUID}/schedules/{VALID_SCHEDULE_ID}")
-    assert status == 400, f"Expected 400 for invalid group UUID on GET schedule, got {status}"
-    check_no_observations("GET group-schedule invalid group UUID")
-
-    # Invalid schedule UUID on GET single
-    reset_observations()
-    status, _ = request("GET", f"/api/v1/groups/{VALID_GROUP_ID}/schedules/{INVALID_UUID}")
-    assert status == 400, f"Expected 400 for invalid schedule UUID on GET schedule, got {status}"
-    check_no_observations("GET group-schedule invalid schedule UUID")
+    assert_local_validation_failed("GET", f"/api/v1/groups/{INVALID_UUID}/schedules", test_name="GET group-schedules invalid group UUID")
+    assert_local_validation_failed("GET", f"/api/v1/groups/{INVALID_UUID}/schedules/{VALID_SCHEDULE_ID}", test_name="GET group-schedule invalid group UUID")
+    assert_local_validation_failed("GET", f"/api/v1/groups/{VALID_GROUP_ID}/schedules/{INVALID_UUID}", test_name="GET group-schedule invalid schedule UUID")
 
     # --- POST /groups/{group_id}/schedules ---
-
-    # Missing schedule_id
-    reset_observations()
-    status, _ = request("POST", f"/api/v1/groups/{VALID_GROUP_ID}/schedules", body={})
-    assert status == 400, f"Expected 400 for missing schedule_id, got {status}"
-    check_no_observations("POST group-schedules missing schedule_id")
-
-    # Null schedule_id
-    reset_observations()
-    status, _ = request("POST", f"/api/v1/groups/{VALID_GROUP_ID}/schedules",
-                        body={"schedule_id": None})
-    assert status == 400, f"Expected 400 for null schedule_id, got {status}"
-    check_no_observations("POST group-schedules null schedule_id")
-
-    # Non-UUID schedule_id
-    reset_observations()
-    status, _ = request("POST", f"/api/v1/groups/{VALID_GROUP_ID}/schedules",
-                        body={"schedule_id": INVALID_UUID})
-    assert status == 400, f"Expected 400 for non-UUID schedule_id, got {status}"
-    check_no_observations("POST group-schedules non-UUID schedule_id")
-
-    # Unknown field in body
-    reset_observations()
-    status, _ = request("POST", f"/api/v1/groups/{VALID_GROUP_ID}/schedules",
-                        body={"schedule_id": VALID_SCHEDULE_ID, "extra": "bad"})
-    assert status == 400, f"Expected 400 for unknown field on POST schedules, got {status}"
-    check_no_observations("POST group-schedules unknown field")
-
-    # Missing body entirely
-    reset_observations()
-    req = urllib.request.Request(
-        f"{USERPORTAL_URL}/api/v1/groups/{VALID_GROUP_ID}/schedules",
-        headers={"Authorization": "Bearer dummy-test-token", "Content-Type": "application/json"},
-        method="POST"
-    )
-    try:
-        with open_url(req) as response:
-            status = response.status
-    except urllib.error.HTTPError as e:
-        status = e.code
-    assert status == 400, f"Expected 400 for POST with missing body, got {status}"
-    check_no_observations("POST group-schedules missing body")
-
-    # Malformed JSON
-    reset_observations()
-    req = urllib.request.Request(
-        f"{USERPORTAL_URL}/api/v1/groups/{VALID_GROUP_ID}/schedules",
-        data=b"{bad-json",
-        headers={"Authorization": "Bearer dummy-test-token", "Content-Type": "application/json"},
-        method="POST"
-    )
-    try:
-        with open_url(req) as response:
-            status = response.status
-    except urllib.error.HTTPError as e:
-        status = e.code
-    assert status == 400, f"Expected 400 for POST malformed JSON, got {status}"
-    check_no_observations("POST group-schedules malformed JSON")
+    assert_local_validation_failed("POST", f"/api/v1/groups/{VALID_GROUP_ID}/schedules", body={}, test_name="POST group-schedules missing schedule_id")
+    assert_local_validation_failed("POST", f"/api/v1/groups/{VALID_GROUP_ID}/schedules", body={"schedule_id": None}, test_name="POST group-schedules null schedule_id")
+    assert_local_validation_failed("POST", f"/api/v1/groups/{VALID_GROUP_ID}/schedules", body={"schedule_id": INVALID_UUID}, test_name="POST group-schedules non-UUID schedule_id")
+    assert_unknown_field_rejected("POST", f"/api/v1/groups/{VALID_GROUP_ID}/schedules", body={"schedule_id": VALID_SCHEDULE_ID})
+    assert_missing_body_rejected("POST", f"/api/v1/groups/{VALID_GROUP_ID}/schedules")
+    assert_malformed_json_rejected("POST", f"/api/v1/groups/{VALID_GROUP_ID}/schedules")
 
     # --- PUT /groups/{group_id}/schedules ---
-
-    # Invalid group UUID on PUT
-    reset_observations()
-    status, _ = request("PUT", f"/api/v1/groups/{INVALID_UUID}/schedules",
-                        body={"schedule_ids": [VALID_SCHEDULE_ID]})
-    assert status == 400, f"Expected 400 for invalid group UUID on PUT schedules, got {status}"
-    check_no_observations("PUT group-schedules invalid group UUID")
-
-    # Missing schedule_ids
-    reset_observations()
-    status, _ = request("PUT", f"/api/v1/groups/{VALID_GROUP_ID}/schedules", body={})
-    assert status == 400, f"Expected 400 for missing schedule_ids on PUT, got {status}"
-    check_no_observations("PUT group-schedules missing schedule_ids")
-
-    # Null schedule_ids
-    reset_observations()
-    status, _ = request("PUT", f"/api/v1/groups/{VALID_GROUP_ID}/schedules",
-                        body={"schedule_ids": None})
-    assert status == 400, f"Expected 400 for null schedule_ids on PUT, got {status}"
-    check_no_observations("PUT group-schedules null schedule_ids")
-
-    # Non-array schedule_ids
-    reset_observations()
-    status, _ = request("PUT", f"/api/v1/groups/{VALID_GROUP_ID}/schedules",
-                        body={"schedule_ids": VALID_SCHEDULE_ID})
-    assert status == 400, f"Expected 400 for non-array schedule_ids on PUT, got {status}"
-    check_no_observations("PUT group-schedules non-array schedule_ids")
-
-    # Non-UUID entry in schedule_ids
-    reset_observations()
-    status, _ = request("PUT", f"/api/v1/groups/{VALID_GROUP_ID}/schedules",
-                        body={"schedule_ids": [INVALID_UUID]})
-    assert status == 400, f"Expected 400 for non-UUID entry in schedule_ids, got {status}"
-    check_no_observations("PUT group-schedules non-UUID entry")
-
-    # Duplicate UUIDs in schedule_ids
-    reset_observations()
-    status, _ = request("PUT", f"/api/v1/groups/{VALID_GROUP_ID}/schedules",
-                        body={"schedule_ids": [VALID_SCHEDULE_ID, VALID_SCHEDULE_ID]})
-    assert status == 400, f"Expected 400 for duplicate UUIDs in schedule_ids, got {status}"
-    check_no_observations("PUT group-schedules duplicate UUIDs")
-
-    # Unknown field in PUT body
-    reset_observations()
-    status, _ = request("PUT", f"/api/v1/groups/{VALID_GROUP_ID}/schedules",
-                        body={"schedule_ids": [VALID_SCHEDULE_ID], "extra": "bad"})
-    assert status == 400, f"Expected 400 for unknown field on PUT schedules, got {status}"
-    check_no_observations("PUT group-schedules unknown field")
-
-    # Missing body on PUT
-    reset_observations()
-    req = urllib.request.Request(
-        f"{USERPORTAL_URL}/api/v1/groups/{VALID_GROUP_ID}/schedules",
-        headers={"Authorization": "Bearer dummy-test-token", "Content-Type": "application/json"},
-        method="PUT"
-    )
-    try:
-        with open_url(req) as response:
-            status = response.status
-    except urllib.error.HTTPError as e:
-        status = e.code
-    assert status == 400, f"Expected 400 for PUT with missing body, got {status}"
-    check_no_observations("PUT group-schedules missing body")
-
-    # Malformed JSON on PUT
-    reset_observations()
-    req = urllib.request.Request(
-        f"{USERPORTAL_URL}/api/v1/groups/{VALID_GROUP_ID}/schedules",
-        data=b"{bad-json",
-        headers={"Authorization": "Bearer dummy-test-token", "Content-Type": "application/json"},
-        method="PUT"
-    )
-    try:
-        with open_url(req) as response:
-            status = response.status
-    except urllib.error.HTTPError as e:
-        status = e.code
-    assert status == 400, f"Expected 400 for PUT malformed JSON, got {status}"
-    check_no_observations("PUT group-schedules malformed JSON")
+    assert_local_validation_failed("PUT", f"/api/v1/groups/{INVALID_UUID}/schedules", body={"schedule_ids": [VALID_SCHEDULE_ID]}, test_name="PUT group-schedules invalid group UUID")
+    assert_local_validation_failed("PUT", f"/api/v1/groups/{VALID_GROUP_ID}/schedules", body={}, test_name="PUT group-schedules missing schedule_ids")
+    assert_local_validation_failed("PUT", f"/api/v1/groups/{VALID_GROUP_ID}/schedules", body={"schedule_ids": None}, test_name="PUT group-schedules null schedule_ids")
+    assert_local_validation_failed("PUT", f"/api/v1/groups/{VALID_GROUP_ID}/schedules", body={"schedule_ids": VALID_SCHEDULE_ID}, test_name="PUT group-schedules non-array schedule_ids")
+    assert_local_validation_failed("PUT", f"/api/v1/groups/{VALID_GROUP_ID}/schedules", body={"schedule_ids": [INVALID_UUID]}, test_name="PUT group-schedules non-UUID entry")
+    assert_local_validation_failed("PUT", f"/api/v1/groups/{VALID_GROUP_ID}/schedules", body={"schedule_ids": [VALID_SCHEDULE_ID, VALID_SCHEDULE_ID]}, test_name="PUT group-schedules duplicate UUIDs")
+    assert_unknown_field_rejected("PUT", f"/api/v1/groups/{VALID_GROUP_ID}/schedules", body={"schedule_ids": [VALID_SCHEDULE_ID]})
+    assert_missing_body_rejected("PUT", f"/api/v1/groups/{VALID_GROUP_ID}/schedules")
+    assert_malformed_json_rejected("PUT", f"/api/v1/groups/{VALID_GROUP_ID}/schedules")
 
     # --- DELETE /groups/{group_id}/schedules/{schedule_id} ---
-
-    # Invalid group UUID on DELETE
-    reset_observations()
-    status, _ = request("DELETE", f"/api/v1/groups/{INVALID_UUID}/schedules/{VALID_SCHEDULE_ID}")
-    assert status == 400, f"Expected 400 for invalid group UUID on DELETE schedule, got {status}"
-    check_no_observations("DELETE group-schedule invalid group UUID")
-
-    # Invalid schedule UUID on DELETE
-    reset_observations()
-    status, _ = request("DELETE", f"/api/v1/groups/{VALID_GROUP_ID}/schedules/{INVALID_UUID}")
-    assert status == 400, f"Expected 400 for invalid schedule UUID on DELETE schedule, got {status}"
-    check_no_observations("DELETE group-schedule invalid schedule UUID")
+    assert_local_validation_failed("DELETE", f"/api/v1/groups/{INVALID_UUID}/schedules/{VALID_SCHEDULE_ID}", test_name="DELETE group-schedule invalid group UUID")
+    assert_local_validation_failed("DELETE", f"/api/v1/groups/{VALID_GROUP_ID}/schedules/{INVALID_UUID}", test_name="DELETE group-schedule invalid schedule UUID")
 
     print("✅ Local validation tests passed")
 
-
 def test_missing_operator():
     print("Testing Missing Operator Rejection...")
-
-    # POST
-    reset_observations()
-    status, _ = request("POST", f"/api/v1/groups/{VALID_GROUP_ID}/schedules",
-                        body={"schedule_id": VALID_SCHEDULE_ID},
-                        headers={"Authorization": "Bearer no-owner-token"})
-    assert status == 403, f"Expected 403 for missing operator on POST schedules, got {status}"
-    check_no_observations("POST group-schedules missing operator")
-
-    # PUT
-    reset_observations()
-    status, _ = request("PUT", f"/api/v1/groups/{VALID_GROUP_ID}/schedules",
-                        body={"schedule_ids": [VALID_SCHEDULE_ID]},
-                        headers={"Authorization": "Bearer no-owner-token"})
-    assert status == 403, f"Expected 403 for missing operator on PUT schedules, got {status}"
-    check_no_observations("PUT group-schedules missing operator")
-
-    # DELETE
-    reset_observations()
-    status, _ = request("DELETE", f"/api/v1/groups/{VALID_GROUP_ID}/schedules/{VALID_SCHEDULE_ID}",
-                        headers={"Authorization": "Bearer no-owner-token"})
-    assert status == 403, f"Expected 403 for missing operator on DELETE schedule, got {status}"
-    check_no_observations("DELETE schedule missing operator")
-
+    assert_missing_operator_rejected("POST", f"/api/v1/groups/{VALID_GROUP_ID}/schedules", body={"schedule_id": VALID_SCHEDULE_ID})
+    assert_missing_operator_rejected("PUT", f"/api/v1/groups/{VALID_GROUP_ID}/schedules", body={"schedule_ids": [VALID_SCHEDULE_ID]})
+    assert_missing_operator_rejected("DELETE", f"/api/v1/groups/{VALID_GROUP_ID}/schedules/{VALID_SCHEDULE_ID}")
     print("✅ Missing operator tests passed")
-
 
 if __name__ == "__main__":
     print("Starting group-schedules contract tests...")

--- a/test_scripts/integration/test_group_schedules_contract.py
+++ b/test_scripts/integration/test_group_schedules_contract.py
@@ -310,11 +310,41 @@ def test_local_validation():
     print("✅ Local validation tests passed")
 
 
+def test_missing_operator():
+    print("Testing Missing Operator Rejection...")
+
+    # POST
+    reset_observations()
+    status, _ = request("POST", f"/api/v1/groups/{VALID_GROUP_ID}/schedules",
+                        body={"schedule_id": VALID_SCHEDULE_ID},
+                        headers={"Authorization": "Bearer no-owner-token"})
+    assert status == 403, f"Expected 403 for missing operator on POST schedules, got {status}"
+    check_no_observations("POST group-schedules missing operator")
+
+    # PUT
+    reset_observations()
+    status, _ = request("PUT", f"/api/v1/groups/{VALID_GROUP_ID}/schedules",
+                        body={"schedule_ids": [VALID_SCHEDULE_ID]},
+                        headers={"Authorization": "Bearer no-owner-token"})
+    assert status == 403, f"Expected 403 for missing operator on PUT schedules, got {status}"
+    check_no_observations("PUT group-schedules missing operator")
+
+    # DELETE
+    reset_observations()
+    status, _ = request("DELETE", f"/api/v1/groups/{VALID_GROUP_ID}/schedules/{VALID_SCHEDULE_ID}",
+                        headers={"Authorization": "Bearer no-owner-token"})
+    assert status == 403, f"Expected 403 for missing operator on DELETE schedule, got {status}"
+    check_no_observations("DELETE schedule missing operator")
+
+    print("✅ Missing operator tests passed")
+
+
 if __name__ == "__main__":
     print("Starting group-schedules contract tests...")
     try:
         test_auth_checks()
         test_local_validation()
+        test_missing_operator()
         print("🎉 All group-schedules contract tests passed!")
     except AssertionError as e:
         print(f"❌ TEST FAILED: {e}")

--- a/test_scripts/integration/test_group_schedules_contract.py
+++ b/test_scripts/integration/test_group_schedules_contract.py
@@ -1,0 +1,321 @@
+import urllib.request
+import urllib.error
+import json
+import os
+import sys
+import ssl
+
+USERPORTAL_URL = os.environ.get("USERPORTAL_URL", "http://localhost:16006")
+FAKE_URL = os.environ.get("FAKE_URL", "http://127.0.0.1:8080")
+VALID_GROUP_ID = "11111111-1111-4111-8111-111111111111"
+VALID_SCHEDULE_ID = "22222222-2222-4222-8222-222222222222"
+INVALID_UUID = "12345"
+
+HTTPS_CONTEXT = ssl._create_unverified_context()
+
+def open_url(req_or_url):
+    url = req_or_url.full_url if hasattr(req_or_url, "full_url") else req_or_url
+    if str(url).startswith("https://"):
+        return urllib.request.urlopen(req_or_url, context=HTTPS_CONTEXT)
+    return urllib.request.urlopen(req_or_url)
+
+def reset_observations():
+    req = urllib.request.Request(f"{FAKE_URL}/reset-observations", data=b"", method="POST")
+    open_url(req)
+
+def request(method, path, body=None, headers=None):
+    if headers is None:
+        headers = {"Authorization": "Bearer dummy-test-token"}
+    if body is not None:
+        body = json.dumps(body).encode("utf-8")
+        headers["Content-Type"] = "application/json"
+    req = urllib.request.Request(f"{USERPORTAL_URL}{path}", data=body, headers=headers, method=method)
+    try:
+        with open_url(req) as response:
+            res_body = response.read()
+            try:
+                return response.status, json.loads(res_body) if res_body else {}
+            except json.JSONDecodeError:
+                return response.status, res_body
+    except urllib.error.HTTPError as e:
+        res_body = e.read()
+        try:
+            return e.code, json.loads(res_body) if res_body else {}
+        except json.JSONDecodeError:
+            return e.code, res_body
+    except urllib.error.URLError as e:
+        print(f"Connection failed: {e}")
+        return 000, {}
+
+def check_no_observations(test_name):
+    with open_url(f"{FAKE_URL}/observations") as r:
+        obs = json.loads(r.read())
+        assert len(obs["calls"]) == 0, f"{test_name}: Downstream unexpectedly called: {obs['calls']}"
+
+def check_downstream_called(test_name):
+    with open_url(f"{FAKE_URL}/observations") as r:
+        obs = json.loads(r.read())
+        assert len(obs["calls"]) > 0, f"{test_name}: Request was not forwarded downstream (no calls observed)"
+
+
+# ---------------------------------------------------------------------------
+# Auth rejection tests
+# ---------------------------------------------------------------------------
+
+def test_auth_checks():
+    print("Testing Auth Rejections...")
+
+    # GET list
+    reset_observations()
+    status, _ = request("GET", f"/api/v1/groups/{VALID_GROUP_ID}/schedules", headers={})
+    assert status == 403, f"Expected 403 for missing auth on GET schedules, got {status}"
+    check_no_observations("GET group-schedules missing auth")
+
+    reset_observations()
+    status, _ = request("GET", f"/api/v1/groups/{VALID_GROUP_ID}/schedules",
+                        headers={"Authorization": "Bearer bad-token"})
+    assert status == 403, f"Expected 403 for bad auth on GET schedules, got {status}"
+    check_no_observations("GET group-schedules bad auth")
+
+    # POST
+    reset_observations()
+    status, _ = request("POST", f"/api/v1/groups/{VALID_GROUP_ID}/schedules",
+                        body={"schedule_id": VALID_SCHEDULE_ID}, headers={})
+    assert status == 403, f"Expected 403 for missing auth on POST schedules, got {status}"
+    check_no_observations("POST group-schedules missing auth")
+
+    # PUT
+    reset_observations()
+    status, _ = request("PUT", f"/api/v1/groups/{VALID_GROUP_ID}/schedules",
+                        body={"schedule_ids": [VALID_SCHEDULE_ID]}, headers={})
+    assert status == 403, f"Expected 403 for missing auth on PUT schedules, got {status}"
+    check_no_observations("PUT group-schedules missing auth")
+
+    reset_observations()
+    status, _ = request("PUT", f"/api/v1/groups/{VALID_GROUP_ID}/schedules",
+                        body={"schedule_ids": [VALID_SCHEDULE_ID]},
+                        headers={"Authorization": "Bearer bad-token"})
+    assert status == 403, f"Expected 403 for bad auth on PUT schedules, got {status}"
+    check_no_observations("PUT group-schedules bad auth")
+
+    # GET single
+    reset_observations()
+    status, _ = request("GET", f"/api/v1/groups/{VALID_GROUP_ID}/schedules/{VALID_SCHEDULE_ID}", headers={})
+    assert status == 403, f"Expected 403 for missing auth on GET single schedule, got {status}"
+    check_no_observations("GET single schedule missing auth")
+
+    reset_observations()
+    status, _ = request("GET", f"/api/v1/groups/{VALID_GROUP_ID}/schedules/{VALID_SCHEDULE_ID}",
+                        headers={"Authorization": "Bearer bad-token"})
+    assert status == 403, f"Expected 403 for bad auth on GET single schedule, got {status}"
+    check_no_observations("GET single schedule bad auth")
+
+    # DELETE
+    reset_observations()
+    status, _ = request("DELETE", f"/api/v1/groups/{VALID_GROUP_ID}/schedules/{VALID_SCHEDULE_ID}", headers={})
+    assert status == 403, f"Expected 403 for missing auth on DELETE schedule, got {status}"
+    check_no_observations("DELETE schedule missing auth")
+
+    reset_observations()
+    status, _ = request("DELETE", f"/api/v1/groups/{VALID_GROUP_ID}/schedules/{VALID_SCHEDULE_ID}",
+                        headers={"Authorization": "Bearer bad-token"})
+    assert status == 403, f"Expected 403 for bad auth on DELETE schedule, got {status}"
+    check_no_observations("DELETE schedule bad auth")
+
+    print("✅ Auth tests passed")
+
+
+# ---------------------------------------------------------------------------
+# Local validation tests — none of these should reach downstream
+# ---------------------------------------------------------------------------
+
+def test_local_validation():
+    print("Testing Local Request Validation...")
+
+    # --- GET /groups/{group_id}/schedules ---
+
+    # Invalid group UUID on GET list
+    reset_observations()
+    status, _ = request("GET", f"/api/v1/groups/{INVALID_UUID}/schedules")
+    assert status == 400, f"Expected 400 for invalid group UUID on GET schedules, got {status}"
+    check_no_observations("GET group-schedules invalid group UUID")
+
+    # Invalid group UUID on GET single schedule link
+    reset_observations()
+    status, _ = request("GET", f"/api/v1/groups/{INVALID_UUID}/schedules/{VALID_SCHEDULE_ID}")
+    assert status == 400, f"Expected 400 for invalid group UUID on GET schedule, got {status}"
+    check_no_observations("GET group-schedule invalid group UUID")
+
+    # Invalid schedule UUID on GET single
+    reset_observations()
+    status, _ = request("GET", f"/api/v1/groups/{VALID_GROUP_ID}/schedules/{INVALID_UUID}")
+    assert status == 400, f"Expected 400 for invalid schedule UUID on GET schedule, got {status}"
+    check_no_observations("GET group-schedule invalid schedule UUID")
+
+    # --- POST /groups/{group_id}/schedules ---
+
+    # Missing schedule_id
+    reset_observations()
+    status, _ = request("POST", f"/api/v1/groups/{VALID_GROUP_ID}/schedules", body={})
+    assert status == 400, f"Expected 400 for missing schedule_id, got {status}"
+    check_no_observations("POST group-schedules missing schedule_id")
+
+    # Null schedule_id
+    reset_observations()
+    status, _ = request("POST", f"/api/v1/groups/{VALID_GROUP_ID}/schedules",
+                        body={"schedule_id": None})
+    assert status == 400, f"Expected 400 for null schedule_id, got {status}"
+    check_no_observations("POST group-schedules null schedule_id")
+
+    # Non-UUID schedule_id
+    reset_observations()
+    status, _ = request("POST", f"/api/v1/groups/{VALID_GROUP_ID}/schedules",
+                        body={"schedule_id": INVALID_UUID})
+    assert status == 400, f"Expected 400 for non-UUID schedule_id, got {status}"
+    check_no_observations("POST group-schedules non-UUID schedule_id")
+
+    # Unknown field in body
+    reset_observations()
+    status, _ = request("POST", f"/api/v1/groups/{VALID_GROUP_ID}/schedules",
+                        body={"schedule_id": VALID_SCHEDULE_ID, "extra": "bad"})
+    assert status == 400, f"Expected 400 for unknown field on POST schedules, got {status}"
+    check_no_observations("POST group-schedules unknown field")
+
+    # Missing body entirely
+    reset_observations()
+    req = urllib.request.Request(
+        f"{USERPORTAL_URL}/api/v1/groups/{VALID_GROUP_ID}/schedules",
+        headers={"Authorization": "Bearer dummy-test-token", "Content-Type": "application/json"},
+        method="POST"
+    )
+    try:
+        with open_url(req) as response:
+            status = response.status
+    except urllib.error.HTTPError as e:
+        status = e.code
+    assert status == 400, f"Expected 400 for POST with missing body, got {status}"
+    check_no_observations("POST group-schedules missing body")
+
+    # Malformed JSON
+    reset_observations()
+    req = urllib.request.Request(
+        f"{USERPORTAL_URL}/api/v1/groups/{VALID_GROUP_ID}/schedules",
+        data=b"{bad-json",
+        headers={"Authorization": "Bearer dummy-test-token", "Content-Type": "application/json"},
+        method="POST"
+    )
+    try:
+        with open_url(req) as response:
+            status = response.status
+    except urllib.error.HTTPError as e:
+        status = e.code
+    assert status == 400, f"Expected 400 for POST malformed JSON, got {status}"
+    check_no_observations("POST group-schedules malformed JSON")
+
+    # --- PUT /groups/{group_id}/schedules ---
+
+    # Invalid group UUID on PUT
+    reset_observations()
+    status, _ = request("PUT", f"/api/v1/groups/{INVALID_UUID}/schedules",
+                        body={"schedule_ids": [VALID_SCHEDULE_ID]})
+    assert status == 400, f"Expected 400 for invalid group UUID on PUT schedules, got {status}"
+    check_no_observations("PUT group-schedules invalid group UUID")
+
+    # Missing schedule_ids
+    reset_observations()
+    status, _ = request("PUT", f"/api/v1/groups/{VALID_GROUP_ID}/schedules", body={})
+    assert status == 400, f"Expected 400 for missing schedule_ids on PUT, got {status}"
+    check_no_observations("PUT group-schedules missing schedule_ids")
+
+    # Null schedule_ids
+    reset_observations()
+    status, _ = request("PUT", f"/api/v1/groups/{VALID_GROUP_ID}/schedules",
+                        body={"schedule_ids": None})
+    assert status == 400, f"Expected 400 for null schedule_ids on PUT, got {status}"
+    check_no_observations("PUT group-schedules null schedule_ids")
+
+    # Non-array schedule_ids
+    reset_observations()
+    status, _ = request("PUT", f"/api/v1/groups/{VALID_GROUP_ID}/schedules",
+                        body={"schedule_ids": VALID_SCHEDULE_ID})
+    assert status == 400, f"Expected 400 for non-array schedule_ids on PUT, got {status}"
+    check_no_observations("PUT group-schedules non-array schedule_ids")
+
+    # Non-UUID entry in schedule_ids
+    reset_observations()
+    status, _ = request("PUT", f"/api/v1/groups/{VALID_GROUP_ID}/schedules",
+                        body={"schedule_ids": [INVALID_UUID]})
+    assert status == 400, f"Expected 400 for non-UUID entry in schedule_ids, got {status}"
+    check_no_observations("PUT group-schedules non-UUID entry")
+
+    # Duplicate UUIDs in schedule_ids
+    reset_observations()
+    status, _ = request("PUT", f"/api/v1/groups/{VALID_GROUP_ID}/schedules",
+                        body={"schedule_ids": [VALID_SCHEDULE_ID, VALID_SCHEDULE_ID]})
+    assert status == 400, f"Expected 400 for duplicate UUIDs in schedule_ids, got {status}"
+    check_no_observations("PUT group-schedules duplicate UUIDs")
+
+    # Unknown field in PUT body
+    reset_observations()
+    status, _ = request("PUT", f"/api/v1/groups/{VALID_GROUP_ID}/schedules",
+                        body={"schedule_ids": [VALID_SCHEDULE_ID], "extra": "bad"})
+    assert status == 400, f"Expected 400 for unknown field on PUT schedules, got {status}"
+    check_no_observations("PUT group-schedules unknown field")
+
+    # Missing body on PUT
+    reset_observations()
+    req = urllib.request.Request(
+        f"{USERPORTAL_URL}/api/v1/groups/{VALID_GROUP_ID}/schedules",
+        headers={"Authorization": "Bearer dummy-test-token", "Content-Type": "application/json"},
+        method="PUT"
+    )
+    try:
+        with open_url(req) as response:
+            status = response.status
+    except urllib.error.HTTPError as e:
+        status = e.code
+    assert status == 400, f"Expected 400 for PUT with missing body, got {status}"
+    check_no_observations("PUT group-schedules missing body")
+
+    # Malformed JSON on PUT
+    reset_observations()
+    req = urllib.request.Request(
+        f"{USERPORTAL_URL}/api/v1/groups/{VALID_GROUP_ID}/schedules",
+        data=b"{bad-json",
+        headers={"Authorization": "Bearer dummy-test-token", "Content-Type": "application/json"},
+        method="PUT"
+    )
+    try:
+        with open_url(req) as response:
+            status = response.status
+    except urllib.error.HTTPError as e:
+        status = e.code
+    assert status == 400, f"Expected 400 for PUT malformed JSON, got {status}"
+    check_no_observations("PUT group-schedules malformed JSON")
+
+    # --- DELETE /groups/{group_id}/schedules/{schedule_id} ---
+
+    # Invalid group UUID on DELETE
+    reset_observations()
+    status, _ = request("DELETE", f"/api/v1/groups/{INVALID_UUID}/schedules/{VALID_SCHEDULE_ID}")
+    assert status == 400, f"Expected 400 for invalid group UUID on DELETE schedule, got {status}"
+    check_no_observations("DELETE group-schedule invalid group UUID")
+
+    # Invalid schedule UUID on DELETE
+    reset_observations()
+    status, _ = request("DELETE", f"/api/v1/groups/{VALID_GROUP_ID}/schedules/{INVALID_UUID}")
+    assert status == 400, f"Expected 400 for invalid schedule UUID on DELETE schedule, got {status}"
+    check_no_observations("DELETE group-schedule invalid schedule UUID")
+
+    print("✅ Local validation tests passed")
+
+
+if __name__ == "__main__":
+    print("Starting group-schedules contract tests...")
+    try:
+        test_auth_checks()
+        test_local_validation()
+        print("🎉 All group-schedules contract tests passed!")
+    except AssertionError as e:
+        print(f"❌ TEST FAILED: {e}")
+        sys.exit(1)

--- a/test_scripts/integration/test_groups_api.py
+++ b/test_scripts/integration/test_groups_api.py
@@ -96,6 +96,11 @@ def test_put_groups():
     # Verify update persisted
     status, read_body = request("GET", f"/api/v1/groups/{CREATED_GROUP_ID}")
     assert read_body.get("name") == "updated-group", "GET after PUT did not return updated name"
+
+    # PUT with description omitted (description is optional) — must also succeed
+    status, body = request("PUT", f"/api/v1/groups/{CREATED_GROUP_ID}", body={"name": "name-only-update"})
+    assert status == 200, f"Expected 200 for PUT with name only (no description), got {status}. Body: {body}"
+    assert body.get("name") == "name-only-update", f"Expected updated name. Body: {body}"
     print("✅ PUT /groups passed")
 
 def test_delete_groups_normal():

--- a/test_scripts/integration/test_groups_contract.py
+++ b/test_scripts/integration/test_groups_contract.py
@@ -51,6 +51,11 @@ def check_no_observations(test_name):
         obs = json.loads(r.read())
         assert len(obs["calls"]) == 0, f"{test_name}: Downstream services were unexpectedly called: {obs['calls']}"
 
+def check_downstream_called(test_name):
+    with open_url(f"{FAKE_URL}/observations") as r:
+        obs = json.loads(r.read())
+        assert len(obs["calls"]) > 0, f"{test_name}: Request was not forwarded downstream (no calls observed)"
+
 def test_auth_checks():
     print("Testing Auth Rejections...")
     # Missing auth
@@ -110,11 +115,19 @@ def test_local_validation():
     assert status == 400, f"Expected 400 for malformed POST json, got {status}"
     check_no_observations("POST malformed json")
 
-    # G) PUT missing description
+    # G) PUT with only name (description is optional) — must be forwarded downstream, not rejected locally
+    # VALID_GROUP_ID does not exist in the fake DB, so downstream returns 404.
+    # A 404 from downstream is proof the request passed local validation and was forwarded.
     reset_observations()
     status, _ = request("PUT", f"/api/v1/groups/{VALID_GROUP_ID}", body={"name":"test"})
-    assert status == 400, f"Expected 400 for missing description on PUT, got {status}"
-    check_no_observations("PUT missing description")
+    assert status == 404, f"Expected 404 (forwarded to downstream, group not found), got {status}"
+    check_downstream_called("PUT with only name (description is optional)")
+
+    # G2) PUT with invalid description type (integer) — must still be rejected locally with 400
+    reset_observations()
+    status, _ = request("PUT", f"/api/v1/groups/{VALID_GROUP_ID}", body={"name":"test", "description": 123})
+    assert status == 400, f"Expected 400 for invalid description type on PUT, got {status}"
+    check_no_observations("PUT invalid description type")
     
     # H) PUT unknown field
     reset_observations()

--- a/test_scripts/integration/test_groups_contract.py
+++ b/test_scripts/integration/test_groups_contract.py
@@ -20,6 +20,12 @@ def open_url(req_or_url):
 def reset_observations():
     req = urllib.request.Request(f"{FAKE_URL}/reset-observations", data=b"", method="POST")
     open_url(req)
+    req2 = urllib.request.Request(
+        f"{FAKE_URL}/set-scenario",
+        data=json.dumps({"scenario": "normal"}).encode(),
+        method="POST"
+    )
+    open_url(req2)
 
 def request(method, path, body=None, headers=None):
     if headers is None:
@@ -55,6 +61,11 @@ def check_downstream_called(test_name):
     with open_url(f"{FAKE_URL}/observations") as r:
         obs = json.loads(r.read())
         assert len(obs["calls"]) > 0, f"{test_name}: Request was not forwarded downstream (no calls observed)"
+
+def get_observations():
+    with open_url(f"{FAKE_URL}/observations") as r:
+        obs = json.loads(r.read())
+        return obs["calls"]
 
 def test_auth_checks():
     print("Testing Auth Rejections...")
@@ -170,11 +181,79 @@ def test_local_validation():
 
     print("✅ Local validation tests passed")
 
+def test_forwarded_payloads():
+    print("Testing Group Forwarded Downstream Payloads...")
+
+    # Case 1: POST /api/v1/groups with description omitted
+    reset_observations()
+    status, res = request("POST", "/api/v1/groups", body={"name": "Omitted desc group"})
+    assert status == 200, f"Expected 200, got {status}"
+    group_id = res.get("id")
+    assert group_id is not None
+    calls = get_observations()
+    post_calls = [c for c in calls if c["method"] == "POST" and "/groups" in c["path"]]
+    assert len(post_calls) > 0
+    body = post_calls[0].get("body", {})
+    assert "description" not in body, f"description should be omitted in downstream payload: {body}"
+
+    # Case 2: POST /api/v1/groups with description: null
+    reset_observations()
+    status, _ = request("POST", "/api/v1/groups", body={"name": "Null desc group", "description": None})
+    assert status == 200, f"Expected 200, got {status}"
+    calls = get_observations()
+    post_calls = [c for c in calls if c["method"] == "POST" and "/groups" in c["path"]]
+    assert len(post_calls) > 0
+    body = post_calls[0].get("body", {})
+    assert "description" in body and body["description"] is None, f"description should be explicitly null in downstream payload: {body}"
+
+    # Case 3: POST /api/v1/groups with description string
+    reset_observations()
+    status, _ = request("POST", "/api/v1/groups", body={"name": "String desc group", "description": "some description"})
+    assert status == 200, f"Expected 200, got {status}"
+    calls = get_observations()
+    post_calls = [c for c in calls if c["method"] == "POST" and "/groups" in c["path"]]
+    assert len(post_calls) > 0
+    body = post_calls[0].get("body", {})
+    assert body.get("description") == "some description", f"description should match: {body}"
+
+    # Case 4: PUT /api/v1/groups/{id} with description omitted
+    reset_observations()
+    status, _ = request("PUT", f"/api/v1/groups/{group_id}", body={"name": "Updated name"})
+    assert status == 200, f"Expected 200, got {status}"
+    calls = get_observations()
+    put_calls = [c for c in calls if c["method"] == "PUT" and f"/groups/{group_id}" in c["path"]]
+    assert len(put_calls) > 0
+    body = put_calls[0].get("body", {})
+    assert "description" not in body, f"description should be omitted in downstream PUT payload: {body}"
+
+    # Case 5: PUT /api/v1/groups/{id} with description: null
+    reset_observations()
+    status, _ = request("PUT", f"/api/v1/groups/{group_id}", body={"name": "Updated name", "description": None})
+    assert status == 200, f"Expected 200, got {status}"
+    calls = get_observations()
+    put_calls = [c for c in calls if c["method"] == "PUT" and f"/groups/{group_id}" in c["path"]]
+    assert len(put_calls) > 0
+    body = put_calls[0].get("body", {})
+    assert "description" in body and body["description"] is None, f"description should be null in downstream PUT payload: {body}"
+
+    # Case 6: PUT /api/v1/groups/{id} with description string
+    reset_observations()
+    status, _ = request("PUT", f"/api/v1/groups/{group_id}", body={"name": "Updated name", "description": "new description"})
+    assert status == 200, f"Expected 200, got {status}"
+    calls = get_observations()
+    put_calls = [c for c in calls if c["method"] == "PUT" and f"/groups/{group_id}" in c["path"]]
+    assert len(put_calls) > 0
+    body = put_calls[0].get("body", {})
+    assert body.get("description") == "new description", f"description should match: {body}"
+
+    print("✅ Group forwarded payload tests passed")
+
 if __name__ == "__main__":
     print("Starting contract tests...")
     try:
         test_auth_checks()
         test_local_validation()
+        test_forwarded_payloads()
         print("🎉 All contract tests passed!")
     except AssertionError as e:
         print(f"❌ TEST FAILED: {e}")

--- a/test_scripts/integration/test_schedules_api.py
+++ b/test_scripts/integration/test_schedules_api.py
@@ -81,7 +81,26 @@ def test_post_schedules():
     assert "start_minute" not in body
     assert "stop_minute" not in body
     CREATED_SCHEDULE_ID = body["id"]
-    print(f"✅ POST /schedules passed, created ID: {CREATED_SCHEDULE_ID}")
+    print(f"\u2705 POST /schedules passed, created ID: {CREATED_SCHEDULE_ID}")
+
+def test_post_schedules_internet_no_target_value():
+    """INTERNET schedules with target_value omitted entirely must be accepted."""
+    print("Testing POST /schedules INTERNET without target_value key...")
+    payload = {
+        "name": "internet-no-tv",
+        "action_type": "BLOCK",
+        "target_kind": "INTERNET",
+        "start_time": "10:00",
+        "stop_time": "20:00",
+        "weekdays": [0]
+    }
+    status, body = request("POST", "/api/v1/schedules", body=payload)
+    assert status == 200, f"Expected 200 for INTERNET schedule without target_value, got {status}. Body: {body}"
+    assert "id" in body, f"Expected id in response. Body: {body}"
+    # Clean up immediately so this extra record does not affect subsequent stateful assertions.
+    del_status, _ = request("DELETE", f"/api/v1/schedules/{body['id']}")
+    assert del_status == 200, f"Expected 200 on cleanup delete, got {del_status}"
+    print("\u2705 POST INTERNET without target_value passed")
 
 def test_get_schedules():
     print("Testing GET /schedules stateful list...")
@@ -137,6 +156,21 @@ def test_put_schedules():
     # Verify update persisted
     status, read_body = request("GET", f"/api/v1/schedules/{CREATED_SCHEDULE_ID}")
     assert read_body.get("name") == "updated-schedule", "GET after PUT did not return updated name"
+
+    # PUT with description omitted (description is optional on PUT) — must also succeed
+    payload_no_desc = {
+        "name": "no-desc-update",
+        "enabled": True,
+        "action_type": "BLOCK",
+        "target_kind": "INTERNET",
+        "target_value": None,
+        "start_time": "09:00",
+        "stop_time": "18:00",
+        "weekdays": [1]
+    }
+    status, body = request("PUT", f"/api/v1/schedules/{CREATED_SCHEDULE_ID}", body=payload_no_desc)
+    assert status == 200, f"Expected 200 for PUT without description, got {status}. Body: {body}"
+    assert body.get("name") == "no-desc-update", f"Expected updated name. Body: {body}"
     print("✅ PUT /schedules passed")
 
 def test_delete_schedules_normal():
@@ -408,6 +442,7 @@ if __name__ == "__main__":
     try:
         reset_db()
         test_post_schedules()
+        test_post_schedules_internet_no_target_value()
         test_get_schedules()
         test_get_schedule_by_id()
         test_put_schedules()

--- a/test_scripts/integration/test_schedules_contract.py
+++ b/test_scripts/integration/test_schedules_contract.py
@@ -20,6 +20,12 @@ def open_url(req_or_url):
 def reset_observations():
     req = urllib.request.Request(f"{FAKE_URL}/reset-observations", data=b"", method="POST")
     open_url(req)
+    req2 = urllib.request.Request(
+        f"{FAKE_URL}/set-scenario",
+        data=json.dumps({"scenario": "normal"}).encode(),
+        method="POST"
+    )
+    open_url(req2)
 
 def request(method, path, body=None, headers=None):
     if headers is None:
@@ -55,6 +61,11 @@ def check_downstream_called(test_name):
     with open_url(f"{FAKE_URL}/observations") as r:
         obs = json.loads(r.read())
         assert len(obs["calls"]) > 0, f"{test_name}: Request was not forwarded downstream (no calls observed)"
+
+def get_observations():
+    with open_url(f"{FAKE_URL}/observations") as r:
+        obs = json.loads(r.read())
+        return obs["calls"]
 
 def test_auth_checks():
     print("Testing Auth Rejections...")
@@ -369,11 +380,149 @@ def test_local_validation():
 
     print("✅ Local validation tests passed")
 
+def test_forwarded_payloads():
+    print("Testing Schedule Forwarded Downstream Payloads...")
+
+    # Case 1: POST /api/v1/schedules with description and target_value omitted
+    reset_observations()
+    status, _ = request("POST", "/api/v1/schedules", body={
+        "name": "Omitted fields test",
+        "action_type": "BLOCK",
+        "target_kind": "INTERNET",
+        "start_time": "08:00",
+        "stop_time": "17:00",
+        "weekdays": [1]
+    })
+    assert status == 200, f"Expected 200, got {status}"
+    calls = get_observations()
+    assert len(calls) > 0, "No calls recorded downstream"
+    schedule_calls = [c for c in calls if c["method"] == "POST" and "/schedules" in c["path"]]
+    assert len(schedule_calls) > 0, f"No schedule creation call found in: {calls}"
+    body = schedule_calls[0].get("body", {})
+    assert "description" not in body, f"description should be omitted from downstream payload, but was: {body}"
+    assert "target_value" not in body, f"target_value should be omitted from downstream payload, but was: {body}"
+
+    # Case 2: POST /api/v1/schedules with description: null and target_value: null explicitly
+    reset_observations()
+    status, _ = request("POST", "/api/v1/schedules", body={
+        "name": "Explicit null fields test",
+        "description": None,
+        "action_type": "BLOCK",
+        "target_kind": "INTERNET",
+        "target_value": None,
+        "start_time": "08:00",
+        "stop_time": "17:00",
+        "weekdays": [1]
+    })
+    assert status == 200, f"Expected 200, got {status}"
+    calls = get_observations()
+    schedule_calls = [c for c in calls if c["method"] == "POST" and "/schedules" in c["path"]]
+    assert len(schedule_calls) > 0
+    body = schedule_calls[0].get("body", {})
+    assert "description" in body and body["description"] is None, f"description should be explicitly null in downstream payload, but was: {body}"
+    assert "target_value" in body and body["target_value"] is None, f"target_value should be explicitly null in downstream payload, but was: {body}"
+
+    # Case 3: POST /api/v1/schedules with description as string
+    reset_observations()
+    status, _ = request("POST", "/api/v1/schedules", body={
+        "name": "String desc test",
+        "description": "My test schedule",
+        "action_type": "BLOCK",
+        "target_kind": "INTERNET",
+        "start_time": "08:00",
+        "stop_time": "17:00",
+        "weekdays": [1]
+    })
+    assert status == 200, f"Expected 200, got {status}"
+    calls = get_observations()
+    schedule_calls = [c for c in calls if c["method"] == "POST" and "/schedules" in c["path"]]
+    assert len(schedule_calls) > 0
+    body = schedule_calls[0].get("body", {})
+    assert body.get("description") == "My test schedule", f"description should be 'My test schedule', but was: {body}"
+    assert "target_value" not in body, f"target_value should be omitted, but was: {body}"
+
+    # Case 4: PUT /api/v1/schedules/{id} with description and target_value omitted
+    reset_observations()
+    status, res = request("POST", "/api/v1/schedules", body={
+        "name": "For PUT test",
+        "description": "desc",
+        "action_type": "BLOCK",
+        "target_kind": "INTERNET",
+        "start_time": "08:00",
+        "stop_time": "17:00",
+        "weekdays": [1]
+    })
+    assert status == 200, f"Expected 200, got {status}"
+    sched_id = res.get("id")
+    assert sched_id is not None, f"POST response should contain id: {res}"
+
+    reset_observations()
+    status, _ = request("PUT", f"/api/v1/schedules/{sched_id}", body={
+        "name": "Updated name",
+        "enabled": True,
+        "action_type": "BLOCK",
+        "target_kind": "INTERNET",
+        "start_time": "09:00",
+        "stop_time": "18:00",
+        "weekdays": [2]
+    })
+    assert status == 200, f"Expected 200 for PUT, got {status}"
+    calls = get_observations()
+    put_calls = [c for c in calls if c["method"] == "PUT" and f"/schedules/{sched_id}" in c["path"]]
+    assert len(put_calls) > 0, f"No PUT call found: {calls}"
+    body = put_calls[0].get("body", {})
+    assert "description" not in body, f"description should be omitted from downstream PUT payload, but was: {body}"
+    assert "target_value" not in body, f"target_value should be omitted from downstream PUT payload, but was: {body}"
+
+    # Case 5: PUT /api/v1/schedules/{id} with description: null and target_value: null explicitly
+    reset_observations()
+    status, _ = request("PUT", f"/api/v1/schedules/{sched_id}", body={
+        "name": "Updated name",
+        "description": None,
+        "enabled": True,
+        "action_type": "BLOCK",
+        "target_kind": "INTERNET",
+        "target_value": None,
+        "start_time": "09:00",
+        "stop_time": "18:00",
+        "weekdays": [2]
+    })
+    assert status == 200, f"Expected 200 for PUT, got {status}"
+    calls = get_observations()
+    put_calls = [c for c in calls if c["method"] == "PUT" and f"/schedules/{sched_id}" in c["path"]]
+    assert len(put_calls) > 0
+    body = put_calls[0].get("body", {})
+    assert "description" in body and body["description"] is None, f"description should be null in downstream PUT payload, but was: {body}"
+    assert "target_value" in body and body["target_value"] is None, f"target_value should be null in downstream PUT payload, but was: {body}"
+
+    # Case 6: PUT /api/v1/schedules/{id} with description string and target_value omitted
+    reset_observations()
+    status, _ = request("PUT", f"/api/v1/schedules/{sched_id}", body={
+        "name": "Updated name",
+        "description": "Updated string description",
+        "enabled": True,
+        "action_type": "BLOCK",
+        "target_kind": "INTERNET",
+        "start_time": "09:00",
+        "stop_time": "18:00",
+        "weekdays": [2]
+    })
+    assert status == 200, f"Expected 200 for PUT, got {status}"
+    calls = get_observations()
+    put_calls = [c for c in calls if c["method"] == "PUT" and f"/schedules/{sched_id}" in c["path"]]
+    assert len(put_calls) > 0
+    body = put_calls[0].get("body", {})
+    assert body.get("description") == "Updated string description", f"description should be updated description, but was: {body}"
+    assert "target_value" not in body, f"target_value should be omitted in downstream PUT payload, but was: {body}"
+
+    print("✅ Schedule forwarded payload tests passed")
+
 if __name__ == "__main__":
     print("Starting schedules contract tests...")
     try:
         test_auth_checks()
         test_local_validation()
+        test_forwarded_payloads()
         print("🎉 All contract tests passed!")
     except AssertionError as e:
         print(f"❌ TEST FAILED: {e}")

--- a/test_scripts/integration/test_schedules_contract.py
+++ b/test_scripts/integration/test_schedules_contract.py
@@ -51,6 +51,11 @@ def check_no_observations(test_name):
         obs = json.loads(r.read())
         assert len(obs["calls"]) == 0, f"{test_name}: Downstream services were unexpectedly called: {obs['calls']}"
 
+def check_downstream_called(test_name):
+    with open_url(f"{FAKE_URL}/observations") as r:
+        obs = json.loads(r.read())
+        assert len(obs["calls"]) > 0, f"{test_name}: Request was not forwarded downstream (no calls observed)"
+
 def test_auth_checks():
     print("Testing Auth Rejections...")
     reset_observations()
@@ -154,7 +159,17 @@ def test_local_validation():
     assert status == 400, f"Expected 400 for missing target_kind, got {status}"
     check_no_observations("POST missing target_kind")
 
-    # POST APP target without target_value
+    # POST APP target without target_value (missing key entirely) — must reject
+    reset_observations()
+    status, _ = request("POST", "/api/v1/schedules", body={
+        "name": "test", "description": "desc", "action_type": "BLOCK",
+        "target_kind": "APP",
+        "start_time": "08:00", "stop_time": "17:00", "weekdays": [1]
+    })
+    assert status == 400, f"Expected 400 for APP schedule with missing target_value, got {status}"
+    check_no_observations("POST APP target with missing target_value")
+
+    # POST APP target with null target_value — must reject
     reset_observations()
     status, _ = request("POST", "/api/v1/schedules", body={
         "name": "test", "description": "desc", "action_type": "BLOCK",
@@ -174,7 +189,7 @@ def test_local_validation():
     assert status == 400, f"Expected 400 for APP schedule with empty target_value, got {status}"
     check_no_observations("POST APP target with empty target_value")
 
-    # POST INTERNET target with non-null target_value
+    # POST INTERNET target with non-null target_value — must reject
     reset_observations()
     status, _ = request("POST", "/api/v1/schedules", body={
         "name": "test", "description": "desc", "action_type": "BLOCK",
@@ -183,6 +198,17 @@ def test_local_validation():
     })
     assert status == 400, f"Expected 400 for INTERNET schedule with non-null target_value, got {status}"
     check_no_observations("POST INTERNET target with non-null target_value")
+
+    # POST INTERNET target with target_value omitted entirely — must be forwarded downstream, not rejected locally.
+    # The fake server creates the schedule and returns 200, proving local validation passed.
+    reset_observations()
+    status, _ = request("POST", "/api/v1/schedules", body={
+        "name": "test", "description": "desc", "action_type": "BLOCK",
+        "target_kind": "INTERNET",
+        "start_time": "08:00", "stop_time": "17:00", "weekdays": [1]
+    })
+    assert status == 200, f"Expected 200 for INTERNET schedule without target_value key, got {status}"
+    check_downstream_called("POST INTERNET without target_value (forwarded)")
 
     # POST invalid start_time format
     reset_observations()
@@ -265,15 +291,27 @@ def test_local_validation():
     assert status == 400, f"Expected 400 for malformed POST json, got {status}"
     check_no_observations("POST malformed json")
 
-    # PUT missing description
+    # PUT with description omitted — must be forwarded downstream, not rejected locally.
+    # VALID_SCHEDULE_ID does not exist in the fake DB, so downstream returns 404.
+    # A 404 from downstream is proof the request passed local validation and was forwarded.
     reset_observations()
     status, _ = request("PUT", f"/api/v1/schedules/{VALID_SCHEDULE_ID}", body={
         "name": "test", "enabled": True, "action_type": "BLOCK",
         "target_kind": "INTERNET", "target_value": None,
         "start_time": "08:00", "stop_time": "17:00", "weekdays": [1]
     })
-    assert status == 400, f"Expected 400 for missing description on PUT, got {status}"
-    check_no_observations("PUT missing description")
+    assert status == 404, f"Expected 404 (forwarded to downstream, schedule not found), got {status}"
+    check_downstream_called("PUT without description (forwarded)")
+
+    # PUT with invalid description type — must still reject
+    reset_observations()
+    status, _ = request("PUT", f"/api/v1/schedules/{VALID_SCHEDULE_ID}", body={
+        "name": "test", "description": 999, "enabled": True, "action_type": "BLOCK",
+        "target_kind": "INTERNET", "target_value": None,
+        "start_time": "08:00", "stop_time": "17:00", "weekdays": [1]
+    })
+    assert status == 400, f"Expected 400 for invalid description type on PUT, got {status}"
+    check_no_observations("PUT invalid description type")
 
     # PUT missing enabled
     reset_observations()

--- a/tests/unit/test_group_devices_handlers.cpp
+++ b/tests/unit/test_group_devices_handlers.cpp
@@ -1,0 +1,541 @@
+/*
+ * SPDX-License-Identifier: AGPL-3.0 OR LicenseRef-Commercial
+ * Copyright (c) 2025 Infernet Systems Pvt Ltd
+ * Portions copyright (c) Telecom Infra Project (TIP), BSD-3-Clause
+ */
+
+#include <algorithm>
+#include <cctype>
+#include <functional>
+#include <iostream>
+#include <sstream>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+#include "Poco/JSON/Array.h"
+#include "Poco/JSON/Object.h"
+#include "Poco/JSON/Parser.h"
+#include "Poco/Logger.h"
+#include "Poco/Net/HTTPServerParams.h"
+#include "Poco/Net/SocketAddress.h"
+#include "RESTAPI/RESTAPI_group_devices_handler.h"
+#include "RESTAPI/RESTAPI_group_devices_list_handler.h"
+#include "RESTAPI/RESTAPI_parental_control_utils.h"
+#include "framework/RESTAPI_GenericServerAccounting.h"
+#include "sdks/SDK_parental_control.h"
+
+namespace {
+
+const std::string kValidGroupId = "11111111-1111-4111-8111-111111111111";
+const std::string kInvalidGroupId = "bad-group-id";
+const std::string kValidMac = "AA:BB:CC:DD:EE:FF";
+const std::string kInvalidMac = "invalid-mac";
+
+class TestFailure : public std::runtime_error {
+  public:
+    using std::runtime_error::runtime_error;
+};
+
+void Expect(bool condition, const std::string &message) {
+    if (!condition) {
+        throw TestFailure(message);
+    }
+}
+
+template <typename T, typename U> void ExpectEq(const T &actual, const U &expected, const std::string &message) {
+    if (!(actual == expected)) {
+        std::ostringstream os;
+        os << message << " expected=" << expected << " actual=" << actual;
+        throw TestFailure(os.str());
+    }
+}
+
+std::string StripMac(const std::string &value) {
+    std::string result;
+    for (char c : value) {
+        if (c == ':' || c == '-' || c == '.') {
+            continue;
+        }
+        result.push_back(static_cast<char>(std::toupper(static_cast<unsigned char>(c))));
+    }
+    return result;
+}
+
+bool IsNormalizedMac(const std::string &value) {
+    if (value.size() != 12) {
+        return false;
+    }
+    return std::all_of(value.begin(), value.end(), [](unsigned char c) { return std::isxdigit(c) != 0; });
+}
+
+std::string MacWithColons(const std::string &value) {
+    std::ostringstream os;
+    for (std::size_t i = 0; i < value.size(); i += 2) {
+        if (i != 0) {
+            os << ':';
+        }
+        os << value.substr(i, 2);
+    }
+    return os.str();
+}
+
+class FakeHTTPServerParams final : public Poco::Net::HTTPServerParams {
+  public:
+    ~FakeHTTPServerParams() override = default;
+};
+
+class FakeResponse final : public Poco::Net::HTTPServerResponse {
+  public:
+    void sendContinue() override {}
+
+    std::ostream &send() override {
+        sent_ = true;
+        return body_;
+    }
+
+    void sendFile(const std::string &, const std::string &) override { sent_ = true; }
+
+    void sendBuffer(const void *buffer, std::size_t length) override {
+        sent_ = true;
+        body_.write(static_cast<const char *>(buffer), static_cast<std::streamsize>(length));
+    }
+
+    void redirect(const std::string &uri, HTTPStatus status = HTTP_FOUND) override {
+        setStatus(status);
+        set("Location", uri);
+        sent_ = true;
+    }
+
+    void requireAuthentication(const std::string &realm) override {
+        setStatus(HTTP_UNAUTHORIZED);
+        set("WWW-Authenticate", realm);
+        sent_ = true;
+    }
+
+    bool sent() const override { return sent_; }
+    std::string body() const { return body_.str(); }
+
+  private:
+    bool sent_ = false;
+    std::ostringstream body_;
+};
+
+class FakeRequest final : public Poco::Net::HTTPServerRequest {
+  public:
+    FakeRequest(const std::string &method, const std::string &uri, const std::string &body, FakeResponse &response)
+        : bodyStream_(body), response_(response), clientAddress_("127.0.0.1", 1111), serverAddress_("127.0.0.1", 16006) {
+        setMethod(method);
+        setURI(uri);
+        setVersion(Poco::Net::HTTPMessage::HTTP_1_1);
+        if (!body.empty()) {
+            setContentType("application/json");
+            setContentLength(static_cast<int>(body.size()));
+        }
+    }
+
+    std::istream &stream() override { return bodyStream_; }
+    const Poco::Net::SocketAddress &clientAddress() const override { return clientAddress_; }
+    const Poco::Net::SocketAddress &serverAddress() const override { return serverAddress_; }
+    const Poco::Net::HTTPServerParams &serverParams() const override { return params_; }
+    Poco::Net::HTTPServerResponse &response() const override { return response_; }
+    bool secure() const override { return false; }
+
+  private:
+    std::istringstream bodyStream_;
+    FakeResponse &response_;
+    Poco::Net::SocketAddress clientAddress_;
+    Poco::Net::SocketAddress serverAddress_;
+    FakeHTTPServerParams params_;
+};
+
+struct DeviceHandlerState {
+    bool getListOk = true;
+    Poco::Net::HTTPResponse::HTTPStatus getListStatus = Poco::Net::HTTPResponse::HTTP_OK;
+    Poco::JSON::Array::Ptr getListArray = Poco::JSON::Array::Ptr(new Poco::JSON::Array());
+    Poco::JSON::Object::Ptr getListError = Poco::JSON::Object::Ptr(new Poco::JSON::Object());
+
+    bool createOk = true;
+    Poco::Net::HTTPResponse::HTTPStatus createStatus = Poco::Net::HTTPResponse::HTTP_OK;
+    Poco::JSON::Object::Ptr createResponse = Poco::JSON::Object::Ptr(new Poco::JSON::Object());
+
+    bool getSingleOk = true;
+    Poco::Net::HTTPResponse::HTTPStatus getSingleStatus = Poco::Net::HTTPResponse::HTTP_OK;
+    Poco::JSON::Object::Ptr getSingleResponse = Poco::JSON::Object::Ptr(new Poco::JSON::Object());
+
+    bool deleteOk = true;
+    Poco::Net::HTTPResponse::HTTPStatus deleteStatus = Poco::Net::HTTPResponse::HTTP_OK;
+    Poco::JSON::Object::Ptr deleteResponse = Poco::JSON::Object::Ptr(new Poco::JSON::Object());
+    std::string deleteRawBody = "{\"config-raw\":[]}";
+
+    OpenWifi::RESTAPI::ParentalControl::ValidateMacResult validateResult =
+        OpenWifi::RESTAPI::ParentalControl::ValidateMacResult::Success;
+    std::string validateGatewaySerial = "GW-123";
+    bool extractConfigRawOk = true;
+    Poco::JSON::Array::Ptr extractedConfigRaw = Poco::JSON::Array::Ptr(new Poco::JSON::Array());
+    OpenWifi::RESTAPI::ParentalControl::ApplyConfigRawResult applyResult =
+        OpenWifi::RESTAPI::ParentalControl::ApplyConfigRawResult::Applied;
+
+    int validateCalls = 0;
+    int createCalls = 0;
+    int deleteCalls = 0;
+    std::string lastSubscriberId;
+    std::string lastGroupId;
+    std::string lastClientMac;
+    std::string lastGatewaySerial;
+};
+
+DeviceHandlerState g_state;
+
+void ResetState() {
+    g_state = DeviceHandlerState{};
+    g_state.getListArray = Poco::JSON::Array::Ptr(new Poco::JSON::Array());
+    g_state.getListError = Poco::JSON::Object::Ptr(new Poco::JSON::Object());
+    g_state.createResponse = Poco::JSON::Object::Ptr(new Poco::JSON::Object());
+    g_state.getSingleResponse = Poco::JSON::Object::Ptr(new Poco::JSON::Object());
+    g_state.deleteResponse = Poco::JSON::Object::Ptr(new Poco::JSON::Object());
+    g_state.extractedConfigRaw = Poco::JSON::Array::Ptr(new Poco::JSON::Array());
+}
+
+Poco::JSON::Object::Ptr ParseObject(const std::string &body) {
+    Poco::JSON::Parser parser;
+    return parser.parse(body).extract<Poco::JSON::Object::Ptr>();
+}
+
+Poco::JSON::Array::Ptr ParseArray(const std::string &body) {
+    Poco::JSON::Parser parser;
+    return parser.parse(body).extract<Poco::JSON::Array::Ptr>();
+}
+
+class TestGroupDevicesListHandler final : public OpenWifi::RESTAPI_group_devices_list_handler {
+  public:
+    using OpenWifi::RESTAPI_group_devices_list_handler::RESTAPI_group_devices_list_handler;
+
+    void setParsedBody(const Poco::JSON::Object::Ptr &body) { ParsedBody_ = body; }
+};
+
+class TestGroupDevicesHandler final : public OpenWifi::RESTAPI_group_devices_handler {
+  public:
+    using OpenWifi::RESTAPI_group_devices_handler::RESTAPI_group_devices_handler;
+};
+
+} // namespace
+
+namespace OpenWifi::RESTAPI::ParentalControl {
+
+ValidateMacResult ValidateMacInTopology(RESTAPIHandler &, const std::string &subscriberId, const std::string &,
+                                        const std::string &clientMac, std::string &gatewaySerial) {
+    ++g_state.validateCalls;
+    g_state.lastSubscriberId = subscriberId;
+    g_state.lastClientMac = clientMac;
+    gatewaySerial = g_state.validateGatewaySerial;
+    return g_state.validateResult;
+}
+
+bool HandleValidateMacResult(RESTAPIHandler &handler, ValidateMacResult result) {
+    if (result == ValidateMacResult::Success) {
+        return true;
+    }
+    if (result == ValidateMacResult::MissingSubscriberOrOperator) {
+        handler.UnAuthorized(RESTAPI::Errors::OperatorIdMustExist);
+        return false;
+    }
+    handler.BadRequest(RESTAPI::Errors::MissingOrInvalidParameters);
+    return false;
+}
+
+bool ExtractConfigRawSnapshot(const Poco::JSON::Object::Ptr &, Poco::JSON::Array::Ptr &configRaw, bool) {
+    configRaw = g_state.extractedConfigRaw;
+    return g_state.extractConfigRawOk;
+}
+
+ApplyConfigRawResult ApplyConfigRaw(RESTAPIHandler &, Poco::Logger &, const std::string &, const std::string &,
+                                    const std::string &objectId, const Poco::JSON::Array::Ptr &, const std::string &,
+                                    const std::string &, const std::string &gatewaySerial) {
+    g_state.lastGroupId = objectId;
+    g_state.lastGatewaySerial = gatewaySerial;
+    return g_state.applyResult;
+}
+
+bool HandleApplyConfigRawResult(RESTAPIHandler &handler, ApplyConfigRawResult result) {
+    if (result == ApplyConfigRawResult::Applied || result == ApplyConfigRawResult::NoConfigApplyNeeded) {
+        return true;
+    }
+    if (result == ApplyConfigRawResult::MissingOperatorId) {
+        handler.UnAuthorized(RESTAPI::Errors::OperatorIdMustExist);
+        return false;
+    }
+    handler.InternalError(RESTAPI::Errors::InternalError);
+    return false;
+}
+
+} // namespace OpenWifi::RESTAPI::ParentalControl
+
+namespace OpenWifi::SDK::ParentalControl {
+
+bool GetGroupDevices(RESTAPIHandler *, const std::string &subscriberId, const std::string &groupId,
+                     Poco::Net::HTTPResponse::HTTPStatus &callStatus, Poco::JSON::Array::Ptr &arrayResponse,
+                     Poco::JSON::Object::Ptr &objectResponse) {
+    g_state.lastSubscriberId = subscriberId;
+    g_state.lastGroupId = groupId;
+    callStatus = g_state.getListStatus;
+    arrayResponse = g_state.getListArray;
+    objectResponse = g_state.getListError;
+    return g_state.getListOk;
+}
+
+bool CreateGroupDevice(RESTAPIHandler *, const std::string &subscriberId, const std::string &groupId,
+                       const Poco::JSON::Object &body, Poco::Net::HTTPResponse::HTTPStatus &callStatus,
+                       Poco::JSON::Object::Ptr &callResponse) {
+    ++g_state.createCalls;
+    g_state.lastSubscriberId = subscriberId;
+    g_state.lastGroupId = groupId;
+    if (body.has("client_mac")) {
+        g_state.lastClientMac = body.getValue<std::string>("client_mac");
+    }
+    callStatus = g_state.createStatus;
+    callResponse = g_state.createResponse;
+    return g_state.createOk;
+}
+
+bool GetGroupDevice(RESTAPIHandler *, const std::string &subscriberId, const std::string &groupId,
+                    const std::string &clientMac, Poco::Net::HTTPResponse::HTTPStatus &callStatus,
+                    Poco::JSON::Object::Ptr &callResponse) {
+    g_state.lastSubscriberId = subscriberId;
+    g_state.lastGroupId = groupId;
+    g_state.lastClientMac = clientMac;
+    callStatus = g_state.getSingleStatus;
+    callResponse = g_state.getSingleResponse;
+    return g_state.getSingleOk;
+}
+
+bool DeleteGroupDevice(RESTAPIHandler *, const std::string &subscriberId, const std::string &groupId,
+                       const std::string &clientMac, Poco::Net::HTTPResponse::HTTPStatus &callStatus,
+                       Poco::JSON::Object::Ptr &callResponse, std::string &rawResponseBody) {
+    ++g_state.deleteCalls;
+    g_state.lastSubscriberId = subscriberId;
+    g_state.lastGroupId = groupId;
+    g_state.lastClientMac = clientMac;
+    callStatus = g_state.deleteStatus;
+    callResponse = g_state.deleteResponse;
+    rawResponseBody = g_state.deleteRawBody;
+    return g_state.deleteOk;
+}
+
+} // namespace OpenWifi::SDK::ParentalControl
+
+#include "../../src/RESTAPI/RESTAPI_group_devices_list_handler.cpp"
+#include "../../src/RESTAPI/RESTAPI_group_devices_handler.cpp"
+
+namespace {
+
+void TestListGetRejectsMissingSubscriberId() {
+    static OpenWifi::RESTAPI_GenericServerAccounting server;
+    auto &logger = Poco::Logger::get("test_group_devices_handlers");
+    TestGroupDevicesListHandler handler({{"group_id", kValidGroupId}}, logger, server, 1, false);
+    FakeResponse response;
+    FakeRequest request(Poco::Net::HTTPRequest::HTTP_GET, "/api/v1/groups/x/devices", "", response);
+    handler.Request = &request;
+    handler.Response = &response;
+
+    handler.DoGet();
+    ExpectEq(static_cast<int>(response.getStatus()), static_cast<int>(Poco::Net::HTTPResponse::HTTP_FORBIDDEN),
+             "missing subscriber should return 403");
+}
+
+void TestListGetRejectsInvalidGroupId() {
+    static OpenWifi::RESTAPI_GenericServerAccounting server;
+    auto &logger = Poco::Logger::get("test_group_devices_handlers");
+    TestGroupDevicesListHandler handler({{"group_id", kInvalidGroupId}}, logger, server, 1, false);
+    handler.UserInfo_.userinfo.id = "subscriber-1";
+    FakeResponse response;
+    FakeRequest request(Poco::Net::HTTPRequest::HTTP_GET, "/api/v1/groups/x/devices", "", response);
+    handler.Request = &request;
+    handler.Response = &response;
+
+    handler.DoGet();
+    ExpectEq(static_cast<int>(response.getStatus()), static_cast<int>(Poco::Net::HTTPResponse::HTTP_BAD_REQUEST),
+             "invalid group id should return 400");
+}
+
+void TestListGetReturnsJSONArrayOnSuccess() {
+    auto device = Poco::JSON::Object::Ptr(new Poco::JSON::Object());
+    device->set("client_mac", kValidMac);
+    g_state.getListArray->add(device);
+
+    static OpenWifi::RESTAPI_GenericServerAccounting server;
+    auto &logger = Poco::Logger::get("test_group_devices_handlers");
+    TestGroupDevicesListHandler handler({{"group_id", kValidGroupId}}, logger, server, 1, false);
+    handler.UserInfo_.userinfo.id = "subscriber-1";
+    FakeResponse response;
+    FakeRequest request(Poco::Net::HTTPRequest::HTTP_GET, "/api/v1/groups/x/devices", "", response);
+    handler.Request = &request;
+    handler.Response = &response;
+
+    handler.DoGet();
+    auto array = ParseArray(response.body());
+    ExpectEq(array->size(), static_cast<std::size_t>(1), "GET list should return one device");
+    ExpectEq(g_state.lastGroupId, kValidGroupId, "group id should be forwarded to SDK");
+    ExpectEq(g_state.lastSubscriberId, std::string("subscriber-1"), "subscriber id should be forwarded to SDK");
+}
+
+void TestPostRejectsMissingOwner() {
+    static OpenWifi::RESTAPI_GenericServerAccounting server;
+    auto &logger = Poco::Logger::get("test_group_devices_handlers");
+    TestGroupDevicesListHandler handler({{"group_id", kValidGroupId}}, logger, server, 1, false);
+    handler.UserInfo_.userinfo.id = "subscriber-1";
+    auto body = Poco::JSON::Object::Ptr(new Poco::JSON::Object());
+    body->set("client_mac", kValidMac);
+    handler.setParsedBody(body);
+    FakeResponse response;
+    FakeRequest request(Poco::Net::HTTPRequest::HTTP_POST, "/api/v1/groups/x/devices", "{\"client_mac\":\"AA:BB:CC:DD:EE:FF\"}", response);
+    handler.Request = &request;
+    handler.Response = &response;
+
+    handler.DoPost();
+    ExpectEq(static_cast<int>(response.getStatus()), static_cast<int>(Poco::Net::HTTPResponse::HTTP_FORBIDDEN),
+             "missing owner should return 403");
+}
+
+void TestPostRejectsInvalidClientMac() {
+    static OpenWifi::RESTAPI_GenericServerAccounting server;
+    auto &logger = Poco::Logger::get("test_group_devices_handlers");
+    TestGroupDevicesListHandler handler({{"group_id", kValidGroupId}}, logger, server, 1, false);
+    handler.UserInfo_.userinfo.id = "subscriber-1";
+    handler.UserInfo_.userinfo.owner = "operator-1";
+    auto body = Poco::JSON::Object::Ptr(new Poco::JSON::Object());
+    body->set("client_mac", kInvalidMac);
+    handler.setParsedBody(body);
+    FakeResponse response;
+    FakeRequest request(Poco::Net::HTTPRequest::HTTP_POST, "/api/v1/groups/x/devices", "{\"client_mac\":\"invalid\"}", response);
+    handler.Request = &request;
+    handler.Response = &response;
+
+    handler.DoPost();
+    ExpectEq(static_cast<int>(response.getStatus()), static_cast<int>(Poco::Net::HTTPResponse::HTTP_BAD_REQUEST),
+             "invalid client_mac should return 400");
+    ExpectEq(g_state.validateCalls, 0, "topology validation should not run for invalid MAC");
+    ExpectEq(g_state.createCalls, 0, "SDK create should not run for invalid MAC");
+}
+
+void TestPostStripsConfigRawAndReturnsObject() {
+    auto responseObject = Poco::JSON::Object::Ptr(new Poco::JSON::Object());
+    responseObject->set("client_mac", kValidMac);
+    responseObject->set("config-raw", Poco::JSON::Array::Ptr(new Poco::JSON::Array()));
+    g_state.createResponse = responseObject;
+
+    static OpenWifi::RESTAPI_GenericServerAccounting server;
+    auto &logger = Poco::Logger::get("test_group_devices_handlers");
+    TestGroupDevicesListHandler handler({{"group_id", kValidGroupId}}, logger, server, 1, false);
+    handler.UserInfo_.userinfo.id = "subscriber-1";
+    handler.UserInfo_.userinfo.owner = "operator-1";
+    auto body = Poco::JSON::Object::Ptr(new Poco::JSON::Object());
+    body->set("client_mac", kValidMac);
+    handler.setParsedBody(body);
+    FakeResponse response;
+    FakeRequest request(Poco::Net::HTTPRequest::HTTP_POST, "/api/v1/groups/x/devices", "{\"client_mac\":\"AA:BB:CC:DD:EE:FF\"}", response);
+    handler.Request = &request;
+    handler.Response = &response;
+
+    handler.DoPost();
+    auto parsed = ParseObject(response.body());
+    Expect(!parsed->has("config-raw"), "POST response should strip config-raw");
+    ExpectEq(parsed->getValue<std::string>("client_mac"), std::string(kValidMac), "client_mac should remain in response");
+    ExpectEq(g_state.lastGatewaySerial, std::string("GW-123"), "gateway serial should be passed to ApplyConfigRaw");
+}
+
+void TestDeleteReturnsOkOnSuccess() {
+    auto responseObject = Poco::JSON::Object::Ptr(new Poco::JSON::Object());
+    responseObject->set("config-raw", Poco::JSON::Array::Ptr(new Poco::JSON::Array()));
+    g_state.deleteResponse = responseObject;
+
+    static OpenWifi::RESTAPI_GenericServerAccounting server;
+    auto &logger = Poco::Logger::get("test_group_devices_handlers");
+    TestGroupDevicesHandler handler({{"group_id", kValidGroupId}, {"client_mac", kValidMac}}, logger, server, 1, false);
+    handler.UserInfo_.userinfo.id = "subscriber-1";
+    handler.UserInfo_.userinfo.owner = "operator-1";
+    FakeResponse response;
+    FakeRequest request(Poco::Net::HTTPRequest::HTTP_DELETE, "/api/v1/groups/x/devices/y", "", response);
+
+    handler.Request = &request;
+    handler.Response = &response;
+
+    handler.DoDelete();
+    ExpectEq(static_cast<int>(response.getStatus()), static_cast<int>(Poco::Net::HTTPResponse::HTTP_OK),
+             "successful delete should return 200");
+}
+
+const std::vector<std::pair<std::string, std::function<void()>>> kTests = {
+    {"ListGetRejectsMissingSubscriberId", TestListGetRejectsMissingSubscriberId},
+    {"ListGetRejectsInvalidGroupId", TestListGetRejectsInvalidGroupId},
+    {"ListGetReturnsJSONArrayOnSuccess", TestListGetReturnsJSONArrayOnSuccess},
+    {"PostRejectsMissingOwner", TestPostRejectsMissingOwner},
+    {"PostRejectsInvalidClientMac", TestPostRejectsInvalidClientMac},
+    {"PostStripsConfigRawAndReturnsObject", TestPostStripsConfigRawAndReturnsObject},
+    {"DeleteReturnsOkOnSuccess", TestDeleteReturnsOkOnSuccess},
+};
+
+} // namespace
+
+int main() {
+    int failures = 0;
+    for (const auto &test : kTests) {
+        try {
+            ResetState();
+            test.second();
+            std::cout << "[PASS] " << test.first << std::endl;
+        } catch (const std::exception &e) {
+            ++failures;
+            std::cerr << "[FAIL] " << test.first << ": " << e.what() << std::endl;
+        }
+    }
+
+    if (failures != 0) {
+        std::cerr << failures << " test(s) failed." << std::endl;
+        return 1;
+    }
+
+    std::cout << kTests.size() << " test(s) passed." << std::endl;
+    return 0;
+}
+
+namespace Poco::Util { class Application; }
+namespace Poco::Net { class HTTPRequestHandler; }
+namespace OpenWifi {
+    class RESTAPI_GenericServerAccounting;
+    void DaemonPostInitialization(Poco::Util::Application &) {}
+    Poco::Net::HTTPRequestHandler* RESTAPI_ExtRouter(const std::string &, std::map<std::string, std::string> &, Poco::Logger &, RESTAPI_GenericServerAccounting &, unsigned long) {
+        return nullptr;
+    }
+    Poco::Net::HTTPRequestHandler* RESTAPI_IntRouter(const std::string &, std::map<std::string, std::string> &, Poco::Logger &, RESTAPI_GenericServerAccounting &, unsigned long) {
+        return nullptr;
+    }
+
+    SubSystemServer::SubSystemServer(const std::string &Name, const std::string &LoggingPrefix,
+                                     const std::string &SubSystemConfigPrefix)
+        : Name_(Name), LoggerPrefix_(LoggingPrefix), SubSystemConfigPrefix_(SubSystemConfigPrefix),
+          Logger_(std::make_unique<LoggerWrapper>(Poco::Logger::get(LoggingPrefix))) {}
+
+    void SubSystemServer::initialize(Poco::Util::Application &) {}
+
+    bool AllowExternalMicroServices() { return false; }
+    bool MicroServiceIsValidAPIKEY(const Poco::Net::HTTPServerRequest &) { return false; }
+    bool AuthClient::IsValidApiKey(const std::string &, SecurityObjects::UserInfoAndPolicy &, unsigned long, bool &, bool &, bool &) { return false; }
+    bool AuthClient::IsAuthorized(const std::string &, SecurityObjects::UserInfoAndPolicy &, unsigned long, bool &, bool &, bool) { return false; }
+}
+
+namespace OpenWifi::Utils {
+    std::string FormatIPv6(const std::string &addr) { return addr; }
+    bool ValidUUID(const std::string &uuid) {
+        return uuid.size() == 36 && uuid[8] == '-' && uuid[13] == '-' && uuid[18] == '-' && uuid[23] == '-';
+    }
+    bool NormalizeMac(std::string &mac) {
+        std::string normalized = StripMac(mac);
+        if (!IsNormalizedMac(normalized)) {
+            return false;
+        }
+        mac = normalized;
+        return true;
+    }
+    std::string SerialToMAC(const std::string &serial) { return MacWithColons(StripMac(serial)); }
+}

--- a/tests/unit/test_group_devices_handlers.cpp
+++ b/tests/unit/test_group_devices_handlers.cpp
@@ -4,26 +4,9 @@
  * Portions copyright (c) Telecom Infra Project (TIP), BSD-3-Clause
  */
 
-#include <algorithm>
-#include <cctype>
-#include <functional>
-#include <iostream>
-#include <sstream>
-#include <stdexcept>
-#include <string>
-#include <vector>
-
-#include "Poco/JSON/Array.h"
-#include "Poco/JSON/Object.h"
-#include "Poco/JSON/Parser.h"
-#include "Poco/Logger.h"
-#include "Poco/Net/HTTPServerParams.h"
-#include "Poco/Net/SocketAddress.h"
+#include "test_parental_control_test_helpers.h"
 #include "RESTAPI/RESTAPI_group_devices_handler.h"
 #include "RESTAPI/RESTAPI_group_devices_list_handler.h"
-#include "RESTAPI/RESTAPI_parental_control_utils.h"
-#include "framework/RESTAPI_GenericServerAccounting.h"
-#include "sdks/SDK_parental_control.h"
 
 namespace {
 
@@ -31,25 +14,6 @@ const std::string kValidGroupId = "11111111-1111-4111-8111-111111111111";
 const std::string kInvalidGroupId = "bad-group-id";
 const std::string kValidMac = "AA:BB:CC:DD:EE:FF";
 const std::string kInvalidMac = "invalid-mac";
-
-class TestFailure : public std::runtime_error {
-  public:
-    using std::runtime_error::runtime_error;
-};
-
-void Expect(bool condition, const std::string &message) {
-    if (!condition) {
-        throw TestFailure(message);
-    }
-}
-
-template <typename T, typename U> void ExpectEq(const T &actual, const U &expected, const std::string &message) {
-    if (!(actual == expected)) {
-        std::ostringstream os;
-        os << message << " expected=" << expected << " actual=" << actual;
-        throw TestFailure(os.str());
-    }
-}
 
 std::string StripMac(const std::string &value) {
     std::string result;
@@ -79,75 +43,6 @@ std::string MacWithColons(const std::string &value) {
     }
     return os.str();
 }
-
-class FakeHTTPServerParams final : public Poco::Net::HTTPServerParams {
-  public:
-    ~FakeHTTPServerParams() override = default;
-};
-
-class FakeResponse final : public Poco::Net::HTTPServerResponse {
-  public:
-    void sendContinue() override {}
-
-    std::ostream &send() override {
-        sent_ = true;
-        return body_;
-    }
-
-    void sendFile(const std::string &, const std::string &) override { sent_ = true; }
-
-    void sendBuffer(const void *buffer, std::size_t length) override {
-        sent_ = true;
-        body_.write(static_cast<const char *>(buffer), static_cast<std::streamsize>(length));
-    }
-
-    void redirect(const std::string &uri, HTTPStatus status = HTTP_FOUND) override {
-        setStatus(status);
-        set("Location", uri);
-        sent_ = true;
-    }
-
-    void requireAuthentication(const std::string &realm) override {
-        setStatus(HTTP_UNAUTHORIZED);
-        set("WWW-Authenticate", realm);
-        sent_ = true;
-    }
-
-    bool sent() const override { return sent_; }
-    std::string body() const { return body_.str(); }
-
-  private:
-    bool sent_ = false;
-    std::ostringstream body_;
-};
-
-class FakeRequest final : public Poco::Net::HTTPServerRequest {
-  public:
-    FakeRequest(const std::string &method, const std::string &uri, const std::string &body, FakeResponse &response)
-        : bodyStream_(body), response_(response), clientAddress_("127.0.0.1", 1111), serverAddress_("127.0.0.1", 16006) {
-        setMethod(method);
-        setURI(uri);
-        setVersion(Poco::Net::HTTPMessage::HTTP_1_1);
-        if (!body.empty()) {
-            setContentType("application/json");
-            setContentLength(static_cast<int>(body.size()));
-        }
-    }
-
-    std::istream &stream() override { return bodyStream_; }
-    const Poco::Net::SocketAddress &clientAddress() const override { return clientAddress_; }
-    const Poco::Net::SocketAddress &serverAddress() const override { return serverAddress_; }
-    const Poco::Net::HTTPServerParams &serverParams() const override { return params_; }
-    Poco::Net::HTTPServerResponse &response() const override { return response_; }
-    bool secure() const override { return false; }
-
-  private:
-    std::istringstream bodyStream_;
-    FakeResponse &response_;
-    Poco::Net::SocketAddress clientAddress_;
-    Poco::Net::SocketAddress serverAddress_;
-    FakeHTTPServerParams params_;
-};
 
 struct DeviceHandlerState {
     bool getListOk = true;
@@ -195,16 +90,6 @@ void ResetState() {
     g_state.getSingleResponse = Poco::JSON::Object::Ptr(new Poco::JSON::Object());
     g_state.deleteResponse = Poco::JSON::Object::Ptr(new Poco::JSON::Object());
     g_state.extractedConfigRaw = Poco::JSON::Array::Ptr(new Poco::JSON::Array());
-}
-
-Poco::JSON::Object::Ptr ParseObject(const std::string &body) {
-    Poco::JSON::Parser parser;
-    return parser.parse(body).extract<Poco::JSON::Object::Ptr>();
-}
-
-Poco::JSON::Array::Ptr ParseArray(const std::string &body) {
-    Poco::JSON::Parser parser;
-    return parser.parse(body).extract<Poco::JSON::Array::Ptr>();
 }
 
 class TestGroupDevicesListHandler final : public OpenWifi::RESTAPI_group_devices_list_handler {
@@ -330,32 +215,27 @@ bool DeleteGroupDevice(RESTAPIHandler *, const std::string &subscriberId, const 
 namespace {
 
 void TestListGetRejectsMissingSubscriberId() {
-    static OpenWifi::RESTAPI_GenericServerAccounting server;
-    auto &logger = Poco::Logger::get("test_group_devices_handlers");
-    TestGroupDevicesListHandler handler({{"group_id", kValidGroupId}}, logger, server, 1, false);
-    FakeResponse response;
-    FakeRequest request(Poco::Net::HTTPRequest::HTTP_GET, "/api/v1/groups/x/devices", "", response);
-    handler.Request = &request;
-    handler.Response = &response;
-
-    handler.DoGet();
-    ExpectEq(static_cast<int>(response.getStatus()), static_cast<int>(Poco::Net::HTTPResponse::HTTP_FORBIDDEN),
-             "missing subscriber should return 403");
+    RunHandlerRequest<TestGroupDevicesListHandler>(
+        Poco::Net::HTTPRequest::HTTP_GET,
+        "/api/v1/groups/x/devices",
+        "",
+        {{"group_id", kValidGroupId}},
+        "",
+        "",
+        Poco::Net::HTTPResponse::HTTP_FORBIDDEN
+    );
 }
 
 void TestListGetRejectsInvalidGroupId() {
-    static OpenWifi::RESTAPI_GenericServerAccounting server;
-    auto &logger = Poco::Logger::get("test_group_devices_handlers");
-    TestGroupDevicesListHandler handler({{"group_id", kInvalidGroupId}}, logger, server, 1, false);
-    handler.UserInfo_.userinfo.id = "subscriber-1";
-    FakeResponse response;
-    FakeRequest request(Poco::Net::HTTPRequest::HTTP_GET, "/api/v1/groups/x/devices", "", response);
-    handler.Request = &request;
-    handler.Response = &response;
-
-    handler.DoGet();
-    ExpectEq(static_cast<int>(response.getStatus()), static_cast<int>(Poco::Net::HTTPResponse::HTTP_BAD_REQUEST),
-             "invalid group id should return 400");
+    RunHandlerRequest<TestGroupDevicesListHandler>(
+        Poco::Net::HTTPRequest::HTTP_GET,
+        "/api/v1/groups/x/devices",
+        "",
+        {{"group_id", kInvalidGroupId}},
+        "subscriber-1",
+        "",
+        Poco::Net::HTTPResponse::HTTP_BAD_REQUEST
+    );
 }
 
 void TestListGetReturnsJSONArrayOnSuccess() {
@@ -363,59 +243,60 @@ void TestListGetReturnsJSONArrayOnSuccess() {
     device->set("client_mac", kValidMac);
     g_state.getListArray->add(device);
 
-    static OpenWifi::RESTAPI_GenericServerAccounting server;
-    auto &logger = Poco::Logger::get("test_group_devices_handlers");
-    TestGroupDevicesListHandler handler({{"group_id", kValidGroupId}}, logger, server, 1, false);
-    handler.UserInfo_.userinfo.id = "subscriber-1";
-    FakeResponse response;
-    FakeRequest request(Poco::Net::HTTPRequest::HTTP_GET, "/api/v1/groups/x/devices", "", response);
-    handler.Request = &request;
-    handler.Response = &response;
-
-    handler.DoGet();
-    auto array = ParseArray(response.body());
-    ExpectEq(array->size(), static_cast<std::size_t>(1), "GET list should return one device");
-    ExpectEq(g_state.lastGroupId, kValidGroupId, "group id should be forwarded to SDK");
-    ExpectEq(g_state.lastSubscriberId, std::string("subscriber-1"), "subscriber id should be forwarded to SDK");
+    RunHandlerRequest<TestGroupDevicesListHandler>(
+        Poco::Net::HTTPRequest::HTTP_GET,
+        "/api/v1/groups/x/devices",
+        "",
+        {{"group_id", kValidGroupId}},
+        "subscriber-1",
+        "",
+        Poco::Net::HTTPResponse::HTTP_OK,
+        nullptr,
+        [](const FakeResponse &response) {
+            auto array = ParseArray(response.body());
+            ExpectEq(array->size(), static_cast<std::size_t>(1), "GET list should return one device");
+            ExpectEq(g_state.lastGroupId, kValidGroupId, "group id should be forwarded to SDK");
+            ExpectEq(g_state.lastSubscriberId, std::string("subscriber-1"), "subscriber id should be forwarded to SDK");
+        }
+    );
 }
 
 void TestPostRejectsMissingOwner() {
-    static OpenWifi::RESTAPI_GenericServerAccounting server;
-    auto &logger = Poco::Logger::get("test_group_devices_handlers");
-    TestGroupDevicesListHandler handler({{"group_id", kValidGroupId}}, logger, server, 1, false);
-    handler.UserInfo_.userinfo.id = "subscriber-1";
-    auto body = Poco::JSON::Object::Ptr(new Poco::JSON::Object());
-    body->set("client_mac", kValidMac);
-    handler.setParsedBody(body);
-    FakeResponse response;
-    FakeRequest request(Poco::Net::HTTPRequest::HTTP_POST, "/api/v1/groups/x/devices", "{\"client_mac\":\"AA:BB:CC:DD:EE:FF\"}", response);
-    handler.Request = &request;
-    handler.Response = &response;
-
-    handler.DoPost();
-    ExpectEq(static_cast<int>(response.getStatus()), static_cast<int>(Poco::Net::HTTPResponse::HTTP_FORBIDDEN),
-             "missing owner should return 403");
+    RunHandlerRequest<TestGroupDevicesListHandler>(
+        Poco::Net::HTTPRequest::HTTP_POST,
+        "/api/v1/groups/x/devices",
+        "{\"client_mac\":\"AA:BB:CC:DD:EE:FF\"}",
+        {{"group_id", kValidGroupId}},
+        "subscriber-1",
+        "",
+        Poco::Net::HTTPResponse::HTTP_FORBIDDEN,
+        [](TestGroupDevicesListHandler &handler) {
+            auto body = Poco::JSON::Object::Ptr(new Poco::JSON::Object());
+            body->set("client_mac", kValidMac);
+            handler.setParsedBody(body);
+        }
+    );
 }
 
 void TestPostRejectsInvalidClientMac() {
-    static OpenWifi::RESTAPI_GenericServerAccounting server;
-    auto &logger = Poco::Logger::get("test_group_devices_handlers");
-    TestGroupDevicesListHandler handler({{"group_id", kValidGroupId}}, logger, server, 1, false);
-    handler.UserInfo_.userinfo.id = "subscriber-1";
-    handler.UserInfo_.userinfo.owner = "operator-1";
-    auto body = Poco::JSON::Object::Ptr(new Poco::JSON::Object());
-    body->set("client_mac", kInvalidMac);
-    handler.setParsedBody(body);
-    FakeResponse response;
-    FakeRequest request(Poco::Net::HTTPRequest::HTTP_POST, "/api/v1/groups/x/devices", "{\"client_mac\":\"invalid\"}", response);
-    handler.Request = &request;
-    handler.Response = &response;
-
-    handler.DoPost();
-    ExpectEq(static_cast<int>(response.getStatus()), static_cast<int>(Poco::Net::HTTPResponse::HTTP_BAD_REQUEST),
-             "invalid client_mac should return 400");
-    ExpectEq(g_state.validateCalls, 0, "topology validation should not run for invalid MAC");
-    ExpectEq(g_state.createCalls, 0, "SDK create should not run for invalid MAC");
+    RunHandlerRequest<TestGroupDevicesListHandler>(
+        Poco::Net::HTTPRequest::HTTP_POST,
+        "/api/v1/groups/x/devices",
+        "{\"client_mac\":\"invalid\"}",
+        {{"group_id", kValidGroupId}},
+        "subscriber-1",
+        "operator-1",
+        Poco::Net::HTTPResponse::HTTP_BAD_REQUEST,
+        [](TestGroupDevicesListHandler &handler) {
+            auto body = Poco::JSON::Object::Ptr(new Poco::JSON::Object());
+            body->set("client_mac", kInvalidMac);
+            handler.setParsedBody(body);
+        },
+        [](const FakeResponse &) {
+            ExpectEq(g_state.validateCalls, 0, "topology validation should not run for invalid MAC");
+            ExpectEq(g_state.createCalls, 0, "SDK create should not run for invalid MAC");
+        }
+    );
 }
 
 void TestPostStripsConfigRawAndReturnsObject() {
@@ -424,24 +305,26 @@ void TestPostStripsConfigRawAndReturnsObject() {
     responseObject->set("config-raw", Poco::JSON::Array::Ptr(new Poco::JSON::Array()));
     g_state.createResponse = responseObject;
 
-    static OpenWifi::RESTAPI_GenericServerAccounting server;
-    auto &logger = Poco::Logger::get("test_group_devices_handlers");
-    TestGroupDevicesListHandler handler({{"group_id", kValidGroupId}}, logger, server, 1, false);
-    handler.UserInfo_.userinfo.id = "subscriber-1";
-    handler.UserInfo_.userinfo.owner = "operator-1";
-    auto body = Poco::JSON::Object::Ptr(new Poco::JSON::Object());
-    body->set("client_mac", kValidMac);
-    handler.setParsedBody(body);
-    FakeResponse response;
-    FakeRequest request(Poco::Net::HTTPRequest::HTTP_POST, "/api/v1/groups/x/devices", "{\"client_mac\":\"AA:BB:CC:DD:EE:FF\"}", response);
-    handler.Request = &request;
-    handler.Response = &response;
-
-    handler.DoPost();
-    auto parsed = ParseObject(response.body());
-    Expect(!parsed->has("config-raw"), "POST response should strip config-raw");
-    ExpectEq(parsed->getValue<std::string>("client_mac"), std::string(kValidMac), "client_mac should remain in response");
-    ExpectEq(g_state.lastGatewaySerial, std::string("GW-123"), "gateway serial should be passed to ApplyConfigRaw");
+    RunHandlerRequest<TestGroupDevicesListHandler>(
+        Poco::Net::HTTPRequest::HTTP_POST,
+        "/api/v1/groups/x/devices",
+        "{\"client_mac\":\"AA:BB:CC:DD:EE:FF\"}",
+        {{"group_id", kValidGroupId}},
+        "subscriber-1",
+        "operator-1",
+        Poco::Net::HTTPResponse::HTTP_OK,
+        [](TestGroupDevicesListHandler &handler) {
+            auto body = Poco::JSON::Object::Ptr(new Poco::JSON::Object());
+            body->set("client_mac", kValidMac);
+            handler.setParsedBody(body);
+        },
+        [](const FakeResponse &response) {
+            auto parsed = ParseObject(response.body());
+            Expect(!parsed->has("config-raw"), "POST response should strip config-raw");
+            ExpectEq(parsed->getValue<std::string>("client_mac"), std::string(kValidMac), "client_mac should remain in response");
+            ExpectEq(g_state.lastGatewaySerial, std::string("GW-123"), "gateway serial should be passed to ApplyConfigRaw");
+        }
+    );
 }
 
 void TestDeleteReturnsOkOnSuccess() {
@@ -449,20 +332,15 @@ void TestDeleteReturnsOkOnSuccess() {
     responseObject->set("config-raw", Poco::JSON::Array::Ptr(new Poco::JSON::Array()));
     g_state.deleteResponse = responseObject;
 
-    static OpenWifi::RESTAPI_GenericServerAccounting server;
-    auto &logger = Poco::Logger::get("test_group_devices_handlers");
-    TestGroupDevicesHandler handler({{"group_id", kValidGroupId}, {"client_mac", kValidMac}}, logger, server, 1, false);
-    handler.UserInfo_.userinfo.id = "subscriber-1";
-    handler.UserInfo_.userinfo.owner = "operator-1";
-    FakeResponse response;
-    FakeRequest request(Poco::Net::HTTPRequest::HTTP_DELETE, "/api/v1/groups/x/devices/y", "", response);
-
-    handler.Request = &request;
-    handler.Response = &response;
-
-    handler.DoDelete();
-    ExpectEq(static_cast<int>(response.getStatus()), static_cast<int>(Poco::Net::HTTPResponse::HTTP_OK),
-             "successful delete should return 200");
+    RunHandlerRequest<TestGroupDevicesHandler>(
+        Poco::Net::HTTPRequest::HTTP_DELETE,
+        "/api/v1/groups/x/devices/y",
+        "",
+        {{"group_id", kValidGroupId}, {"client_mac", kValidMac}},
+        "subscriber-1",
+        "operator-1",
+        Poco::Net::HTTPResponse::HTTP_OK
+    );
 }
 
 const std::vector<std::pair<std::string, std::function<void()>>> kTests = {
@@ -498,37 +376,7 @@ int main() {
     std::cout << kTests.size() << " test(s) passed." << std::endl;
     return 0;
 }
-
-namespace Poco::Util { class Application; }
-namespace Poco::Net { class HTTPRequestHandler; }
-namespace OpenWifi {
-    class RESTAPI_GenericServerAccounting;
-    void DaemonPostInitialization(Poco::Util::Application &) {}
-    Poco::Net::HTTPRequestHandler* RESTAPI_ExtRouter(const std::string &, std::map<std::string, std::string> &, Poco::Logger &, RESTAPI_GenericServerAccounting &, unsigned long) {
-        return nullptr;
-    }
-    Poco::Net::HTTPRequestHandler* RESTAPI_IntRouter(const std::string &, std::map<std::string, std::string> &, Poco::Logger &, RESTAPI_GenericServerAccounting &, unsigned long) {
-        return nullptr;
-    }
-
-    SubSystemServer::SubSystemServer(const std::string &Name, const std::string &LoggingPrefix,
-                                     const std::string &SubSystemConfigPrefix)
-        : Name_(Name), LoggerPrefix_(LoggingPrefix), SubSystemConfigPrefix_(SubSystemConfigPrefix),
-          Logger_(std::make_unique<LoggerWrapper>(Poco::Logger::get(LoggingPrefix))) {}
-
-    void SubSystemServer::initialize(Poco::Util::Application &) {}
-
-    bool AllowExternalMicroServices() { return false; }
-    bool MicroServiceIsValidAPIKEY(const Poco::Net::HTTPServerRequest &) { return false; }
-    bool AuthClient::IsValidApiKey(const std::string &, SecurityObjects::UserInfoAndPolicy &, unsigned long, bool &, bool &, bool &) { return false; }
-    bool AuthClient::IsAuthorized(const std::string &, SecurityObjects::UserInfoAndPolicy &, unsigned long, bool &, bool &, bool) { return false; }
-}
-
 namespace OpenWifi::Utils {
-    std::string FormatIPv6(const std::string &addr) { return addr; }
-    bool ValidUUID(const std::string &uuid) {
-        return uuid.size() == 36 && uuid[8] == '-' && uuid[13] == '-' && uuid[18] == '-' && uuid[23] == '-';
-    }
     bool NormalizeMac(std::string &mac) {
         std::string normalized = StripMac(mac);
         if (!IsNormalizedMac(normalized)) {
@@ -539,3 +387,4 @@ namespace OpenWifi::Utils {
     }
     std::string SerialToMAC(const std::string &serial) { return MacWithColons(StripMac(serial)); }
 }
+

--- a/tests/unit/test_group_schedules_handlers.cpp
+++ b/tests/unit/test_group_schedules_handlers.cpp
@@ -1,0 +1,563 @@
+/*
+ * SPDX-License-Identifier: AGPL-3.0 OR LicenseRef-Commercial
+ * Copyright (c) 2025 Infernet Systems Pvt Ltd
+ * Portions copyright (c) Telecom Infra Project (TIP), BSD-3-Clause
+ */
+
+#include <functional>
+#include <iostream>
+#include <sstream>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+#include "Poco/JSON/Array.h"
+#include "Poco/JSON/Object.h"
+#include "Poco/JSON/Parser.h"
+#include "Poco/Logger.h"
+#include "Poco/Net/HTTPServerParams.h"
+#include "Poco/Net/SocketAddress.h"
+#include "RESTAPI/RESTAPI_group_schedules_handler.h"
+#include "RESTAPI/RESTAPI_group_schedules_list_handler.h"
+#include "RESTAPI/RESTAPI_parental_control_utils.h"
+#include "framework/RESTAPI_GenericServerAccounting.h"
+#include "sdks/SDK_parental_control.h"
+
+namespace {
+
+const std::string kValidGroupId = "11111111-1111-4111-8111-111111111111";
+const std::string kValidScheduleId = "22222222-2222-4222-8222-222222222222";
+const std::string kAnotherScheduleId = "33333333-3333-4333-8333-333333333333";
+const std::string kInvalidUuid = "not-a-uuid";
+
+class TestFailure : public std::runtime_error {
+  public:
+    using std::runtime_error::runtime_error;
+};
+
+void Expect(bool condition, const std::string &message) {
+    if (!condition) {
+        throw TestFailure(message);
+    }
+}
+
+template <typename T, typename U> void ExpectEq(const T &actual, const U &expected, const std::string &message) {
+    if (!(actual == expected)) {
+        std::ostringstream os;
+        os << message << " expected=" << expected << " actual=" << actual;
+        throw TestFailure(os.str());
+    }
+}
+
+class FakeHTTPServerParams final : public Poco::Net::HTTPServerParams {
+  public:
+    ~FakeHTTPServerParams() override = default;
+};
+
+class FakeResponse final : public Poco::Net::HTTPServerResponse {
+  public:
+    void sendContinue() override {}
+
+    std::ostream &send() override {
+        sent_ = true;
+        return body_;
+    }
+
+    void sendFile(const std::string &, const std::string &) override { sent_ = true; }
+
+    void sendBuffer(const void *buffer, std::size_t length) override {
+        sent_ = true;
+        body_.write(static_cast<const char *>(buffer), static_cast<std::streamsize>(length));
+    }
+
+    void redirect(const std::string &uri, HTTPStatus status = HTTP_FOUND) override {
+        setStatus(status);
+        set("Location", uri);
+        sent_ = true;
+    }
+
+    void requireAuthentication(const std::string &realm) override {
+        setStatus(HTTP_UNAUTHORIZED);
+        set("WWW-Authenticate", realm);
+        sent_ = true;
+    }
+
+    bool sent() const override { return sent_; }
+    std::string body() const { return body_.str(); }
+
+  private:
+    bool sent_ = false;
+    std::ostringstream body_;
+};
+
+class FakeRequest final : public Poco::Net::HTTPServerRequest {
+  public:
+    FakeRequest(const std::string &method, const std::string &uri, const std::string &body, FakeResponse &response)
+        : bodyStream_(body), response_(response), clientAddress_("127.0.0.1", 1111), serverAddress_("127.0.0.1", 16006) {
+        setMethod(method);
+        setURI(uri);
+        setVersion(Poco::Net::HTTPMessage::HTTP_1_1);
+        if (!body.empty()) {
+            setContentType("application/json");
+            setContentLength(static_cast<int>(body.size()));
+        }
+    }
+
+    std::istream &stream() override { return bodyStream_; }
+    const Poco::Net::SocketAddress &clientAddress() const override { return clientAddress_; }
+    const Poco::Net::SocketAddress &serverAddress() const override { return serverAddress_; }
+    const Poco::Net::HTTPServerParams &serverParams() const override { return params_; }
+    Poco::Net::HTTPServerResponse &response() const override { return response_; }
+    bool secure() const override { return false; }
+
+  private:
+    std::istringstream bodyStream_;
+    FakeResponse &response_;
+    Poco::Net::SocketAddress clientAddress_;
+    Poco::Net::SocketAddress serverAddress_;
+    FakeHTTPServerParams params_;
+};
+
+struct ScheduleHandlerState {
+    bool getListOk = true;
+    Poco::Net::HTTPResponse::HTTPStatus getListStatus = Poco::Net::HTTPResponse::HTTP_OK;
+    Poco::JSON::Array::Ptr getListArray = Poco::JSON::Array::Ptr(new Poco::JSON::Array());
+    Poco::JSON::Object::Ptr getListError = Poco::JSON::Object::Ptr(new Poco::JSON::Object());
+
+    bool createOk = true;
+    Poco::Net::HTTPResponse::HTTPStatus createStatus = Poco::Net::HTTPResponse::HTTP_OK;
+    Poco::JSON::Object::Ptr createResponse = Poco::JSON::Object::Ptr(new Poco::JSON::Object());
+
+    bool replaceOk = true;
+    Poco::Net::HTTPResponse::HTTPStatus replaceStatus = Poco::Net::HTTPResponse::HTTP_OK;
+    Poco::JSON::Object::Ptr replaceResponse = Poco::JSON::Object::Ptr(new Poco::JSON::Object());
+
+    bool getSingleOk = true;
+    Poco::Net::HTTPResponse::HTTPStatus getSingleStatus = Poco::Net::HTTPResponse::HTTP_OK;
+    Poco::JSON::Object::Ptr getSingleResponse = Poco::JSON::Object::Ptr(new Poco::JSON::Object());
+
+    bool deleteOk = true;
+    Poco::Net::HTTPResponse::HTTPStatus deleteStatus = Poco::Net::HTTPResponse::HTTP_OK;
+    Poco::JSON::Object::Ptr deleteResponse = Poco::JSON::Object::Ptr(new Poco::JSON::Object());
+    std::string deleteRawBody = "{\"config-raw\":[]}";
+
+    bool extractConfigRawOk = true;
+    Poco::JSON::Array::Ptr extractedConfigRaw = Poco::JSON::Array::Ptr(new Poco::JSON::Array());
+    OpenWifi::RESTAPI::ParentalControl::ApplyConfigRawResult applyResult =
+        OpenWifi::RESTAPI::ParentalControl::ApplyConfigRawResult::Applied;
+
+    std::string lastSubscriberId;
+    std::string lastGroupId;
+    std::string lastScheduleId;
+    std::size_t replaceCount = 0;
+};
+
+ScheduleHandlerState g_state;
+
+void ResetState() {
+    g_state = ScheduleHandlerState{};
+    g_state.getListArray = Poco::JSON::Array::Ptr(new Poco::JSON::Array());
+    g_state.getListError = Poco::JSON::Object::Ptr(new Poco::JSON::Object());
+    g_state.createResponse = Poco::JSON::Object::Ptr(new Poco::JSON::Object());
+    g_state.replaceResponse = Poco::JSON::Object::Ptr(new Poco::JSON::Object());
+    g_state.getSingleResponse = Poco::JSON::Object::Ptr(new Poco::JSON::Object());
+    g_state.deleteResponse = Poco::JSON::Object::Ptr(new Poco::JSON::Object());
+    g_state.extractedConfigRaw = Poco::JSON::Array::Ptr(new Poco::JSON::Array());
+}
+
+Poco::JSON::Object::Ptr ParseObject(const std::string &body) {
+    Poco::JSON::Parser parser;
+    return parser.parse(body).extract<Poco::JSON::Object::Ptr>();
+}
+
+Poco::JSON::Array::Ptr ParseArray(const std::string &body) {
+    Poco::JSON::Parser parser;
+    return parser.parse(body).extract<Poco::JSON::Array::Ptr>();
+}
+
+class TestGroupSchedulesListHandler final : public OpenWifi::RESTAPI_group_schedules_list_handler {
+  public:
+    using OpenWifi::RESTAPI_group_schedules_list_handler::RESTAPI_group_schedules_list_handler;
+
+    void setParsedBody(const Poco::JSON::Object::Ptr &body) { ParsedBody_ = body; }
+};
+
+class TestGroupSchedulesHandler final : public OpenWifi::RESTAPI_group_schedules_handler {
+  public:
+    using OpenWifi::RESTAPI_group_schedules_handler::RESTAPI_group_schedules_handler;
+};
+
+} // namespace
+
+
+namespace OpenWifi::RESTAPI::ParentalControl {
+
+bool ExtractConfigRawSnapshot(const Poco::JSON::Object::Ptr &, Poco::JSON::Array::Ptr &configRaw, bool) {
+    configRaw = g_state.extractedConfigRaw;
+    return g_state.extractConfigRawOk;
+}
+
+ApplyConfigRawResult ApplyConfigRaw(RESTAPIHandler &, Poco::Logger &, const std::string &subscriberId, const std::string &,
+                                    const std::string &objectId, const Poco::JSON::Array::Ptr &, const std::string &,
+                                    const std::string &, const std::string &) {
+    g_state.lastSubscriberId = subscriberId;
+    g_state.lastGroupId = objectId;
+    return g_state.applyResult;
+}
+
+bool HandleApplyConfigRawResult(RESTAPIHandler &handler, ApplyConfigRawResult result) {
+    if (result == ApplyConfigRawResult::Applied || result == ApplyConfigRawResult::NoConfigApplyNeeded) {
+        return true;
+    }
+    if (result == ApplyConfigRawResult::MissingOperatorId) {
+        handler.UnAuthorized(RESTAPI::Errors::OperatorIdMustExist);
+        return false;
+    }
+    handler.InternalError(RESTAPI::Errors::InternalError);
+    return false;
+}
+
+} // namespace OpenWifi::RESTAPI::ParentalControl
+
+namespace OpenWifi::SDK::ParentalControl {
+
+bool GetGroupSchedules(RESTAPIHandler *, const std::string &subscriberId, const std::string &groupId,
+                       Poco::Net::HTTPResponse::HTTPStatus &callStatus, Poco::JSON::Array::Ptr &arrayResponse,
+                       Poco::JSON::Object::Ptr &objectResponse) {
+    g_state.lastSubscriberId = subscriberId;
+    g_state.lastGroupId = groupId;
+    callStatus = g_state.getListStatus;
+    arrayResponse = g_state.getListArray;
+    objectResponse = g_state.getListError;
+    return g_state.getListOk;
+}
+
+bool CreateGroupSchedule(RESTAPIHandler *, const std::string &subscriberId, const std::string &groupId,
+                         const Poco::JSON::Object &body, Poco::Net::HTTPResponse::HTTPStatus &callStatus,
+                         Poco::JSON::Object::Ptr &callResponse) {
+    g_state.lastSubscriberId = subscriberId;
+    g_state.lastGroupId = groupId;
+    if (body.has("schedule_id")) {
+        g_state.lastScheduleId = body.getValue<std::string>("schedule_id");
+    }
+    callStatus = g_state.createStatus;
+    callResponse = g_state.createResponse;
+    return g_state.createOk;
+}
+
+bool ReplaceGroupSchedules(RESTAPIHandler *, const std::string &subscriberId, const std::string &groupId,
+                           const Poco::JSON::Object &body, Poco::Net::HTTPResponse::HTTPStatus &callStatus,
+                           Poco::JSON::Object::Ptr &callResponse) {
+    g_state.lastSubscriberId = subscriberId;
+    g_state.lastGroupId = groupId;
+    if (body.has("schedule_ids") && body.isArray("schedule_ids")) {
+        g_state.replaceCount = body.getArray("schedule_ids")->size();
+    }
+    callStatus = g_state.replaceStatus;
+    callResponse = g_state.replaceResponse;
+    return g_state.replaceOk;
+}
+
+bool GetGroupSchedule(RESTAPIHandler *, const std::string &subscriberId, const std::string &groupId,
+                      const std::string &scheduleId, Poco::Net::HTTPResponse::HTTPStatus &callStatus,
+                      Poco::JSON::Object::Ptr &callResponse) {
+    g_state.lastSubscriberId = subscriberId;
+    g_state.lastGroupId = groupId;
+    g_state.lastScheduleId = scheduleId;
+    callStatus = g_state.getSingleStatus;
+    callResponse = g_state.getSingleResponse;
+    return g_state.getSingleOk;
+}
+
+bool DeleteGroupSchedule(RESTAPIHandler *, const std::string &subscriberId, const std::string &groupId,
+                         const std::string &scheduleId, Poco::Net::HTTPResponse::HTTPStatus &callStatus,
+                         Poco::JSON::Object::Ptr &callResponse, std::string &rawResponseBody) {
+    g_state.lastSubscriberId = subscriberId;
+    g_state.lastGroupId = groupId;
+    g_state.lastScheduleId = scheduleId;
+    callStatus = g_state.deleteStatus;
+    callResponse = g_state.deleteResponse;
+    rawResponseBody = g_state.deleteRawBody;
+    return g_state.deleteOk;
+}
+
+} // namespace OpenWifi::SDK::ParentalControl
+
+#include "../../src/RESTAPI/RESTAPI_group_schedules_list_handler.cpp"
+#include "../../src/RESTAPI/RESTAPI_group_schedules_handler.cpp"
+
+namespace {
+
+void TestListGetRejectsInvalidGroupUuid() {
+    static OpenWifi::RESTAPI_GenericServerAccounting server;
+    auto &logger = Poco::Logger::get("test_group_schedules_handlers");
+    TestGroupSchedulesListHandler handler({{"group_id", kInvalidUuid}}, logger, server, 1, false);
+    handler.UserInfo_.userinfo.id = "subscriber-1";
+    FakeResponse response;
+    FakeRequest request(Poco::Net::HTTPRequest::HTTP_GET, "/api/v1/groups/x/schedules", "", response);
+    handler.Request = &request;
+    handler.Response = &response;
+
+    handler.DoGet();
+    ExpectEq(static_cast<int>(response.getStatus()), static_cast<int>(Poco::Net::HTTPResponse::HTTP_BAD_REQUEST),
+             "invalid group uuid should return 400");
+}
+
+void TestListGetReturnsJsonArrayOnSuccess() {
+    auto item = Poco::JSON::Object::Ptr(new Poco::JSON::Object());
+    item->set("schedule_id", kValidScheduleId);
+    g_state.getListArray->add(item);
+
+    static OpenWifi::RESTAPI_GenericServerAccounting server;
+    auto &logger = Poco::Logger::get("test_group_schedules_handlers");
+    TestGroupSchedulesListHandler handler({{"group_id", kValidGroupId}}, logger, server, 1, false);
+    handler.UserInfo_.userinfo.id = "subscriber-1";
+    FakeResponse response;
+    FakeRequest request(Poco::Net::HTTPRequest::HTTP_GET, "/api/v1/groups/x/schedules", "", response);
+    handler.Request = &request;
+    handler.Response = &response;
+
+    handler.DoGet();
+    auto array = ParseArray(response.body());
+    ExpectEq(array->size(), static_cast<std::size_t>(1), "GET schedules should return one entry");
+    ExpectEq(g_state.lastGroupId, kValidGroupId, "group id should be forwarded");
+}
+
+void TestPostRejectsInvalidScheduleId() {
+    static OpenWifi::RESTAPI_GenericServerAccounting server;
+    auto &logger = Poco::Logger::get("test_group_schedules_handlers");
+    TestGroupSchedulesListHandler handler({{"group_id", kValidGroupId}}, logger, server, 1, false);
+    handler.UserInfo_.userinfo.id = "subscriber-1";
+    handler.UserInfo_.userinfo.owner = "operator-1";
+    auto body = Poco::JSON::Object::Ptr(new Poco::JSON::Object());
+    body->set("schedule_id", kInvalidUuid);
+    handler.setParsedBody(body);
+    FakeResponse response;
+    FakeRequest request(Poco::Net::HTTPRequest::HTTP_POST, "/api/v1/groups/x/schedules", "{\"schedule_id\":\"bad\"}", response);
+    handler.Request = &request;
+    handler.Response = &response;
+
+    handler.DoPost();
+    ExpectEq(static_cast<int>(response.getStatus()), static_cast<int>(Poco::Net::HTTPResponse::HTTP_BAD_REQUEST),
+             "invalid schedule_id should return 400");
+}
+
+void TestPostStripsConfigRawAndReturnsObject() {
+    auto responseObject = Poco::JSON::Object::Ptr(new Poco::JSON::Object());
+    responseObject->set("schedule_id", kValidScheduleId);
+    responseObject->set("config-raw", Poco::JSON::Array::Ptr(new Poco::JSON::Array()));
+    g_state.createResponse = responseObject;
+
+    static OpenWifi::RESTAPI_GenericServerAccounting server;
+    auto &logger = Poco::Logger::get("test_group_schedules_handlers");
+    TestGroupSchedulesListHandler handler({{"group_id", kValidGroupId}}, logger, server, 1, false);
+    handler.UserInfo_.userinfo.id = "subscriber-1";
+    handler.UserInfo_.userinfo.owner = "operator-1";
+    auto body = Poco::JSON::Object::Ptr(new Poco::JSON::Object());
+    body->set("schedule_id", kValidScheduleId);
+    handler.setParsedBody(body);
+    FakeResponse response;
+    FakeRequest request(Poco::Net::HTTPRequest::HTTP_POST, "/api/v1/groups/x/schedules", "{\"schedule_id\":\"ok\"}", response);
+    handler.Request = &request;
+    handler.Response = &response;
+
+    handler.DoPost();
+    auto parsed = ParseObject(response.body());
+    Expect(!parsed->has("config-raw"), "POST response should strip config-raw");
+    ExpectEq(parsed->getValue<std::string>("schedule_id"), kValidScheduleId, "schedule_id should remain");
+}
+
+void TestPutRejectsDuplicateScheduleIds() {
+    static OpenWifi::RESTAPI_GenericServerAccounting server;
+    auto &logger = Poco::Logger::get("test_group_schedules_handlers");
+    TestGroupSchedulesListHandler handler({{"group_id", kValidGroupId}}, logger, server, 1, false);
+    handler.UserInfo_.userinfo.id = "subscriber-1";
+    handler.UserInfo_.userinfo.owner = "operator-1";
+    auto ids = Poco::JSON::Array::Ptr(new Poco::JSON::Array());
+    ids->add(kValidScheduleId);
+    ids->add(kValidScheduleId);
+    auto body = Poco::JSON::Object::Ptr(new Poco::JSON::Object());
+    body->set("schedule_ids", ids);
+    handler.setParsedBody(body);
+    FakeResponse response;
+    FakeRequest request(Poco::Net::HTTPRequest::HTTP_PUT, "/api/v1/groups/x/schedules", "{\"schedule_ids\":[]}", response);
+    handler.Request = &request;
+    handler.Response = &response;
+
+    handler.DoPut();
+    ExpectEq(static_cast<int>(response.getStatus()), static_cast<int>(Poco::Net::HTTPResponse::HTTP_BAD_REQUEST),
+             "duplicate schedule_ids should return 400");
+}
+
+void TestPutRejectsNonStringScheduleIdEntry() {
+    static OpenWifi::RESTAPI_GenericServerAccounting server;
+    auto &logger = Poco::Logger::get("test_group_schedules_handlers");
+    TestGroupSchedulesListHandler handler({{"group_id", kValidGroupId}}, logger, server, 1, false);
+    handler.UserInfo_.userinfo.id = "subscriber-1";
+    handler.UserInfo_.userinfo.owner = "operator-1";
+    auto ids = Poco::JSON::Array::Ptr(new Poco::JSON::Array());
+    ids->add(7);
+    auto body = Poco::JSON::Object::Ptr(new Poco::JSON::Object());
+    body->set("schedule_ids", ids);
+    handler.setParsedBody(body);
+    FakeResponse response;
+    FakeRequest request(Poco::Net::HTTPRequest::HTTP_PUT, "/api/v1/groups/x/schedules", "{\"schedule_ids\":[]}", response);
+    handler.Request = &request;
+    handler.Response = &response;
+
+    handler.DoPut();
+    ExpectEq(static_cast<int>(response.getStatus()), static_cast<int>(Poco::Net::HTTPResponse::HTTP_BAD_REQUEST),
+             "non-string schedule_ids entry should return 400");
+}
+
+void TestPutStripsConfigRawAndReturnsObject() {
+    auto responseObject = Poco::JSON::Object::Ptr(new Poco::JSON::Object());
+    responseObject->set("replaced", true);
+    responseObject->set("config-raw", Poco::JSON::Array::Ptr(new Poco::JSON::Array()));
+    g_state.replaceResponse = responseObject;
+
+    static OpenWifi::RESTAPI_GenericServerAccounting server;
+    auto &logger = Poco::Logger::get("test_group_schedules_handlers");
+    TestGroupSchedulesListHandler handler({{"group_id", kValidGroupId}}, logger, server, 1, false);
+    handler.UserInfo_.userinfo.id = "subscriber-1";
+    handler.UserInfo_.userinfo.owner = "operator-1";
+    auto ids = Poco::JSON::Array::Ptr(new Poco::JSON::Array());
+    ids->add(kValidScheduleId);
+    ids->add(kAnotherScheduleId);
+    auto body = Poco::JSON::Object::Ptr(new Poco::JSON::Object());
+    body->set("schedule_ids", ids);
+    handler.setParsedBody(body);
+    FakeResponse response;
+    FakeRequest request(Poco::Net::HTTPRequest::HTTP_PUT, "/api/v1/groups/x/schedules", "{\"schedule_ids\":[]}", response);
+    handler.Request = &request;
+    handler.Response = &response;
+
+    handler.DoPut();
+    auto parsed = ParseObject(response.body());
+    Expect(!parsed->has("config-raw"), "PUT response should strip config-raw");
+    ExpectEq(g_state.replaceCount, static_cast<std::size_t>(2), "two schedule ids should be forwarded");
+}
+
+void TestSingleGetReturnsObjectOnSuccess() {
+    auto responseObject = Poco::JSON::Object::Ptr(new Poco::JSON::Object());
+    responseObject->set("schedule_id", kValidScheduleId);
+    g_state.getSingleResponse = responseObject;
+
+    static OpenWifi::RESTAPI_GenericServerAccounting server;
+    auto &logger = Poco::Logger::get("test_group_schedules_handlers");
+    TestGroupSchedulesHandler handler({{"group_id", kValidGroupId}, {"schedule_id", kValidScheduleId}}, logger, server, 1, false);
+    handler.UserInfo_.userinfo.id = "subscriber-1";
+    FakeResponse response;
+    FakeRequest request(Poco::Net::HTTPRequest::HTTP_GET, "/api/v1/groups/x/schedules/y", "", response);
+    handler.Request = &request;
+    handler.Response = &response;
+
+    handler.DoGet();
+    auto parsed = ParseObject(response.body());
+    ExpectEq(parsed->getValue<std::string>("schedule_id"), kValidScheduleId, "GET should return schedule object");
+}
+
+void TestSingleDeleteRejectsMissingOwner() {
+    static OpenWifi::RESTAPI_GenericServerAccounting server;
+    auto &logger = Poco::Logger::get("test_group_schedules_handlers");
+    TestGroupSchedulesHandler handler({{"group_id", kValidGroupId}, {"schedule_id", kValidScheduleId}}, logger, server, 1, false);
+    handler.UserInfo_.userinfo.id = "subscriber-1";
+    FakeResponse response;
+    FakeRequest request(Poco::Net::HTTPRequest::HTTP_DELETE, "/api/v1/groups/x/schedules/y", "", response);
+    handler.Request = &request;
+    handler.Response = &response;
+
+    handler.DoDelete();
+    ExpectEq(static_cast<int>(response.getStatus()), static_cast<int>(Poco::Net::HTTPResponse::HTTP_FORBIDDEN),
+             "missing owner should return 403");
+}
+
+void TestSingleDeleteReturnsOkOnSuccess() {
+    auto responseObject = Poco::JSON::Object::Ptr(new Poco::JSON::Object());
+    responseObject->set("config-raw", Poco::JSON::Array::Ptr(new Poco::JSON::Array()));
+    g_state.deleteResponse = responseObject;
+
+    static OpenWifi::RESTAPI_GenericServerAccounting server;
+    auto &logger = Poco::Logger::get("test_group_schedules_handlers");
+    TestGroupSchedulesHandler handler({{"group_id", kValidGroupId}, {"schedule_id", kValidScheduleId}}, logger, server, 1, false);
+    handler.UserInfo_.userinfo.id = "subscriber-1";
+    handler.UserInfo_.userinfo.owner = "operator-1";
+    FakeResponse response;
+    FakeRequest request(Poco::Net::HTTPRequest::HTTP_DELETE, "/api/v1/groups/x/schedules/y", "", response);
+    handler.Request = &request;
+    handler.Response = &response;
+
+    handler.DoDelete();
+    ExpectEq(static_cast<int>(response.getStatus()), static_cast<int>(Poco::Net::HTTPResponse::HTTP_OK),
+             "successful delete should return 200");
+}
+
+const std::vector<std::pair<std::string, std::function<void()>>> kTests = {
+    {"ListGetRejectsInvalidGroupUuid", TestListGetRejectsInvalidGroupUuid},
+    {"ListGetReturnsJsonArrayOnSuccess", TestListGetReturnsJsonArrayOnSuccess},
+    {"PostRejectsInvalidScheduleId", TestPostRejectsInvalidScheduleId},
+    {"PostStripsConfigRawAndReturnsObject", TestPostStripsConfigRawAndReturnsObject},
+    {"PutRejectsDuplicateScheduleIds", TestPutRejectsDuplicateScheduleIds},
+    {"PutRejectsNonStringScheduleIdEntry", TestPutRejectsNonStringScheduleIdEntry},
+    {"PutStripsConfigRawAndReturnsObject", TestPutStripsConfigRawAndReturnsObject},
+    {"SingleGetReturnsObjectOnSuccess", TestSingleGetReturnsObjectOnSuccess},
+    {"SingleDeleteRejectsMissingOwner", TestSingleDeleteRejectsMissingOwner},
+    {"SingleDeleteReturnsOkOnSuccess", TestSingleDeleteReturnsOkOnSuccess},
+};
+
+} // namespace
+
+int main() {
+    int failures = 0;
+    for (const auto &test : kTests) {
+        try {
+            ResetState();
+            test.second();
+
+            std::cout << "[PASS] " << test.first << std::endl;
+        } catch (const std::exception &e) {
+            ++failures;
+            std::cerr << "[FAIL] " << test.first << ": " << e.what() << std::endl;
+        }
+    }
+
+    if (failures != 0) {
+        std::cerr << failures << " test(s) failed." << std::endl;
+        return 1;
+    }
+
+    std::cout << kTests.size() << " test(s) passed." << std::endl;
+    return 0;
+}
+
+namespace Poco::Util { class Application; }
+namespace Poco::Net { class HTTPRequestHandler; }
+namespace OpenWifi {
+    class RESTAPI_GenericServerAccounting;
+    void DaemonPostInitialization(Poco::Util::Application &) {}
+    Poco::Net::HTTPRequestHandler* RESTAPI_ExtRouter(const std::string &, std::map<std::string, std::string> &, Poco::Logger &, RESTAPI_GenericServerAccounting &, unsigned long) {
+        return nullptr;
+    }
+    Poco::Net::HTTPRequestHandler* RESTAPI_IntRouter(const std::string &, std::map<std::string, std::string> &, Poco::Logger &, RESTAPI_GenericServerAccounting &, unsigned long) {
+        return nullptr;
+    }
+
+    SubSystemServer::SubSystemServer(const std::string &Name, const std::string &LoggingPrefix,
+                                     const std::string &SubSystemConfigPrefix)
+        : Name_(Name), LoggerPrefix_(LoggingPrefix), SubSystemConfigPrefix_(SubSystemConfigPrefix),
+          Logger_(std::make_unique<LoggerWrapper>(Poco::Logger::get(LoggingPrefix))) {}
+
+    void SubSystemServer::initialize(Poco::Util::Application &) {}
+
+    bool AllowExternalMicroServices() { return false; }
+    bool MicroServiceIsValidAPIKEY(const Poco::Net::HTTPServerRequest &) { return false; }
+    bool AuthClient::IsValidApiKey(const std::string &, SecurityObjects::UserInfoAndPolicy &, unsigned long, bool &, bool &, bool &) { return false; }
+    bool AuthClient::IsAuthorized(const std::string &, SecurityObjects::UserInfoAndPolicy &, unsigned long, bool &, bool &, bool) { return false; }
+}
+
+namespace OpenWifi::Utils {
+    std::string FormatIPv6(const std::string &addr) { return addr; }
+    bool ValidUUID(const std::string &uuid) {
+        return uuid.size() == 36 && uuid[8] == '-' && uuid[13] == '-' && uuid[18] == '-' && uuid[23] == '-';
+    }
+}

--- a/tests/unit/test_group_schedules_handlers.cpp
+++ b/tests/unit/test_group_schedules_handlers.cpp
@@ -4,24 +4,9 @@
  * Portions copyright (c) Telecom Infra Project (TIP), BSD-3-Clause
  */
 
-#include <functional>
-#include <iostream>
-#include <sstream>
-#include <stdexcept>
-#include <string>
-#include <vector>
-
-#include "Poco/JSON/Array.h"
-#include "Poco/JSON/Object.h"
-#include "Poco/JSON/Parser.h"
-#include "Poco/Logger.h"
-#include "Poco/Net/HTTPServerParams.h"
-#include "Poco/Net/SocketAddress.h"
+#include "test_parental_control_test_helpers.h"
 #include "RESTAPI/RESTAPI_group_schedules_handler.h"
 #include "RESTAPI/RESTAPI_group_schedules_list_handler.h"
-#include "RESTAPI/RESTAPI_parental_control_utils.h"
-#include "framework/RESTAPI_GenericServerAccounting.h"
-#include "sdks/SDK_parental_control.h"
 
 namespace {
 
@@ -29,94 +14,6 @@ const std::string kValidGroupId = "11111111-1111-4111-8111-111111111111";
 const std::string kValidScheduleId = "22222222-2222-4222-8222-222222222222";
 const std::string kAnotherScheduleId = "33333333-3333-4333-8333-333333333333";
 const std::string kInvalidUuid = "not-a-uuid";
-
-class TestFailure : public std::runtime_error {
-  public:
-    using std::runtime_error::runtime_error;
-};
-
-void Expect(bool condition, const std::string &message) {
-    if (!condition) {
-        throw TestFailure(message);
-    }
-}
-
-template <typename T, typename U> void ExpectEq(const T &actual, const U &expected, const std::string &message) {
-    if (!(actual == expected)) {
-        std::ostringstream os;
-        os << message << " expected=" << expected << " actual=" << actual;
-        throw TestFailure(os.str());
-    }
-}
-
-class FakeHTTPServerParams final : public Poco::Net::HTTPServerParams {
-  public:
-    ~FakeHTTPServerParams() override = default;
-};
-
-class FakeResponse final : public Poco::Net::HTTPServerResponse {
-  public:
-    void sendContinue() override {}
-
-    std::ostream &send() override {
-        sent_ = true;
-        return body_;
-    }
-
-    void sendFile(const std::string &, const std::string &) override { sent_ = true; }
-
-    void sendBuffer(const void *buffer, std::size_t length) override {
-        sent_ = true;
-        body_.write(static_cast<const char *>(buffer), static_cast<std::streamsize>(length));
-    }
-
-    void redirect(const std::string &uri, HTTPStatus status = HTTP_FOUND) override {
-        setStatus(status);
-        set("Location", uri);
-        sent_ = true;
-    }
-
-    void requireAuthentication(const std::string &realm) override {
-        setStatus(HTTP_UNAUTHORIZED);
-        set("WWW-Authenticate", realm);
-        sent_ = true;
-    }
-
-    bool sent() const override { return sent_; }
-    std::string body() const { return body_.str(); }
-
-  private:
-    bool sent_ = false;
-    std::ostringstream body_;
-};
-
-class FakeRequest final : public Poco::Net::HTTPServerRequest {
-  public:
-    FakeRequest(const std::string &method, const std::string &uri, const std::string &body, FakeResponse &response)
-        : bodyStream_(body), response_(response), clientAddress_("127.0.0.1", 1111), serverAddress_("127.0.0.1", 16006) {
-        setMethod(method);
-        setURI(uri);
-        setVersion(Poco::Net::HTTPMessage::HTTP_1_1);
-        if (!body.empty()) {
-            setContentType("application/json");
-            setContentLength(static_cast<int>(body.size()));
-        }
-    }
-
-    std::istream &stream() override { return bodyStream_; }
-    const Poco::Net::SocketAddress &clientAddress() const override { return clientAddress_; }
-    const Poco::Net::SocketAddress &serverAddress() const override { return serverAddress_; }
-    const Poco::Net::HTTPServerParams &serverParams() const override { return params_; }
-    Poco::Net::HTTPServerResponse &response() const override { return response_; }
-    bool secure() const override { return false; }
-
-  private:
-    std::istringstream bodyStream_;
-    FakeResponse &response_;
-    Poco::Net::SocketAddress clientAddress_;
-    Poco::Net::SocketAddress serverAddress_;
-    FakeHTTPServerParams params_;
-};
 
 struct ScheduleHandlerState {
     bool getListOk = true;
@@ -163,16 +60,6 @@ void ResetState() {
     g_state.getSingleResponse = Poco::JSON::Object::Ptr(new Poco::JSON::Object());
     g_state.deleteResponse = Poco::JSON::Object::Ptr(new Poco::JSON::Object());
     g_state.extractedConfigRaw = Poco::JSON::Array::Ptr(new Poco::JSON::Array());
-}
-
-Poco::JSON::Object::Ptr ParseObject(const std::string &body) {
-    Poco::JSON::Parser parser;
-    return parser.parse(body).extract<Poco::JSON::Object::Ptr>();
-}
-
-Poco::JSON::Array::Ptr ParseArray(const std::string &body) {
-    Poco::JSON::Parser parser;
-    return parser.parse(body).extract<Poco::JSON::Array::Ptr>();
 }
 
 class TestGroupSchedulesListHandler final : public OpenWifi::RESTAPI_group_schedules_list_handler {
@@ -289,18 +176,15 @@ bool DeleteGroupSchedule(RESTAPIHandler *, const std::string &subscriberId, cons
 namespace {
 
 void TestListGetRejectsInvalidGroupUuid() {
-    static OpenWifi::RESTAPI_GenericServerAccounting server;
-    auto &logger = Poco::Logger::get("test_group_schedules_handlers");
-    TestGroupSchedulesListHandler handler({{"group_id", kInvalidUuid}}, logger, server, 1, false);
-    handler.UserInfo_.userinfo.id = "subscriber-1";
-    FakeResponse response;
-    FakeRequest request(Poco::Net::HTTPRequest::HTTP_GET, "/api/v1/groups/x/schedules", "", response);
-    handler.Request = &request;
-    handler.Response = &response;
-
-    handler.DoGet();
-    ExpectEq(static_cast<int>(response.getStatus()), static_cast<int>(Poco::Net::HTTPResponse::HTTP_BAD_REQUEST),
-             "invalid group uuid should return 400");
+    RunHandlerRequest<TestGroupSchedulesListHandler>(
+        Poco::Net::HTTPRequest::HTTP_GET,
+        "/api/v1/groups/x/schedules",
+        "",
+        {{"group_id", kInvalidUuid}},
+        "subscriber-1",
+        "",
+        Poco::Net::HTTPResponse::HTTP_BAD_REQUEST
+    );
 }
 
 void TestListGetReturnsJsonArrayOnSuccess() {
@@ -308,38 +192,38 @@ void TestListGetReturnsJsonArrayOnSuccess() {
     item->set("schedule_id", kValidScheduleId);
     g_state.getListArray->add(item);
 
-    static OpenWifi::RESTAPI_GenericServerAccounting server;
-    auto &logger = Poco::Logger::get("test_group_schedules_handlers");
-    TestGroupSchedulesListHandler handler({{"group_id", kValidGroupId}}, logger, server, 1, false);
-    handler.UserInfo_.userinfo.id = "subscriber-1";
-    FakeResponse response;
-    FakeRequest request(Poco::Net::HTTPRequest::HTTP_GET, "/api/v1/groups/x/schedules", "", response);
-    handler.Request = &request;
-    handler.Response = &response;
-
-    handler.DoGet();
-    auto array = ParseArray(response.body());
-    ExpectEq(array->size(), static_cast<std::size_t>(1), "GET schedules should return one entry");
-    ExpectEq(g_state.lastGroupId, kValidGroupId, "group id should be forwarded");
+    RunHandlerRequest<TestGroupSchedulesListHandler>(
+        Poco::Net::HTTPRequest::HTTP_GET,
+        "/api/v1/groups/x/schedules",
+        "",
+        {{"group_id", kValidGroupId}},
+        "subscriber-1",
+        "",
+        Poco::Net::HTTPResponse::HTTP_OK,
+        nullptr,
+        [](const FakeResponse &response) {
+            auto array = ParseArray(response.body());
+            ExpectEq(array->size(), static_cast<std::size_t>(1), "GET schedules should return one entry");
+            ExpectEq(g_state.lastGroupId, kValidGroupId, "group id should be forwarded");
+        }
+    );
 }
 
 void TestPostRejectsInvalidScheduleId() {
-    static OpenWifi::RESTAPI_GenericServerAccounting server;
-    auto &logger = Poco::Logger::get("test_group_schedules_handlers");
-    TestGroupSchedulesListHandler handler({{"group_id", kValidGroupId}}, logger, server, 1, false);
-    handler.UserInfo_.userinfo.id = "subscriber-1";
-    handler.UserInfo_.userinfo.owner = "operator-1";
-    auto body = Poco::JSON::Object::Ptr(new Poco::JSON::Object());
-    body->set("schedule_id", kInvalidUuid);
-    handler.setParsedBody(body);
-    FakeResponse response;
-    FakeRequest request(Poco::Net::HTTPRequest::HTTP_POST, "/api/v1/groups/x/schedules", "{\"schedule_id\":\"bad\"}", response);
-    handler.Request = &request;
-    handler.Response = &response;
-
-    handler.DoPost();
-    ExpectEq(static_cast<int>(response.getStatus()), static_cast<int>(Poco::Net::HTTPResponse::HTTP_BAD_REQUEST),
-             "invalid schedule_id should return 400");
+    RunHandlerRequest<TestGroupSchedulesListHandler>(
+        Poco::Net::HTTPRequest::HTTP_POST,
+        "/api/v1/groups/x/schedules",
+        "{\"schedule_id\":\"bad\"}",
+        {{"group_id", kValidGroupId}},
+        "subscriber-1",
+        "operator-1",
+        Poco::Net::HTTPResponse::HTTP_BAD_REQUEST,
+        [](TestGroupSchedulesListHandler &handler) {
+            auto body = Poco::JSON::Object::Ptr(new Poco::JSON::Object());
+            body->set("schedule_id", kInvalidUuid);
+            handler.setParsedBody(body);
+        }
+    );
 }
 
 void TestPostStripsConfigRawAndReturnsObject() {
@@ -348,66 +232,64 @@ void TestPostStripsConfigRawAndReturnsObject() {
     responseObject->set("config-raw", Poco::JSON::Array::Ptr(new Poco::JSON::Array()));
     g_state.createResponse = responseObject;
 
-    static OpenWifi::RESTAPI_GenericServerAccounting server;
-    auto &logger = Poco::Logger::get("test_group_schedules_handlers");
-    TestGroupSchedulesListHandler handler({{"group_id", kValidGroupId}}, logger, server, 1, false);
-    handler.UserInfo_.userinfo.id = "subscriber-1";
-    handler.UserInfo_.userinfo.owner = "operator-1";
-    auto body = Poco::JSON::Object::Ptr(new Poco::JSON::Object());
-    body->set("schedule_id", kValidScheduleId);
-    handler.setParsedBody(body);
-    FakeResponse response;
-    FakeRequest request(Poco::Net::HTTPRequest::HTTP_POST, "/api/v1/groups/x/schedules", "{\"schedule_id\":\"ok\"}", response);
-    handler.Request = &request;
-    handler.Response = &response;
-
-    handler.DoPost();
-    auto parsed = ParseObject(response.body());
-    Expect(!parsed->has("config-raw"), "POST response should strip config-raw");
-    ExpectEq(parsed->getValue<std::string>("schedule_id"), kValidScheduleId, "schedule_id should remain");
+    RunHandlerRequest<TestGroupSchedulesListHandler>(
+        Poco::Net::HTTPRequest::HTTP_POST,
+        "/api/v1/groups/x/schedules",
+        "{\"schedule_id\":\"ok\"}",
+        {{"group_id", kValidGroupId}},
+        "subscriber-1",
+        "operator-1",
+        Poco::Net::HTTPResponse::HTTP_OK,
+        [](TestGroupSchedulesListHandler &handler) {
+            auto body = Poco::JSON::Object::Ptr(new Poco::JSON::Object());
+            body->set("schedule_id", kValidScheduleId);
+            handler.setParsedBody(body);
+        },
+        [](const FakeResponse &response) {
+            auto parsed = ParseObject(response.body());
+            Expect(!parsed->has("config-raw"), "POST response should strip config-raw");
+            ExpectEq(parsed->getValue<std::string>("schedule_id"), kValidScheduleId, "schedule_id should remain");
+        }
+    );
 }
 
 void TestPutRejectsDuplicateScheduleIds() {
-    static OpenWifi::RESTAPI_GenericServerAccounting server;
-    auto &logger = Poco::Logger::get("test_group_schedules_handlers");
-    TestGroupSchedulesListHandler handler({{"group_id", kValidGroupId}}, logger, server, 1, false);
-    handler.UserInfo_.userinfo.id = "subscriber-1";
-    handler.UserInfo_.userinfo.owner = "operator-1";
-    auto ids = Poco::JSON::Array::Ptr(new Poco::JSON::Array());
-    ids->add(kValidScheduleId);
-    ids->add(kValidScheduleId);
-    auto body = Poco::JSON::Object::Ptr(new Poco::JSON::Object());
-    body->set("schedule_ids", ids);
-    handler.setParsedBody(body);
-    FakeResponse response;
-    FakeRequest request(Poco::Net::HTTPRequest::HTTP_PUT, "/api/v1/groups/x/schedules", "{\"schedule_ids\":[]}", response);
-    handler.Request = &request;
-    handler.Response = &response;
-
-    handler.DoPut();
-    ExpectEq(static_cast<int>(response.getStatus()), static_cast<int>(Poco::Net::HTTPResponse::HTTP_BAD_REQUEST),
-             "duplicate schedule_ids should return 400");
+    RunHandlerRequest<TestGroupSchedulesListHandler>(
+        Poco::Net::HTTPRequest::HTTP_PUT,
+        "/api/v1/groups/x/schedules",
+        "{\"schedule_ids\":[]}",
+        {{"group_id", kValidGroupId}},
+        "subscriber-1",
+        "operator-1",
+        Poco::Net::HTTPResponse::HTTP_BAD_REQUEST,
+        [](TestGroupSchedulesListHandler &handler) {
+            auto ids = Poco::JSON::Array::Ptr(new Poco::JSON::Array());
+            ids->add(kValidScheduleId);
+            ids->add(kValidScheduleId);
+            auto body = Poco::JSON::Object::Ptr(new Poco::JSON::Object());
+            body->set("schedule_ids", ids);
+            handler.setParsedBody(body);
+        }
+    );
 }
 
 void TestPutRejectsNonStringScheduleIdEntry() {
-    static OpenWifi::RESTAPI_GenericServerAccounting server;
-    auto &logger = Poco::Logger::get("test_group_schedules_handlers");
-    TestGroupSchedulesListHandler handler({{"group_id", kValidGroupId}}, logger, server, 1, false);
-    handler.UserInfo_.userinfo.id = "subscriber-1";
-    handler.UserInfo_.userinfo.owner = "operator-1";
-    auto ids = Poco::JSON::Array::Ptr(new Poco::JSON::Array());
-    ids->add(7);
-    auto body = Poco::JSON::Object::Ptr(new Poco::JSON::Object());
-    body->set("schedule_ids", ids);
-    handler.setParsedBody(body);
-    FakeResponse response;
-    FakeRequest request(Poco::Net::HTTPRequest::HTTP_PUT, "/api/v1/groups/x/schedules", "{\"schedule_ids\":[]}", response);
-    handler.Request = &request;
-    handler.Response = &response;
-
-    handler.DoPut();
-    ExpectEq(static_cast<int>(response.getStatus()), static_cast<int>(Poco::Net::HTTPResponse::HTTP_BAD_REQUEST),
-             "non-string schedule_ids entry should return 400");
+    RunHandlerRequest<TestGroupSchedulesListHandler>(
+        Poco::Net::HTTPRequest::HTTP_PUT,
+        "/api/v1/groups/x/schedules",
+        "{\"schedule_ids\":[]}",
+        {{"group_id", kValidGroupId}},
+        "subscriber-1",
+        "operator-1",
+        Poco::Net::HTTPResponse::HTTP_BAD_REQUEST,
+        [](TestGroupSchedulesListHandler &handler) {
+            auto ids = Poco::JSON::Array::Ptr(new Poco::JSON::Array());
+            ids->add(7);
+            auto body = Poco::JSON::Object::Ptr(new Poco::JSON::Object());
+            body->set("schedule_ids", ids);
+            handler.setParsedBody(body);
+        }
+    );
 }
 
 void TestPutStripsConfigRawAndReturnsObject() {
@@ -416,26 +298,28 @@ void TestPutStripsConfigRawAndReturnsObject() {
     responseObject->set("config-raw", Poco::JSON::Array::Ptr(new Poco::JSON::Array()));
     g_state.replaceResponse = responseObject;
 
-    static OpenWifi::RESTAPI_GenericServerAccounting server;
-    auto &logger = Poco::Logger::get("test_group_schedules_handlers");
-    TestGroupSchedulesListHandler handler({{"group_id", kValidGroupId}}, logger, server, 1, false);
-    handler.UserInfo_.userinfo.id = "subscriber-1";
-    handler.UserInfo_.userinfo.owner = "operator-1";
-    auto ids = Poco::JSON::Array::Ptr(new Poco::JSON::Array());
-    ids->add(kValidScheduleId);
-    ids->add(kAnotherScheduleId);
-    auto body = Poco::JSON::Object::Ptr(new Poco::JSON::Object());
-    body->set("schedule_ids", ids);
-    handler.setParsedBody(body);
-    FakeResponse response;
-    FakeRequest request(Poco::Net::HTTPRequest::HTTP_PUT, "/api/v1/groups/x/schedules", "{\"schedule_ids\":[]}", response);
-    handler.Request = &request;
-    handler.Response = &response;
-
-    handler.DoPut();
-    auto parsed = ParseObject(response.body());
-    Expect(!parsed->has("config-raw"), "PUT response should strip config-raw");
-    ExpectEq(g_state.replaceCount, static_cast<std::size_t>(2), "two schedule ids should be forwarded");
+    RunHandlerRequest<TestGroupSchedulesListHandler>(
+        Poco::Net::HTTPRequest::HTTP_PUT,
+        "/api/v1/groups/x/schedules",
+        "{\"schedule_ids\":[]}",
+        {{"group_id", kValidGroupId}},
+        "subscriber-1",
+        "operator-1",
+        Poco::Net::HTTPResponse::HTTP_OK,
+        [](TestGroupSchedulesListHandler &handler) {
+            auto ids = Poco::JSON::Array::Ptr(new Poco::JSON::Array());
+            ids->add(kValidScheduleId);
+            ids->add(kAnotherScheduleId);
+            auto body = Poco::JSON::Object::Ptr(new Poco::JSON::Object());
+            body->set("schedule_ids", ids);
+            handler.setParsedBody(body);
+        },
+        [](const FakeResponse &response) {
+            auto parsed = ParseObject(response.body());
+            Expect(!parsed->has("config-raw"), "PUT response should strip config-raw");
+            ExpectEq(g_state.replaceCount, static_cast<std::size_t>(2), "two schedule ids should be forwarded");
+        }
+    );
 }
 
 void TestSingleGetReturnsObjectOnSuccess() {
@@ -443,33 +327,32 @@ void TestSingleGetReturnsObjectOnSuccess() {
     responseObject->set("schedule_id", kValidScheduleId);
     g_state.getSingleResponse = responseObject;
 
-    static OpenWifi::RESTAPI_GenericServerAccounting server;
-    auto &logger = Poco::Logger::get("test_group_schedules_handlers");
-    TestGroupSchedulesHandler handler({{"group_id", kValidGroupId}, {"schedule_id", kValidScheduleId}}, logger, server, 1, false);
-    handler.UserInfo_.userinfo.id = "subscriber-1";
-    FakeResponse response;
-    FakeRequest request(Poco::Net::HTTPRequest::HTTP_GET, "/api/v1/groups/x/schedules/y", "", response);
-    handler.Request = &request;
-    handler.Response = &response;
-
-    handler.DoGet();
-    auto parsed = ParseObject(response.body());
-    ExpectEq(parsed->getValue<std::string>("schedule_id"), kValidScheduleId, "GET should return schedule object");
+    RunHandlerRequest<TestGroupSchedulesHandler>(
+        Poco::Net::HTTPRequest::HTTP_GET,
+        "/api/v1/groups/x/schedules/y",
+        "",
+        {{"group_id", kValidGroupId}, {"schedule_id", kValidScheduleId}},
+        "subscriber-1",
+        "",
+        Poco::Net::HTTPResponse::HTTP_OK,
+        nullptr,
+        [](const FakeResponse &response) {
+            auto parsed = ParseObject(response.body());
+            ExpectEq(parsed->getValue<std::string>("schedule_id"), kValidScheduleId, "GET should return schedule object");
+        }
+    );
 }
 
 void TestSingleDeleteRejectsMissingOwner() {
-    static OpenWifi::RESTAPI_GenericServerAccounting server;
-    auto &logger = Poco::Logger::get("test_group_schedules_handlers");
-    TestGroupSchedulesHandler handler({{"group_id", kValidGroupId}, {"schedule_id", kValidScheduleId}}, logger, server, 1, false);
-    handler.UserInfo_.userinfo.id = "subscriber-1";
-    FakeResponse response;
-    FakeRequest request(Poco::Net::HTTPRequest::HTTP_DELETE, "/api/v1/groups/x/schedules/y", "", response);
-    handler.Request = &request;
-    handler.Response = &response;
-
-    handler.DoDelete();
-    ExpectEq(static_cast<int>(response.getStatus()), static_cast<int>(Poco::Net::HTTPResponse::HTTP_FORBIDDEN),
-             "missing owner should return 403");
+    RunHandlerRequest<TestGroupSchedulesHandler>(
+        Poco::Net::HTTPRequest::HTTP_DELETE,
+        "/api/v1/groups/x/schedules/y",
+        "",
+        {{"group_id", kValidGroupId}, {"schedule_id", kValidScheduleId}},
+        "subscriber-1",
+        "",
+        Poco::Net::HTTPResponse::HTTP_FORBIDDEN
+    );
 }
 
 void TestSingleDeleteReturnsOkOnSuccess() {
@@ -477,19 +360,15 @@ void TestSingleDeleteReturnsOkOnSuccess() {
     responseObject->set("config-raw", Poco::JSON::Array::Ptr(new Poco::JSON::Array()));
     g_state.deleteResponse = responseObject;
 
-    static OpenWifi::RESTAPI_GenericServerAccounting server;
-    auto &logger = Poco::Logger::get("test_group_schedules_handlers");
-    TestGroupSchedulesHandler handler({{"group_id", kValidGroupId}, {"schedule_id", kValidScheduleId}}, logger, server, 1, false);
-    handler.UserInfo_.userinfo.id = "subscriber-1";
-    handler.UserInfo_.userinfo.owner = "operator-1";
-    FakeResponse response;
-    FakeRequest request(Poco::Net::HTTPRequest::HTTP_DELETE, "/api/v1/groups/x/schedules/y", "", response);
-    handler.Request = &request;
-    handler.Response = &response;
-
-    handler.DoDelete();
-    ExpectEq(static_cast<int>(response.getStatus()), static_cast<int>(Poco::Net::HTTPResponse::HTTP_OK),
-             "successful delete should return 200");
+    RunHandlerRequest<TestGroupSchedulesHandler>(
+        Poco::Net::HTTPRequest::HTTP_DELETE,
+        "/api/v1/groups/x/schedules/y",
+        "",
+        {{"group_id", kValidGroupId}, {"schedule_id", kValidScheduleId}},
+        "subscriber-1",
+        "operator-1",
+        Poco::Net::HTTPResponse::HTTP_OK
+    );
 }
 
 const std::vector<std::pair<std::string, std::function<void()>>> kTests = {
@@ -530,34 +409,3 @@ int main() {
     return 0;
 }
 
-namespace Poco::Util { class Application; }
-namespace Poco::Net { class HTTPRequestHandler; }
-namespace OpenWifi {
-    class RESTAPI_GenericServerAccounting;
-    void DaemonPostInitialization(Poco::Util::Application &) {}
-    Poco::Net::HTTPRequestHandler* RESTAPI_ExtRouter(const std::string &, std::map<std::string, std::string> &, Poco::Logger &, RESTAPI_GenericServerAccounting &, unsigned long) {
-        return nullptr;
-    }
-    Poco::Net::HTTPRequestHandler* RESTAPI_IntRouter(const std::string &, std::map<std::string, std::string> &, Poco::Logger &, RESTAPI_GenericServerAccounting &, unsigned long) {
-        return nullptr;
-    }
-
-    SubSystemServer::SubSystemServer(const std::string &Name, const std::string &LoggingPrefix,
-                                     const std::string &SubSystemConfigPrefix)
-        : Name_(Name), LoggerPrefix_(LoggingPrefix), SubSystemConfigPrefix_(SubSystemConfigPrefix),
-          Logger_(std::make_unique<LoggerWrapper>(Poco::Logger::get(LoggingPrefix))) {}
-
-    void SubSystemServer::initialize(Poco::Util::Application &) {}
-
-    bool AllowExternalMicroServices() { return false; }
-    bool MicroServiceIsValidAPIKEY(const Poco::Net::HTTPServerRequest &) { return false; }
-    bool AuthClient::IsValidApiKey(const std::string &, SecurityObjects::UserInfoAndPolicy &, unsigned long, bool &, bool &, bool &) { return false; }
-    bool AuthClient::IsAuthorized(const std::string &, SecurityObjects::UserInfoAndPolicy &, unsigned long, bool &, bool &, bool) { return false; }
-}
-
-namespace OpenWifi::Utils {
-    std::string FormatIPv6(const std::string &addr) { return addr; }
-    bool ValidUUID(const std::string &uuid) {
-        return uuid.size() == 36 && uuid[8] == '-' && uuid[13] == '-' && uuid[18] == '-' && uuid[23] == '-';
-    }
-}

--- a/tests/unit/test_parental_control_test_helpers.h
+++ b/tests/unit/test_parental_control_test_helpers.h
@@ -1,0 +1,209 @@
+/*
+ * SPDX-License-Identifier: AGPL-3.0 OR LicenseRef-Commercial
+ * Copyright (c) 2025 Infernet Systems Pvt Ltd
+ * Portions copyright (c) Telecom Infra Project (TIP), BSD-3-Clause
+ */
+
+#pragma once
+
+#include <iostream>
+#include <sstream>
+#include <stdexcept>
+#include <string>
+#include <vector>
+#include <map>
+#include <memory>
+#include <functional>
+
+#include "Poco/JSON/Object.h"
+#include "Poco/JSON/Array.h"
+#include "Poco/JSON/Parser.h"
+#include "Poco/Logger.h"
+#include "Poco/Net/HTTPServerParams.h"
+#include "Poco/Net/HTTPServerRequest.h"
+#include "Poco/Net/HTTPServerResponse.h"
+#include "Poco/Net/SocketAddress.h"
+
+#include "framework/MicroService.h"
+#include "framework/RESTAPI_GenericServerAccounting.h"
+#include "framework/AuthClient.h"
+#include "RESTAPI/RESTAPI_parental_control_utils.h"
+#include "sdks/SDK_parental_control.h"
+
+class TestFailure : public std::runtime_error {
+  public:
+    using std::runtime_error::runtime_error;
+};
+
+inline void Expect(bool condition, const std::string &message) {
+    if (!condition) {
+        throw TestFailure(message);
+    }
+}
+
+template <typename T, typename U>
+inline void ExpectEq(const T &actual, const U &expected, const std::string &message) {
+    if (!(actual == expected)) {
+        std::ostringstream os;
+        os << message << " expected=" << expected << " actual=" << actual;
+        throw TestFailure(os.str());
+    }
+}
+
+inline Poco::JSON::Object::Ptr ParseObject(const std::string &body) {
+    Poco::JSON::Parser parser;
+    return parser.parse(body).extract<Poco::JSON::Object::Ptr>();
+}
+
+inline Poco::JSON::Array::Ptr ParseArray(const std::string &body) {
+    Poco::JSON::Parser parser;
+    return parser.parse(body).extract<Poco::JSON::Array::Ptr>();
+}
+
+class FakeHTTPServerParams final : public Poco::Net::HTTPServerParams {
+  public:
+    ~FakeHTTPServerParams() override = default;
+};
+
+class FakeResponse final : public Poco::Net::HTTPServerResponse {
+  public:
+    void sendContinue() override {}
+
+    std::ostream &send() override {
+        sent_ = true;
+        return body_;
+    }
+
+    void sendFile(const std::string &, const std::string &) override { sent_ = true; }
+
+    void sendBuffer(const void *buffer, std::size_t length) override {
+        sent_ = true;
+        body_.write(static_cast<const char *>(buffer), static_cast<std::streamsize>(length));
+    }
+
+    void redirect(const std::string &uri, HTTPStatus status = HTTP_FOUND) override {
+        setStatus(status);
+        set("Location", uri);
+        sent_ = true;
+    }
+
+    void requireAuthentication(const std::string &realm) override {
+        setStatus(HTTP_UNAUTHORIZED);
+        set("WWW-Authenticate", realm);
+        sent_ = true;
+    }
+
+    bool sent() const override { return sent_; }
+    std::string body() const { return body_.str(); }
+
+  private:
+    bool sent_ = false;
+    std::ostringstream body_;
+};
+
+class FakeRequest final : public Poco::Net::HTTPServerRequest {
+  public:
+    FakeRequest(const std::string &method, const std::string &uri, const std::string &body, FakeResponse &response)
+        : bodyStream_(body), response_(response), clientAddress_("127.0.0.1", 1111), serverAddress_("127.0.0.1", 16006) {
+        setMethod(method);
+        setURI(uri);
+        setVersion(Poco::Net::HTTPMessage::HTTP_1_1);
+        if (!body.empty()) {
+            setContentType("application/json");
+            setContentLength(static_cast<int>(body.size()));
+        }
+    }
+
+    std::istream &stream() override { return bodyStream_; }
+    const Poco::Net::SocketAddress &clientAddress() const override { return clientAddress_; }
+    const Poco::Net::SocketAddress &serverAddress() const override { return serverAddress_; }
+    const Poco::Net::HTTPServerParams &serverParams() const override { return params_; }
+    Poco::Net::HTTPServerResponse &response() const override { return response_; }
+    bool secure() const override { return false; }
+
+  private:
+    std::istringstream bodyStream_;
+    FakeResponse &response_;
+    Poco::Net::SocketAddress clientAddress_;
+    Poco::Net::SocketAddress serverAddress_;
+    FakeHTTPServerParams params_;
+};
+
+template <typename HandlerType>
+inline void RunHandlerRequest(
+    const std::string &method,
+    const std::string &uri,
+    const std::string &body,
+    const std::map<std::string, std::string> &bindings,
+    const std::string &subscriberId,
+    const std::string &operatorId,
+    Poco::Net::HTTPResponse::HTTPStatus expectedStatus,
+    const std::function<void(HandlerType &)> &customSetup = nullptr,
+    const std::function<void(const FakeResponse &)> &assertions = nullptr
+) {
+    static OpenWifi::RESTAPI_GenericServerAccounting server;
+    auto &logger = Poco::Logger::get("test_handlers");
+    HandlerType handler(bindings, logger, server, 1, false);
+    if (!subscriberId.empty()) {
+        handler.UserInfo_.userinfo.id = subscriberId;
+    }
+    if (!operatorId.empty()) {
+        handler.UserInfo_.userinfo.owner = operatorId;
+    }
+    if (customSetup) {
+        customSetup(handler);
+    }
+    FakeResponse response;
+    FakeRequest request(method, uri, body, response);
+    handler.Request = &request;
+    handler.Response = &response;
+
+    if (method == Poco::Net::HTTPRequest::HTTP_GET) {
+        handler.DoGet();
+    } else if (method == Poco::Net::HTTPRequest::HTTP_POST) {
+        handler.DoPost();
+    } else if (method == Poco::Net::HTTPRequest::HTTP_PUT) {
+        handler.DoPut();
+    } else if (method == Poco::Net::HTTPRequest::HTTP_DELETE) {
+        handler.DoDelete();
+    }
+
+    ExpectEq(static_cast<int>(response.getStatus()), static_cast<int>(expectedStatus),
+             "HTTP status mismatch for " + method + " " + uri);
+    if (assertions) {
+        assertions(response);
+    }
+}
+
+namespace Poco::Util { class Application; }
+namespace Poco::Net { class HTTPRequestHandler; }
+namespace OpenWifi {
+    class RESTAPI_GenericServerAccounting;
+    inline void DaemonPostInitialization(Poco::Util::Application &) {}
+    inline Poco::Net::HTTPRequestHandler* RESTAPI_ExtRouter(const std::string &, std::map<std::string, std::string> &, Poco::Logger &, RESTAPI_GenericServerAccounting &, unsigned long) {
+        return nullptr;
+    }
+    inline Poco::Net::HTTPRequestHandler* RESTAPI_IntRouter(const std::string &, std::map<std::string, std::string> &, Poco::Logger &, RESTAPI_GenericServerAccounting &, unsigned long) {
+        return nullptr;
+    }
+
+    inline SubSystemServer::SubSystemServer(const std::string &Name, const std::string &LoggingPrefix,
+                                     const std::string &SubSystemConfigPrefix)
+        : Name_(Name), LoggerPrefix_(LoggingPrefix),
+          Logger_(std::make_unique<LoggerWrapper>(Poco::Logger::get(LoggingPrefix))),
+          SubSystemConfigPrefix_(SubSystemConfigPrefix) {}
+
+    inline void SubSystemServer::initialize(Poco::Util::Application &) {}
+
+    inline bool AllowExternalMicroServices() { return false; }
+    inline bool MicroServiceIsValidAPIKEY(const Poco::Net::HTTPServerRequest &) { return false; }
+    inline bool AuthClient::IsValidApiKey(const std::string &, SecurityObjects::UserInfoAndPolicy &, unsigned long, bool &, bool &, bool &) { return false; }
+    inline bool AuthClient::IsAuthorized(const std::string &, SecurityObjects::UserInfoAndPolicy &, unsigned long, bool &, bool &, bool) { return false; }
+}
+
+namespace OpenWifi::Utils {
+    inline std::string FormatIPv6(const std::string &addr) { return addr; }
+    inline bool ValidUUID(const std::string &uuid) {
+        return uuid.size() == 36 && uuid[8] == '-' && uuid[13] == '-' && uuid[18] == '-' && uuid[23] == '-';
+    }
+}

--- a/tests/unit/test_parental_control_utils.cpp
+++ b/tests/unit/test_parental_control_utils.cpp
@@ -1,0 +1,607 @@
+/*
+ * SPDX-License-Identifier: AGPL-3.0 OR LicenseRef-Commercial
+ * Copyright (c) 2025 Infernet Systems Pvt Ltd
+ * Portions copyright (c) Telecom Infra Project (TIP), BSD-3-Clause
+ */
+
+#include <algorithm>
+#include <cctype>
+#include <functional>
+#include <iostream>
+#include <sstream>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+#include "Poco/JSON/Array.h"
+#include "Poco/JSON/Object.h"
+#include "Poco/JSON/Parser.h"
+#include "Poco/Logger.h"
+#include "Poco/Net/HTTPServerParams.h"
+#include "Poco/Net/SocketAddress.h"
+#include "RESTAPI/RESTAPI_parental_control_utils.h"
+#include "framework/RESTAPI_GenericServerAccounting.h"
+#include "sdks/SDK_gw.h"
+#include "sdks/SDK_nw_topology.h"
+#include "sdks/SDK_prov.h"
+
+namespace {
+
+class TestFailure : public std::runtime_error {
+  public:
+    using std::runtime_error::runtime_error;
+};
+
+void Expect(bool condition, const std::string &message) {
+    if (!condition) {
+        throw TestFailure(message);
+    }
+}
+
+template <typename T, typename U> void ExpectEq(const T &actual, const U &expected, const std::string &message) {
+    if (!(actual == expected)) {
+        std::ostringstream os;
+        os << message << " expected=" << expected << " actual=" << actual;
+        throw TestFailure(os.str());
+    }
+}
+
+Poco::JSON::Array::Ptr MakeStringArray(std::initializer_list<std::string> values) {
+    auto arr = Poco::JSON::Array::Ptr(new Poco::JSON::Array());
+    for (const auto &value : values) {
+        arr->add(value);
+    }
+    return arr;
+}
+
+Poco::JSON::Array::Ptr MakeIntArray(std::initializer_list<int> values) {
+    auto arr = Poco::JSON::Array::Ptr(new Poco::JSON::Array());
+    for (int value : values) {
+        arr->add(value);
+    }
+    return arr;
+}
+
+std::string StripMac(const std::string &value) {
+    std::string result;
+    for (char c : value) {
+        if (c == ':' || c == '-' || c == '.') {
+            continue;
+        }
+        result.push_back(static_cast<char>(std::toupper(static_cast<unsigned char>(c))));
+    }
+    return result;
+}
+
+bool IsNormalizedMac(const std::string &value) {
+    if (value.size() != 12) {
+        return false;
+    }
+    return std::all_of(value.begin(), value.end(), [](unsigned char c) { return std::isxdigit(c) != 0; });
+}
+
+std::string MacWithColons(const std::string &value) {
+    if (!IsNormalizedMac(value)) {
+        return value;
+    }
+    std::ostringstream os;
+    for (std::size_t i = 0; i < value.size(); i += 2) {
+        if (i != 0) {
+            os << ':';
+        }
+        os << value.substr(i, 2);
+    }
+    return os.str();
+}
+
+class FakeHTTPServerParams final : public Poco::Net::HTTPServerParams {
+  public:
+    ~FakeHTTPServerParams() override = default;
+};
+
+class FakeResponse final : public Poco::Net::HTTPServerResponse {
+  public:
+    void sendContinue() override {}
+
+    std::ostream &send() override {
+        sent_ = true;
+        return body_;
+    }
+
+    void sendFile(const std::string &, const std::string &) override { sent_ = true; }
+
+    void sendBuffer(const void *buffer, std::size_t length) override {
+        sent_ = true;
+        body_.write(static_cast<const char *>(buffer), static_cast<std::streamsize>(length));
+    }
+
+    void redirect(const std::string &uri, HTTPStatus status = HTTP_FOUND) override {
+        setStatus(status);
+        set("Location", uri);
+        sent_ = true;
+    }
+
+    void requireAuthentication(const std::string &realm) override {
+        setStatus(HTTP_UNAUTHORIZED);
+        set("WWW-Authenticate", realm);
+        sent_ = true;
+    }
+
+    bool sent() const override { return sent_; }
+
+    std::string body() const { return body_.str(); }
+
+  private:
+    bool sent_ = false;
+    std::ostringstream body_;
+};
+
+class FakeRequest final : public Poco::Net::HTTPServerRequest {
+  public:
+    FakeRequest(const std::string &method, const std::string &uri, const std::string &body, FakeResponse &response)
+        : bodyStream_(body), response_(response), clientAddress_("127.0.0.1", 1111), serverAddress_("127.0.0.1", 16006) {
+        setMethod(method);
+        setURI(uri);
+        setVersion(Poco::Net::HTTPMessage::HTTP_1_1);
+        if (!body.empty()) {
+            setContentType("application/json");
+            setContentLength(static_cast<int>(body.size()));
+        }
+    }
+
+    std::istream &stream() override { return bodyStream_; }
+    const Poco::Net::SocketAddress &clientAddress() const override { return clientAddress_; }
+    const Poco::Net::SocketAddress &serverAddress() const override { return serverAddress_; }
+    const Poco::Net::HTTPServerParams &serverParams() const override { return params_; }
+    Poco::Net::HTTPServerResponse &response() const override { return response_; }
+    bool secure() const override { return false; }
+
+  private:
+    std::istringstream bodyStream_;
+    FakeResponse &response_;
+    Poco::Net::SocketAddress clientAddress_;
+    Poco::Net::SocketAddress serverAddress_;
+    FakeHTTPServerParams params_;
+};
+
+
+struct StubState {
+    bool provGetDevicesOk = true;
+    Poco::Net::HTTPResponse::HTTPStatus provStatus = Poco::Net::HTTPResponse::HTTP_OK;
+    Poco::JSON::Object::Ptr provResponse = Poco::JSON::Object::Ptr(new Poco::JSON::Object());
+    std::vector<std::pair<std::string, std::string>> subscriberDevices;
+
+    bool inventoryOk = true;
+    OpenWifi::ProvObjects::InventoryTag inventory;
+
+    bool venueOk = true;
+    Poco::Net::HTTPResponse::HTTPStatus venueStatus = Poco::Net::HTTPResponse::HTTP_OK;
+    Poco::JSON::Object::Ptr venueResponse = Poco::JSON::Object::Ptr(new Poco::JSON::Object());
+    OpenWifi::ProvObjects::Venue venue;
+
+    bool topologyOk = true;
+    Poco::Net::HTTPResponse::HTTPStatus topologyStatus = Poco::Net::HTTPResponse::HTTP_OK;
+    Poco::JSON::Object::Ptr topologyResponse = Poco::JSON::Object::Ptr(new Poco::JSON::Object());
+    std::string lastBoardId;
+
+    bool gatewayGetConfigOk = true;
+    Poco::Net::HTTPResponse::HTTPStatus gatewayGetConfigStatus = Poco::Net::HTTPResponse::HTTP_OK;
+    Poco::JSON::Object::Ptr gatewayGetConfigResponse = Poco::JSON::Object::Ptr(new Poco::JSON::Object());
+
+    bool gatewayConfigureOk = true;
+    Poco::Net::HTTPResponse::HTTPStatus gatewayConfigureStatus = Poco::Net::HTTPResponse::HTTP_OK;
+    Poco::JSON::Object::Ptr gatewayConfigureResponse = Poco::JSON::Object::Ptr(new Poco::JSON::Object());
+    std::string configuredSerial;
+    Poco::JSON::Object::Ptr configuredObject;
+};
+
+StubState g_state;
+
+void ResetStubs() {
+    g_state = StubState{};
+    g_state.inventory.venue = "venue-1";
+    g_state.venue.boards = {"board-1"};
+
+    auto configuration = Poco::JSON::Object::Ptr(new Poco::JSON::Object());
+    configuration->set("existing", "value");
+    auto gatewayObject = Poco::JSON::Object::Ptr(new Poco::JSON::Object());
+    gatewayObject->set("configuration", configuration);
+    g_state.gatewayGetConfigResponse = gatewayObject;
+}
+
+} // namespace
+
+
+namespace OpenWifi::SDK::Prov::Subscriber {
+
+bool GetDevices(RESTAPIHandler *, const std::string &, const std::string &, ProvObjects::SubscriberDeviceList &devList,
+                Poco::Net::HTTPServerResponse::HTTPStatus &callStatus, Poco::JSON::Object::Ptr &callResponse) {
+    callStatus = g_state.provStatus;
+    callResponse = g_state.provResponse;
+    devList.subscriberDevices.clear();
+    for (const auto &entry : g_state.subscriberDevices) {
+        ProvObjects::SubscriberDevice device;
+        device.deviceGroup = entry.first;
+        device.serialNumber = entry.second;
+        devList.subscriberDevices.push_back(device);
+    }
+    return g_state.provGetDevicesOk;
+}
+
+} // namespace OpenWifi::SDK::Prov::Subscriber
+
+namespace OpenWifi::SDK::Prov::Device {
+
+bool Get(RESTAPIHandler *, const std::string &, ProvObjects::InventoryTag &device) {
+    device = g_state.inventory;
+    return g_state.inventoryOk;
+}
+
+} // namespace OpenWifi::SDK::Prov::Device
+
+namespace OpenWifi::SDK::Prov::Venue {
+
+bool Get(RESTAPIHandler *, const std::string &, ProvObjects::Venue &venue,
+         Poco::Net::HTTPServerResponse::HTTPStatus &callStatus, Poco::JSON::Object::Ptr &callResponse) {
+    venue = g_state.venue;
+    callStatus = g_state.venueStatus;
+    callResponse = g_state.venueResponse;
+    return g_state.venueOk;
+}
+
+} // namespace OpenWifi::SDK::Prov::Venue
+
+namespace OpenWifi::SDK::GW::Device {
+
+bool GetConfig(RESTAPIHandler *, const std::string &, Poco::Net::HTTPResponse::HTTPStatus &responseStatus,
+               Poco::JSON::Object::Ptr &response) {
+    responseStatus = g_state.gatewayGetConfigStatus;
+    response = g_state.gatewayGetConfigResponse;
+    return g_state.gatewayGetConfigOk;
+}
+
+bool Configure(RESTAPIHandler *, const std::string &mac, Poco::JSON::Object::Ptr &configuration,
+               Poco::Net::HTTPResponse::HTTPStatus &responseStatus, Poco::JSON::Object::Ptr &response) {
+    g_state.configuredSerial = mac;
+    g_state.configuredObject = configuration;
+    responseStatus = g_state.gatewayConfigureStatus;
+    response = g_state.gatewayConfigureResponse;
+    return g_state.gatewayConfigureOk;
+}
+
+} // namespace OpenWifi::SDK::GW::Device
+
+namespace OpenWifi::SDK::Topology {
+
+bool Get(RESTAPIHandler *, const std::string &boardId, Poco::Net::HTTPServerResponse::HTTPStatus &callStatus,
+         Poco::JSON::Object::Ptr &callResponse) {
+    g_state.lastBoardId = boardId;
+    callStatus = g_state.topologyStatus;
+    callResponse = g_state.topologyResponse;
+    return g_state.topologyOk;
+}
+
+} // namespace OpenWifi::SDK::Topology
+
+#include "../../src/RESTAPI/RESTAPI_parental_control_utils.cpp"
+
+namespace {
+
+Poco::JSON::Object::Ptr MakeTopologyWithHistoricalClient(const std::string &mac) {
+    auto client = Poco::JSON::Object::Ptr(new Poco::JSON::Object());
+    client->set("station", mac);
+
+    auto historicalClients = Poco::JSON::Array::Ptr(new Poco::JSON::Array());
+    historicalClients->add(client);
+
+    auto topology = Poco::JSON::Object::Ptr(new Poco::JSON::Object());
+    topology->set("historicalClients", historicalClients);
+    return topology;
+}
+
+Poco::JSON::Object::Ptr MakeTopologyWithNodesClient(const std::string &mac) {
+    auto client = Poco::JSON::Object::Ptr(new Poco::JSON::Object());
+    client->set("station", mac);
+    auto clients = Poco::JSON::Array::Ptr(new Poco::JSON::Array());
+    clients->add(client);
+
+    auto ap = Poco::JSON::Object::Ptr(new Poco::JSON::Object());
+    ap->set("clients", clients);
+    auto aps = Poco::JSON::Array::Ptr(new Poco::JSON::Array());
+    aps->add(ap);
+
+    auto node = Poco::JSON::Object::Ptr(new Poco::JSON::Object());
+    node->set("aps", aps);
+    auto nodes = Poco::JSON::Array::Ptr(new Poco::JSON::Array());
+    nodes->add(node);
+
+    auto topology = Poco::JSON::Object::Ptr(new Poco::JSON::Object());
+    topology->set("nodes", nodes);
+    return topology;
+}
+
+
+void TestParseTimeStringAcceptsMidnight() {
+    int minuteOfDay = -1;
+    Expect(OpenWifi::RESTAPI::ParentalControl::ParseTimeString(Poco::Dynamic::Var(std::string("00:00")), minuteOfDay),
+           "00:00 should parse");
+    ExpectEq(minuteOfDay, 0, "midnight minute value");
+}
+
+void TestParseTimeStringAcceptsLastMinuteOfDay() {
+    int minuteOfDay = -1;
+    Expect(OpenWifi::RESTAPI::ParentalControl::ParseTimeString(Poco::Dynamic::Var(std::string("23:59")), minuteOfDay),
+           "23:59 should parse");
+    ExpectEq(minuteOfDay, 1439, "23:59 minute value");
+}
+
+void TestParseTimeStringRejectsNonString() {
+    int minuteOfDay = -1;
+    Expect(!OpenWifi::RESTAPI::ParentalControl::ParseTimeString(Poco::Dynamic::Var(7), minuteOfDay),
+           "non-string time should fail");
+}
+
+void TestParseTimeStringRejectsMalformedString() {
+    int minuteOfDay = -1;
+    Expect(!OpenWifi::RESTAPI::ParentalControl::ParseTimeString(Poco::Dynamic::Var(std::string("7:30")), minuteOfDay),
+           "bad HH:MM formatting should fail");
+}
+
+void TestParseTimeStringRejectsHourOutOfRange() {
+    int minuteOfDay = -1;
+    Expect(!OpenWifi::RESTAPI::ParentalControl::ParseTimeString(Poco::Dynamic::Var(std::string("24:00")), minuteOfDay),
+           "24:00 should fail");
+}
+
+void TestParseTimeStringRejectsMinuteOutOfRange() {
+    int minuteOfDay = -1;
+    Expect(!OpenWifi::RESTAPI::ParentalControl::ParseTimeString(Poco::Dynamic::Var(std::string("10:60")), minuteOfDay),
+           "10:60 should fail");
+}
+
+void TestValidateWeekdaysAcceptsDistinctWeekdays() {
+    Expect(OpenWifi::RESTAPI::ParentalControl::ValidateWeekdays(MakeIntArray({0, 2, 4, 6})),
+           "distinct weekday values should pass");
+}
+
+void TestValidateWeekdaysRejectsEmptyArray() {
+    Expect(!OpenWifi::RESTAPI::ParentalControl::ValidateWeekdays(Poco::JSON::Array::Ptr(new Poco::JSON::Array())),
+           "empty weekday array should fail");
+}
+
+void TestValidateWeekdaysRejectsDuplicates() {
+    Expect(!OpenWifi::RESTAPI::ParentalControl::ValidateWeekdays(MakeIntArray({1, 1, 2})),
+           "duplicate weekday array should fail");
+}
+
+void TestValidateWeekdaysRejectsOutOfRangeValue() {
+    Expect(!OpenWifi::RESTAPI::ParentalControl::ValidateWeekdays(MakeIntArray({0, 7})),
+           "weekday outside 0..6 should fail");
+}
+
+void TestValidateWeekdaysRejectsNonIntegerValue() {
+    auto arr = Poco::JSON::Array::Ptr(new Poco::JSON::Array());
+    arr->add("three");
+    Expect(!OpenWifi::RESTAPI::ParentalControl::ValidateWeekdays(arr),
+           "non-integer weekday entries should fail");
+}
+
+void TestNormalizeScheduleResponseConvertsMinuteFields() {
+    auto schedule = Poco::JSON::Object::Ptr(new Poco::JSON::Object());
+    schedule->set("start_minute", 60);
+    schedule->set("stop_minute", 90);
+    schedule->set("config-raw", MakeStringArray({"remove-me"}));
+
+    Expect(OpenWifi::RESTAPI::ParentalControl::NormalizeScheduleResponse(schedule),
+           "schedule normalization should succeed");
+    ExpectEq(schedule->getValue<std::string>("start_time"), std::string("01:00"), "start_time conversion");
+    ExpectEq(schedule->getValue<std::string>("stop_time"), std::string("01:30"), "stop_time conversion");
+    Expect(!schedule->has("start_minute"), "start_minute should be removed");
+    Expect(!schedule->has("stop_minute"), "stop_minute should be removed");
+    Expect(!schedule->has("config-raw"), "config-raw should be removed");
+}
+
+void TestNormalizeScheduleResponseRejectsMissingMinuteFields() {
+    auto schedule = Poco::JSON::Object::Ptr(new Poco::JSON::Object());
+    schedule->set("start_minute", 60);
+    Expect(!OpenWifi::RESTAPI::ParentalControl::NormalizeScheduleResponse(schedule),
+           "missing stop_minute should fail");
+}
+
+void TestNormalizeScheduleResponseRejectsOutOfRangeMinute() {
+    auto schedule = Poco::JSON::Object::Ptr(new Poco::JSON::Object());
+    schedule->set("start_minute", -1);
+    schedule->set("stop_minute", 90);
+    Expect(!OpenWifi::RESTAPI::ParentalControl::NormalizeScheduleResponse(schedule),
+           "negative minute should fail");
+}
+
+void TestNormalizeScheduleResponseRejectsNonIntegerField() {
+    auto schedule = Poco::JSON::Object::Ptr(new Poco::JSON::Object());
+    schedule->set("start_minute", "sixty");
+    schedule->set("stop_minute", 90);
+    Expect(!OpenWifi::RESTAPI::ParentalControl::NormalizeScheduleResponse(schedule),
+           "non-integer minute field should fail");
+}
+
+void TestBuildScheduleRequestBodyForAppTarget() {
+    OpenWifi::RESTAPI::ParentalControl::ParsedScheduleRequest request;
+    request.name = "Homework";
+    request.description = std::string("School apps");
+    request.enabled = true;
+    request.targetKind = "APP";
+    request.targetValue = "youtube";
+    request.startMinute = 480;
+    request.stopMinute = 960;
+    request.weekdays = MakeIntArray({1, 2, 3});
+
+    auto body = OpenWifi::RESTAPI::ParentalControl::BuildScheduleRequestBody(request);
+    ExpectEq(body.getValue<std::string>("name"), std::string("Homework"), "name should be preserved");
+    ExpectEq(body.getValue<std::string>("target_kind"), std::string("APP"), "APP target kind");
+    ExpectEq(body.getValue<std::string>("target_value"), std::string("youtube"), "APP target value");
+}
+
+void TestBuildScheduleRequestBodyForInternetTargetSetsNullTargetValue() {
+    OpenWifi::RESTAPI::ParentalControl::ParsedScheduleRequest request;
+    request.name = "Internet";
+    request.description = std::string("General block");
+    request.enabled = false;
+    request.targetKind = "INTERNET";
+    request.startMinute = 0;
+    request.stopMinute = 60;
+    request.weekdays = MakeIntArray({0});
+
+    auto body = OpenWifi::RESTAPI::ParentalControl::BuildScheduleRequestBody(request);
+    Expect(body.isNull("target_value"), "INTERNET target value should be null");
+}
+
+void TestBuildScheduleRequestBodyUsesNullDescriptionWhenOmitted() {
+    OpenWifi::RESTAPI::ParentalControl::ParsedScheduleRequest request;
+    request.name = "No description";
+    request.enabled = true;
+    request.targetKind = "INTERNET";
+    request.startMinute = 10;
+    request.stopMinute = 20;
+    request.weekdays = MakeIntArray({0, 1});
+
+    auto body = OpenWifi::RESTAPI::ParentalControl::BuildScheduleRequestBody(request);
+    Expect(body.isNull("description"), "omitted description should serialize as null");
+}
+
+void TestExtractConfigRawSnapshotAllowsMissingResponseWhenOptional() {
+    Poco::JSON::Array::Ptr configRaw;
+    Expect(OpenWifi::RESTAPI::ParentalControl::ExtractConfigRawSnapshot(nullptr, configRaw, false),
+           "optional missing response should pass");
+    Expect(!configRaw, "config-raw should remain null");
+}
+
+void TestExtractConfigRawSnapshotRejectsMissingResponseWhenRequired() {
+    Poco::JSON::Array::Ptr configRaw;
+    Expect(!OpenWifi::RESTAPI::ParentalControl::ExtractConfigRawSnapshot(nullptr, configRaw, true),
+           "required missing response should fail");
+}
+
+void TestExtractConfigRawSnapshotAcceptsNullConfigRaw() {
+    auto response = Poco::JSON::Object::Ptr(new Poco::JSON::Object());
+    response->set("config-raw", Poco::Dynamic::Var());
+    Poco::JSON::Array::Ptr configRaw;
+
+    Expect(OpenWifi::RESTAPI::ParentalControl::ExtractConfigRawSnapshot(response, configRaw, true),
+           "null config-raw should be accepted");
+    Expect(!configRaw, "config-raw should remain null when response config-raw is null");
+}
+
+void TestExtractConfigRawSnapshotAcceptsValidCommands() {
+    auto response = Poco::JSON::Object::Ptr(new Poco::JSON::Object());
+    auto configRaw = Poco::JSON::Array::Ptr(new Poco::JSON::Array());
+    configRaw->add(MakeStringArray({"set", "foo"}));
+    configRaw->add(MakeStringArray({"set", "bar", "baz"}));
+    response->set("config-raw", configRaw);
+
+    Poco::JSON::Array::Ptr extracted;
+    Expect(OpenWifi::RESTAPI::ParentalControl::ExtractConfigRawSnapshot(response, extracted, true),
+           "well-formed config-raw should pass");
+    Expect(extracted && extracted->size() == 2, "config-raw should be returned");
+}
+
+void TestExtractConfigRawSnapshotRejectsInvalidCommandLength() {
+    auto response = Poco::JSON::Object::Ptr(new Poco::JSON::Object());
+    auto configRaw = Poco::JSON::Array::Ptr(new Poco::JSON::Array());
+    configRaw->add(MakeStringArray({"only-one"}));
+    response->set("config-raw", configRaw);
+
+    Poco::JSON::Array::Ptr extracted;
+    Expect(!OpenWifi::RESTAPI::ParentalControl::ExtractConfigRawSnapshot(response, extracted, true),
+           "command arrays must have length 2 or 3");
+}
+
+void TestExtractConfigRawSnapshotRejectsNonStringCommandEntry() {
+    auto response = Poco::JSON::Object::Ptr(new Poco::JSON::Object());
+    auto configRaw = Poco::JSON::Array::Ptr(new Poco::JSON::Array());
+    auto badCommand = Poco::JSON::Array::Ptr(new Poco::JSON::Array());
+    badCommand->add("set");
+    badCommand->add(123);
+    configRaw->add(badCommand);
+    response->set("config-raw", configRaw);
+
+    Poco::JSON::Array::Ptr extracted;
+    Expect(!OpenWifi::RESTAPI::ParentalControl::ExtractConfigRawSnapshot(response, extracted, true),
+           "command entries must all be strings");
+}
+
+const std::vector<std::pair<std::string, std::function<void()>>> kTests = {
+    {"ParseTimeStringAcceptsMidnight", TestParseTimeStringAcceptsMidnight},
+    {"ParseTimeStringAcceptsLastMinuteOfDay", TestParseTimeStringAcceptsLastMinuteOfDay},
+    {"ParseTimeStringRejectsNonString", TestParseTimeStringRejectsNonString},
+    {"ParseTimeStringRejectsMalformedString", TestParseTimeStringRejectsMalformedString},
+    {"ParseTimeStringRejectsHourOutOfRange", TestParseTimeStringRejectsHourOutOfRange},
+    {"ParseTimeStringRejectsMinuteOutOfRange", TestParseTimeStringRejectsMinuteOutOfRange},
+    {"ValidateWeekdaysAcceptsDistinctWeekdays", TestValidateWeekdaysAcceptsDistinctWeekdays},
+    {"ValidateWeekdaysRejectsEmptyArray", TestValidateWeekdaysRejectsEmptyArray},
+    {"ValidateWeekdaysRejectsDuplicates", TestValidateWeekdaysRejectsDuplicates},
+    {"ValidateWeekdaysRejectsOutOfRangeValue", TestValidateWeekdaysRejectsOutOfRangeValue},
+    {"ValidateWeekdaysRejectsNonIntegerValue", TestValidateWeekdaysRejectsNonIntegerValue},
+    {"NormalizeScheduleResponseConvertsMinuteFields", TestNormalizeScheduleResponseConvertsMinuteFields},
+    {"NormalizeScheduleResponseRejectsMissingMinuteFields", TestNormalizeScheduleResponseRejectsMissingMinuteFields},
+    {"NormalizeScheduleResponseRejectsOutOfRangeMinute", TestNormalizeScheduleResponseRejectsOutOfRangeMinute},
+    {"NormalizeScheduleResponseRejectsNonIntegerField", TestNormalizeScheduleResponseRejectsNonIntegerField},
+    {"BuildScheduleRequestBodyForAppTarget", TestBuildScheduleRequestBodyForAppTarget},
+    {"BuildScheduleRequestBodyForInternetTargetSetsNullTargetValue", TestBuildScheduleRequestBodyForInternetTargetSetsNullTargetValue},
+    {"BuildScheduleRequestBodyUsesNullDescriptionWhenOmitted", TestBuildScheduleRequestBodyUsesNullDescriptionWhenOmitted},
+    {"ExtractConfigRawSnapshotAllowsMissingResponseWhenOptional", TestExtractConfigRawSnapshotAllowsMissingResponseWhenOptional},
+    {"ExtractConfigRawSnapshotRejectsMissingResponseWhenRequired", TestExtractConfigRawSnapshotRejectsMissingResponseWhenRequired},
+    {"ExtractConfigRawSnapshotAcceptsNullConfigRaw", TestExtractConfigRawSnapshotAcceptsNullConfigRaw},
+    {"ExtractConfigRawSnapshotAcceptsValidCommands", TestExtractConfigRawSnapshotAcceptsValidCommands},
+    {"ExtractConfigRawSnapshotRejectsInvalidCommandLength", TestExtractConfigRawSnapshotRejectsInvalidCommandLength},
+    {"ExtractConfigRawSnapshotRejectsNonStringCommandEntry", TestExtractConfigRawSnapshotRejectsNonStringCommandEntry},
+};
+
+} // namespace
+
+int main() {
+    int failures = 0;
+    for (const auto &test : kTests) {
+        try {
+            ResetStubs();
+            test.second();
+            std::cout << "[PASS] " << test.first << std::endl;
+        } catch (const std::exception &e) {
+            ++failures;
+            std::cerr << "[FAIL] " << test.first << ": " << e.what() << std::endl;
+        }
+    }
+
+    if (failures != 0) {
+        std::cerr << failures << " test(s) failed." << std::endl;
+        return 1;
+    }
+
+    std::cout << kTests.size() << " test(s) passed." << std::endl;
+    return 0;
+}
+
+namespace Poco::Util { class Application; }
+namespace Poco::Net { class HTTPRequestHandler; }
+namespace OpenWifi {
+    class RESTAPI_GenericServerAccounting;
+    void DaemonPostInitialization(Poco::Util::Application &) {}
+    Poco::Net::HTTPRequestHandler* RESTAPI_ExtRouter(const std::string &, std::map<std::string, std::string> &, Poco::Logger &, RESTAPI_GenericServerAccounting &, unsigned long) {
+        return nullptr;
+    }
+    Poco::Net::HTTPRequestHandler* RESTAPI_IntRouter(const std::string &, std::map<std::string, std::string> &, Poco::Logger &, RESTAPI_GenericServerAccounting &, unsigned long) {
+        return nullptr;
+    }
+    bool AllowExternalMicroServices() { return false; }
+}
+
+namespace OpenWifi::Utils {
+    bool NormalizeMac(std::string &mac) {
+        std::string normalized = StripMac(mac);
+        if (!IsNormalizedMac(normalized)) {
+            return false;
+        }
+        mac = normalized;
+        return true;
+    }
+    std::string SerialToMAC(const std::string &serial) { return MacWithColons(StripMac(serial)); }
+}

--- a/tests/unit/test_parental_control_utils.cpp
+++ b/tests/unit/test_parental_control_utils.cpp
@@ -477,31 +477,73 @@ void TestBuildScheduleRequestBodyForAppTarget() {
     ExpectEq(body.getValue<std::string>("target_value"), std::string("youtube"), "APP target value");
 }
 
-void TestBuildScheduleRequestBodyForInternetTargetSetsNullTargetValue() {
-    OpenWifi::RESTAPI::ParentalControl::ParsedScheduleRequest request;
-    request.name = "Internet";
-    request.description = std::string("General block");
-    request.enabled = false;
-    request.targetKind = "INTERNET";
-    request.startMinute = 0;
-    request.stopMinute = 60;
-    request.weekdays = MakeIntArray({0});
+void TestBuildScheduleRequestBodyForInternetTargetOmittedAndExplicitNull() {
+    // 1. Omitted case
+    {
+        OpenWifi::RESTAPI::ParentalControl::ParsedScheduleRequest request;
+        request.name = "Internet";
+        request.description = std::string("General block");
+        request.has_description = true;
+        request.enabled = false;
+        request.targetKind = "INTERNET";
+        request.has_target_value = false;
+        request.startMinute = 0;
+        request.stopMinute = 60;
+        request.weekdays = MakeIntArray({0});
 
-    auto body = OpenWifi::RESTAPI::ParentalControl::BuildScheduleRequestBody(request);
-    Expect(body.isNull("target_value"), "INTERNET target value should be null");
+        auto body = OpenWifi::RESTAPI::ParentalControl::BuildScheduleRequestBody(request);
+        Expect(!body.has("target_value"), "omitted INTERNET target value should not be present in payload");
+    }
+
+    // 2. Explicit null case
+    {
+        OpenWifi::RESTAPI::ParentalControl::ParsedScheduleRequest request;
+        request.name = "Internet";
+        request.description = std::string("General block");
+        request.has_description = true;
+        request.enabled = false;
+        request.targetKind = "INTERNET";
+        request.has_target_value = true;
+        request.startMinute = 0;
+        request.stopMinute = 60;
+        request.weekdays = MakeIntArray({0});
+
+        auto body = OpenWifi::RESTAPI::ParentalControl::BuildScheduleRequestBody(request);
+        Expect(body.has("target_value") && body.isNull("target_value"), "explicitly null INTERNET target value should be null in payload");
+    }
 }
 
-void TestBuildScheduleRequestBodyUsesNullDescriptionWhenOmitted() {
-    OpenWifi::RESTAPI::ParentalControl::ParsedScheduleRequest request;
-    request.name = "No description";
-    request.enabled = true;
-    request.targetKind = "INTERNET";
-    request.startMinute = 10;
-    request.stopMinute = 20;
-    request.weekdays = MakeIntArray({0, 1});
+void TestBuildScheduleRequestBodyDescriptionOmittedAndExplicitNull() {
+    // 1. Omitted case
+    {
+        OpenWifi::RESTAPI::ParentalControl::ParsedScheduleRequest request;
+        request.name = "No description";
+        request.has_description = false;
+        request.enabled = true;
+        request.targetKind = "INTERNET";
+        request.startMinute = 10;
+        request.stopMinute = 20;
+        request.weekdays = MakeIntArray({0, 1});
 
-    auto body = OpenWifi::RESTAPI::ParentalControl::BuildScheduleRequestBody(request);
-    Expect(body.isNull("description"), "omitted description should serialize as null");
+        auto body = OpenWifi::RESTAPI::ParentalControl::BuildScheduleRequestBody(request);
+        Expect(!body.has("description"), "omitted description should not be present in payload");
+    }
+
+    // 2. Explicit null case
+    {
+        OpenWifi::RESTAPI::ParentalControl::ParsedScheduleRequest request;
+        request.name = "Null description";
+        request.has_description = true;
+        request.description = std::nullopt;
+        request.enabled = true;
+        request.targetKind = "INTERNET";
+        request.startMinute = 10;
+        request.stopMinute = 20;
+        request.weekdays = MakeIntArray({0, 1});
+
+        auto body = OpenWifi::RESTAPI::ParentalControl::BuildScheduleRequestBody(request);
+        Expect(body.has("description") && body.isNull("description"), "explicitly null description should be null in payload");
+    }
 }
 
 void TestExtractConfigRawSnapshotAllowsMissingResponseWhenOptional() {
@@ -1017,8 +1059,8 @@ const std::vector<std::pair<std::string, std::function<void()>>> kTests = {
     {"NormalizeScheduleResponseRejectsOutOfRangeMinute", TestNormalizeScheduleResponseRejectsOutOfRangeMinute},
     {"NormalizeScheduleResponseRejectsNonIntegerField", TestNormalizeScheduleResponseRejectsNonIntegerField},
     {"BuildScheduleRequestBodyForAppTarget", TestBuildScheduleRequestBodyForAppTarget},
-    {"BuildScheduleRequestBodyForInternetTargetSetsNullTargetValue", TestBuildScheduleRequestBodyForInternetTargetSetsNullTargetValue},
-    {"BuildScheduleRequestBodyUsesNullDescriptionWhenOmitted", TestBuildScheduleRequestBodyUsesNullDescriptionWhenOmitted},
+    {"BuildScheduleRequestBodyForInternetTargetOmittedAndExplicitNull", TestBuildScheduleRequestBodyForInternetTargetOmittedAndExplicitNull},
+    {"BuildScheduleRequestBodyDescriptionOmittedAndExplicitNull", TestBuildScheduleRequestBodyDescriptionOmittedAndExplicitNull},
     {"ExtractConfigRawSnapshotAllowsMissingResponseWhenOptional", TestExtractConfigRawSnapshotAllowsMissingResponseWhenOptional},
     {"ExtractConfigRawSnapshotRejectsMissingResponseWhenRequired", TestExtractConfigRawSnapshotRejectsMissingResponseWhenRequired},
     {"ExtractConfigRawSnapshotAcceptsNullConfigRaw", TestExtractConfigRawSnapshotAcceptsNullConfigRaw},

--- a/tests/unit/test_parental_control_utils.cpp
+++ b/tests/unit/test_parental_control_utils.cpp
@@ -164,6 +164,33 @@ class FakeRequest final : public Poco::Net::HTTPServerRequest {
     FakeHTTPServerParams params_;
 };
 
+class FakeRESTAPIHandler : public OpenWifi::RESTAPIHandler {
+  public:
+    FakeRESTAPIHandler(Poco::Logger &logger, Poco::Net::HTTPServerRequest *request, Poco::Net::HTTPServerResponse *response)
+        : OpenWifi::RESTAPIHandler(
+              OpenWifi::RESTAPIHandler::BindingMap{}, 
+              logger, 
+              std::vector<std::string>{"GET", "POST", "PUT", "DELETE"}, 
+              GetServer(), 
+              0, 
+              false,
+              true // AlwaysAuthorize
+          ) {
+        Request = request;
+        Response = response;
+    }
+    void DoGet() override {}
+    void DoDelete() override {}
+    void DoPost() override {}
+    void DoPut() override {}
+
+  private:
+    static OpenWifi::RESTAPI_GenericServerAccounting &GetServer() {
+        static OpenWifi::RESTAPI_GenericServerAccounting server;
+        return server;
+    }
+};
+
 
 struct StubState {
     bool provGetDevicesOk = true;
@@ -296,6 +323,15 @@ Poco::JSON::Object::Ptr MakeTopologyWithHistoricalClient(const std::string &mac)
 
     auto topology = Poco::JSON::Object::Ptr(new Poco::JSON::Object());
     topology->set("historicalClients", historicalClients);
+    return topology;
+}
+
+Poco::JSON::Object::Ptr MakeTopologyWithHistoricalDevice(const std::string &mac) {
+    auto historicalDevices = Poco::JSON::Array::Ptr(new Poco::JSON::Array());
+    historicalDevices->add(mac);
+
+    auto topology = Poco::JSON::Object::Ptr(new Poco::JSON::Object());
+    topology->set("historicalDevices", historicalDevices);
     return topology;
 }
 
@@ -529,7 +565,442 @@ void TestExtractConfigRawSnapshotRejectsNonStringCommandEntry() {
            "command entries must all be strings");
 }
 
+void TestValidateMacInTopologySuccessHistoricalClient() {
+    g_state.subscriberDevices = {{"olg", "112233445566"}};
+    g_state.topologyResponse = MakeTopologyWithHistoricalClient("11:22:33:44:55:66");
+
+    std::string gatewaySerial;
+    FakeResponse response;
+    FakeRequest request("GET", "/test", "", response);
+    FakeRESTAPIHandler handler(Poco::Logger::get("test"), &request, &response);
+
+    ExpectEq(
+        (int)OpenWifi::RESTAPI::ParentalControl::ValidateMacInTopology(handler, "sub-1", "op-1", "112233445566", gatewaySerial),
+        (int)OpenWifi::RESTAPI::ParentalControl::ValidateMacResult::Success,
+        "should succeed for historical client MAC"
+    );
+    ExpectEq(gatewaySerial, std::string("112233445566"), "resolved gateway serial");
+}
+
+void TestValidateMacInTopologySuccessHistoricalDevice() {
+    g_state.subscriberDevices = {{"olg", "112233445566"}};
+    g_state.topologyResponse = MakeTopologyWithHistoricalDevice("11:22:33:44:55:66");
+
+    std::string gatewaySerial;
+    FakeResponse response;
+    FakeRequest request("GET", "/test", "", response);
+    FakeRESTAPIHandler handler(Poco::Logger::get("test"), &request, &response);
+
+    ExpectEq(
+        (int)OpenWifi::RESTAPI::ParentalControl::ValidateMacInTopology(handler, "sub-1", "op-1", "112233445566", gatewaySerial),
+        (int)OpenWifi::RESTAPI::ParentalControl::ValidateMacResult::Success,
+        "should succeed for historical device MAC"
+    );
+}
+
+void TestValidateMacInTopologySuccessNodesClient() {
+    g_state.subscriberDevices = {{"olg", "112233445566"}};
+    g_state.topologyResponse = MakeTopologyWithNodesClient("11:22:33:44:55:66");
+
+    std::string gatewaySerial;
+    FakeResponse response;
+    FakeRequest request("GET", "/test", "", response);
+    FakeRESTAPIHandler handler(Poco::Logger::get("test"), &request, &response);
+
+    ExpectEq(
+        (int)OpenWifi::RESTAPI::ParentalControl::ValidateMacInTopology(handler, "sub-1", "op-1", "112233445566", gatewaySerial),
+        (int)OpenWifi::RESTAPI::ParentalControl::ValidateMacResult::Success,
+        "should succeed for nodes active client MAC"
+    );
+}
+
+void TestValidateMacInTopologyMacNotPresent() {
+    g_state.subscriberDevices = {{"olg", "112233445566"}};
+    g_state.topologyResponse = MakeTopologyWithHistoricalClient("66:55:44:33:22:11");
+
+    std::string gatewaySerial;
+    FakeResponse response;
+    FakeRequest request("GET", "/test", "", response);
+    FakeRESTAPIHandler handler(Poco::Logger::get("test"), &request, &response);
+
+    ExpectEq(
+        (int)OpenWifi::RESTAPI::ParentalControl::ValidateMacInTopology(handler, "sub-1", "op-1", "112233445566", gatewaySerial),
+        (int)OpenWifi::RESTAPI::ParentalControl::ValidateMacResult::MacNotPresentInTopology,
+        "should fail when MAC is not in topology"
+    );
+}
+
+void TestValidateMacInTopologyProvisioningLookupFailure() {
+    g_state.provGetDevicesOk = false;
+    g_state.provStatus = Poco::Net::HTTPResponse::HTTP_INTERNAL_SERVER_ERROR;
+
+    std::string gatewaySerial;
+    FakeResponse response;
+    FakeRequest request("GET", "/test", "", response);
+    FakeRESTAPIHandler handler(Poco::Logger::get("test"), &request, &response);
+
+    ExpectEq(
+        (int)OpenWifi::RESTAPI::ParentalControl::ValidateMacInTopology(handler, "sub-1", "op-1", "112233445566", gatewaySerial),
+        (int)OpenWifi::RESTAPI::ParentalControl::ValidateMacResult::ProvisioningLookupFailed,
+        "should fail when provisioning GetDevices fails"
+    );
+}
+
+void TestValidateMacInTopologyInventoryMissing() {
+    g_state.subscriberDevices = {{"olg", "112233445566"}};
+    g_state.inventoryOk = false;
+
+    std::string gatewaySerial;
+    FakeResponse response;
+    FakeRequest request("GET", "/test", "", response);
+    FakeRESTAPIHandler handler(Poco::Logger::get("test"), &request, &response);
+
+    ExpectEq(
+        (int)OpenWifi::RESTAPI::ParentalControl::ValidateMacInTopology(handler, "sub-1", "op-1", "112233445566", gatewaySerial),
+        (int)OpenWifi::RESTAPI::ParentalControl::ValidateMacResult::InventoryNotFound,
+        "should fail when inventory lookup fails"
+    );
+}
+
+void TestValidateMacInTopologyVenueIdMissing() {
+    g_state.subscriberDevices = {{"olg", "112233445566"}};
+    g_state.inventory.venue = ""; // missing venue in inventory
+
+    std::string gatewaySerial;
+    FakeResponse response;
+    FakeRequest request("GET", "/test", "", response);
+    FakeRESTAPIHandler handler(Poco::Logger::get("test"), &request, &response);
+
+    ExpectEq(
+        (int)OpenWifi::RESTAPI::ParentalControl::ValidateMacInTopology(handler, "sub-1", "op-1", "112233445566", gatewaySerial),
+        (int)OpenWifi::RESTAPI::ParentalControl::ValidateMacResult::VenueNotFound,
+        "should fail when venue id is missing in inventory"
+    );
+}
+
+void TestValidateMacInTopologyVenueNotFound() {
+    g_state.subscriberDevices = {{"olg", "112233445566"}};
+    g_state.venueOk = false;
+    g_state.venueStatus = Poco::Net::HTTPResponse::HTTP_NOT_FOUND;
+
+    std::string gatewaySerial;
+    FakeResponse response;
+    FakeRequest request("GET", "/test", "", response);
+    FakeRESTAPIHandler handler(Poco::Logger::get("test"), &request, &response);
+
+    ExpectEq(
+        (int)OpenWifi::RESTAPI::ParentalControl::ValidateMacInTopology(handler, "sub-1", "op-1", "112233445566", gatewaySerial),
+        (int)OpenWifi::RESTAPI::ParentalControl::ValidateMacResult::VenueNotFound,
+        "should fail with VenueNotFound when venue lookup returns 404"
+    );
+}
+
+void TestValidateMacInTopologyVenueLookupFailure() {
+    g_state.subscriberDevices = {{"olg", "112233445566"}};
+    g_state.venueOk = false;
+    g_state.venueStatus = Poco::Net::HTTPResponse::HTTP_INTERNAL_SERVER_ERROR;
+
+    std::string gatewaySerial;
+    FakeResponse response;
+    FakeRequest request("GET", "/test", "", response);
+    FakeRESTAPIHandler handler(Poco::Logger::get("test"), &request, &response);
+
+    ExpectEq(
+        (int)OpenWifi::RESTAPI::ParentalControl::ValidateMacInTopology(handler, "sub-1", "op-1", "112233445566", gatewaySerial),
+        (int)OpenWifi::RESTAPI::ParentalControl::ValidateMacResult::VenueLookupFailed,
+        "should fail with VenueLookupFailed when venue lookup fails with 5xx"
+    );
+}
+
+void TestValidateMacInTopologyBoardMissing() {
+    g_state.subscriberDevices = {{"olg", "112233445566"}};
+    g_state.venue.boards = {}; // empty boards
+
+    std::string gatewaySerial;
+    FakeResponse response;
+    FakeRequest request("GET", "/test", "", response);
+    FakeRESTAPIHandler handler(Poco::Logger::get("test"), &request, &response);
+
+    ExpectEq(
+        (int)OpenWifi::RESTAPI::ParentalControl::ValidateMacInTopology(handler, "sub-1", "op-1", "112233445566", gatewaySerial),
+        (int)OpenWifi::RESTAPI::ParentalControl::ValidateMacResult::BoardIdNotFound,
+        "should fail when board is missing/empty in venue"
+    );
+}
+
+void TestValidateMacInTopologyTopologyFetchFailure() {
+    g_state.subscriberDevices = {{"olg", "112233445566"}};
+    g_state.topologyOk = false;
+
+    std::string gatewaySerial;
+    FakeResponse response;
+    FakeRequest request("GET", "/test", "", response);
+    FakeRESTAPIHandler handler(Poco::Logger::get("test"), &request, &response);
+
+    ExpectEq(
+        (int)OpenWifi::RESTAPI::ParentalControl::ValidateMacInTopology(handler, "sub-1", "op-1", "112233445566", gatewaySerial),
+        (int)OpenWifi::RESTAPI::ParentalControl::ValidateMacResult::TopologyNotFound,
+        "should fail when topology lookup fails"
+    );
+}
+
+void TestValidateMacInTopologyMalformedTopology() {
+    g_state.subscriberDevices = {{"olg", "112233445566"}};
+    auto malformed = Poco::JSON::Object::Ptr(new Poco::JSON::Object());
+    malformed->set("nodes", "not-an-array"); // malformed shape
+    g_state.topologyResponse = malformed;
+
+    std::string gatewaySerial;
+    FakeResponse response;
+    FakeRequest request("GET", "/test", "", response);
+    FakeRESTAPIHandler handler(Poco::Logger::get("test"), &request, &response);
+
+    ExpectEq(
+        (int)OpenWifi::RESTAPI::ParentalControl::ValidateMacInTopology(handler, "sub-1", "op-1", "112233445566", gatewaySerial),
+        (int)OpenWifi::RESTAPI::ParentalControl::ValidateMacResult::TopologyUnusable,
+        "should fail for malformed topology payload"
+    );
+}
+
+void TestValidateMacInTopologyMalformedNoFields() {
+    g_state.subscriberDevices = {{"olg", "112233445566"}};
+    auto malformed = Poco::JSON::Object::Ptr(new Poco::JSON::Object());
+    g_state.topologyResponse = malformed;
+
+    std::string gatewaySerial;
+    FakeResponse response;
+    FakeRequest request("GET", "/test", "", response);
+    FakeRESTAPIHandler handler(Poco::Logger::get("test"), &request, &response);
+
+    ExpectEq(
+        (int)OpenWifi::RESTAPI::ParentalControl::ValidateMacInTopology(handler, "sub-1", "op-1", "112233445566", gatewaySerial),
+        (int)OpenWifi::RESTAPI::ParentalControl::ValidateMacResult::TopologyUnusable,
+        "should fail when topology has none of nodes, historicalClients, historicalDevices"
+    );
+}
+
+void TestValidateMacInTopologyMalformedHistoricalClientsNotArray() {
+    g_state.subscriberDevices = {{"olg", "112233445566"}};
+    auto malformed = Poco::JSON::Object::Ptr(new Poco::JSON::Object());
+    malformed->set("historicalClients", 12345);
+    g_state.topologyResponse = malformed;
+
+    std::string gatewaySerial;
+    FakeResponse response;
+    FakeRequest request("GET", "/test", "", response);
+    FakeRESTAPIHandler handler(Poco::Logger::get("test"), &request, &response);
+
+    ExpectEq(
+        (int)OpenWifi::RESTAPI::ParentalControl::ValidateMacInTopology(handler, "sub-1", "op-1", "112233445566", gatewaySerial),
+        (int)OpenWifi::RESTAPI::ParentalControl::ValidateMacResult::TopologyUnusable,
+        "should fail when historicalClients is not an array"
+    );
+}
+
+void TestValidateMacInTopologyMalformedHistoricalDevicesNotArray() {
+    g_state.subscriberDevices = {{"olg", "112233445566"}};
+    auto malformed = Poco::JSON::Object::Ptr(new Poco::JSON::Object());
+    malformed->set("historicalDevices", "not-an-array");
+    g_state.topologyResponse = malformed;
+
+    std::string gatewaySerial;
+    FakeResponse response;
+    FakeRequest request("GET", "/test", "", response);
+    FakeRESTAPIHandler handler(Poco::Logger::get("test"), &request, &response);
+
+    ExpectEq(
+        (int)OpenWifi::RESTAPI::ParentalControl::ValidateMacInTopology(handler, "sub-1", "op-1", "112233445566", gatewaySerial),
+        (int)OpenWifi::RESTAPI::ParentalControl::ValidateMacResult::TopologyUnusable,
+        "should fail when historicalDevices is not an array"
+    );
+}
+
+void TestValidateMacInTopologyMalformedHistoricalClientsElementNotObject() {
+    g_state.subscriberDevices = {{"olg", "112233445566"}};
+    auto malformed = Poco::JSON::Object::Ptr(new Poco::JSON::Object());
+    auto arr = Poco::JSON::Array::Ptr(new Poco::JSON::Array());
+    arr->add("not-an-object");
+    malformed->set("historicalClients", arr);
+    g_state.topologyResponse = malformed;
+
+    std::string gatewaySerial;
+    FakeResponse response;
+    FakeRequest request("GET", "/test", "", response);
+    FakeRESTAPIHandler handler(Poco::Logger::get("test"), &request, &response);
+
+    ExpectEq(
+        (int)OpenWifi::RESTAPI::ParentalControl::ValidateMacInTopology(handler, "sub-1", "op-1", "112233445566", gatewaySerial),
+        (int)OpenWifi::RESTAPI::ParentalControl::ValidateMacResult::TopologyUnusable,
+        "should fail when historicalClients contains non-object element"
+    );
+}
+
+void TestValidateMacInTopologyMalformedHistoricalDevicesElementNotString() {
+    g_state.subscriberDevices = {{"olg", "112233445566"}};
+    auto malformed = Poco::JSON::Object::Ptr(new Poco::JSON::Object());
+    auto arr = Poco::JSON::Array::Ptr(new Poco::JSON::Array());
+    arr->add(12345); // not a string
+    malformed->set("historicalDevices", arr);
+    g_state.topologyResponse = malformed;
+
+    std::string gatewaySerial;
+    FakeResponse response;
+    FakeRequest request("GET", "/test", "", response);
+    FakeRESTAPIHandler handler(Poco::Logger::get("test"), &request, &response);
+
+    ExpectEq(
+        (int)OpenWifi::RESTAPI::ParentalControl::ValidateMacInTopology(handler, "sub-1", "op-1", "112233445566", gatewaySerial),
+        (int)OpenWifi::RESTAPI::ParentalControl::ValidateMacResult::TopologyUnusable,
+        "should fail when historicalDevices contains non-string element"
+    );
+}
+
+void TestValidateMacInTopologyMalformedNodesApsNotArray() {
+    g_state.subscriberDevices = {{"olg", "112233445566"}};
+    auto malformed = Poco::JSON::Object::Ptr(new Poco::JSON::Object());
+    auto nodes = Poco::JSON::Array::Ptr(new Poco::JSON::Array());
+    auto node = Poco::JSON::Object::Ptr(new Poco::JSON::Object());
+    node->set("aps", "not-an-array");
+    nodes->add(node);
+    malformed->set("nodes", nodes);
+    g_state.topologyResponse = malformed;
+
+    std::string gatewaySerial;
+    FakeResponse response;
+    FakeRequest request("GET", "/test", "", response);
+    FakeRESTAPIHandler handler(Poco::Logger::get("test"), &request, &response);
+
+    ExpectEq(
+        (int)OpenWifi::RESTAPI::ParentalControl::ValidateMacInTopology(handler, "sub-1", "op-1", "112233445566", gatewaySerial),
+        (int)OpenWifi::RESTAPI::ParentalControl::ValidateMacResult::TopologyUnusable,
+        "should fail when nodes/aps is not an array"
+    );
+}
+
+void TestValidateMacInTopologyMalformedNodesApsElementNotObject() {
+    g_state.subscriberDevices = {{"olg", "112233445566"}};
+    auto malformed = Poco::JSON::Object::Ptr(new Poco::JSON::Object());
+    auto nodes = Poco::JSON::Array::Ptr(new Poco::JSON::Array());
+    auto node = Poco::JSON::Object::Ptr(new Poco::JSON::Object());
+    auto aps = Poco::JSON::Array::Ptr(new Poco::JSON::Array());
+    aps->add("not-an-object");
+    node->set("aps", aps);
+    nodes->add(node);
+    malformed->set("nodes", nodes);
+    g_state.topologyResponse = malformed;
+
+    std::string gatewaySerial;
+    FakeResponse response;
+    FakeRequest request("GET", "/test", "", response);
+    FakeRESTAPIHandler handler(Poco::Logger::get("test"), &request, &response);
+
+    ExpectEq(
+        (int)OpenWifi::RESTAPI::ParentalControl::ValidateMacInTopology(handler, "sub-1", "op-1", "112233445566", gatewaySerial),
+        (int)OpenWifi::RESTAPI::ParentalControl::ValidateMacResult::TopologyUnusable,
+        "should fail when nodes/aps contains non-object element"
+    );
+}
+
+void TestValidateMacInTopologyMalformedNodesApsClientsNotArray() {
+    g_state.subscriberDevices = {{"olg", "112233445566"}};
+    auto malformed = Poco::JSON::Object::Ptr(new Poco::JSON::Object());
+    auto nodes = Poco::JSON::Array::Ptr(new Poco::JSON::Array());
+    auto node = Poco::JSON::Object::Ptr(new Poco::JSON::Object());
+    auto aps = Poco::JSON::Array::Ptr(new Poco::JSON::Array());
+    auto ap = Poco::JSON::Object::Ptr(new Poco::JSON::Object());
+    ap->set("clients", 12345); // not an array
+    aps->add(ap);
+    node->set("aps", aps);
+    nodes->add(node);
+    malformed->set("nodes", nodes);
+    g_state.topologyResponse = malformed;
+
+    std::string gatewaySerial;
+    FakeResponse response;
+    FakeRequest request("GET", "/test", "", response);
+    FakeRESTAPIHandler handler(Poco::Logger::get("test"), &request, &response);
+
+    ExpectEq(
+        (int)OpenWifi::RESTAPI::ParentalControl::ValidateMacInTopology(handler, "sub-1", "op-1", "112233445566", gatewaySerial),
+        (int)OpenWifi::RESTAPI::ParentalControl::ValidateMacResult::TopologyUnusable,
+        "should fail when nodes/aps/clients is not an array"
+    );
+}
+
+void TestHandleValidateMacResult() {
+    using namespace OpenWifi::RESTAPI::ParentalControl;
+
+    // Helper lambda to test individual mapping
+    auto verifyMapping = [](ValidateMacResult result, Poco::Net::HTTPResponse::HTTPStatus expectedHTTPStatus, int expectedErrorCode) {
+        auto *response = new FakeResponse();
+        FakeRequest request("GET", "/test", "", *response);
+        FakeRESTAPIHandler handler(Poco::Logger::get("test"), &request, response);
+
+        bool success = HandleValidateMacResult(handler, result);
+        if (result == ValidateMacResult::Success) {
+            Expect(success, "Success should return true");
+            ExpectEq((int)response->getStatus(), (int)Poco::Net::HTTPResponse::HTTP_OK, "Success status is 200 OK");
+            Expect(response->body().empty(), "Success body should be empty");
+        } else {
+            Expect(!success, "Failure result should return false");
+            ExpectEq((int)response->getStatus(), (int)expectedHTTPStatus, "HTTP Status mismatch");
+            
+            Poco::JSON::Parser parser;
+            auto parsed = parser.parse(response->body()).extract<Poco::JSON::Object::Ptr>();
+            
+            if (expectedHTTPStatus == Poco::Net::HTTPResponse::HTTP_FORBIDDEN) {
+                ExpectEq(parsed->getValue<int>("ErrorCode"), expectedErrorCode, "ErrorCode mismatch for UnAuthorized");
+            } else if (expectedHTTPStatus == Poco::Net::HTTPResponse::HTTP_BAD_REQUEST) {
+                ExpectEq(parsed->getValue<int>("ErrorCode"), 400, "ErrorCode mismatch for BadRequest");
+            } else if (expectedHTTPStatus == Poco::Net::HTTPResponse::HTTP_INTERNAL_SERVER_ERROR) {
+                ExpectEq(parsed->getValue<int>("ErrorCode"), 500, "ErrorCode mismatch for InternalError");
+            }
+
+            std::string desc = parsed->getValue<std::string>("ErrorDescription");
+            auto colonPos = desc.find(':');
+            Expect(colonPos != std::string::npos, "ErrorDescription must contain ':' separator");
+            int actualSpecificCode = std::stoi(desc.substr(0, colonPos));
+            ExpectEq(actualSpecificCode, expectedErrorCode, "Specific error code mismatch in ErrorDescription");
+        }
+        delete response;
+    };
+
+    verifyMapping(ValidateMacResult::Success, Poco::Net::HTTPResponse::HTTP_OK, 0);
+    verifyMapping(ValidateMacResult::MissingSubscriberOrOperator, Poco::Net::HTTPResponse::HTTP_FORBIDDEN, 1066);
+    verifyMapping(ValidateMacResult::SubscriberDevicesNotFound, Poco::Net::HTTPResponse::HTTP_BAD_REQUEST, 1100);
+    verifyMapping(ValidateMacResult::GatewaySerialNotFound, Poco::Net::HTTPResponse::HTTP_BAD_REQUEST, 1100);
+    verifyMapping(ValidateMacResult::ProvisioningLookupFailed, Poco::Net::HTTPResponse::HTTP_INTERNAL_SERVER_ERROR, 1002);
+    verifyMapping(ValidateMacResult::InventoryNotFound, Poco::Net::HTTPResponse::HTTP_BAD_REQUEST, 1199);
+    verifyMapping(ValidateMacResult::VenueNotFound, Poco::Net::HTTPResponse::HTTP_BAD_REQUEST, 1023);
+    verifyMapping(ValidateMacResult::VenueLookupFailed, Poco::Net::HTTPResponse::HTTP_INTERNAL_SERVER_ERROR, 1002);
+    verifyMapping(ValidateMacResult::BoardIdNotFound, Poco::Net::HTTPResponse::HTTP_BAD_REQUEST, 1200);
+    verifyMapping(ValidateMacResult::TopologyNotFound, Poco::Net::HTTPResponse::HTTP_INTERNAL_SERVER_ERROR, 1002);
+    verifyMapping(ValidateMacResult::MacNotPresentInTopology, Poco::Net::HTTPResponse::HTTP_BAD_REQUEST, 1198);
+    verifyMapping(ValidateMacResult::TopologyUnusable, Poco::Net::HTTPResponse::HTTP_INTERNAL_SERVER_ERROR, 1002);
+}
+
 const std::vector<std::pair<std::string, std::function<void()>>> kTests = {
+    {"ValidateMacInTopologySuccessHistoricalClient", TestValidateMacInTopologySuccessHistoricalClient},
+    {"ValidateMacInTopologySuccessHistoricalDevice", TestValidateMacInTopologySuccessHistoricalDevice},
+    {"ValidateMacInTopologySuccessNodesClient", TestValidateMacInTopologySuccessNodesClient},
+    {"ValidateMacInTopologyMacNotPresent", TestValidateMacInTopologyMacNotPresent},
+    {"ValidateMacInTopologyProvisioningLookupFailure", TestValidateMacInTopologyProvisioningLookupFailure},
+    {"ValidateMacInTopologyInventoryMissing", TestValidateMacInTopologyInventoryMissing},
+    {"ValidateMacInTopologyVenueIdMissing", TestValidateMacInTopologyVenueIdMissing},
+    {"ValidateMacInTopologyVenueNotFound", TestValidateMacInTopologyVenueNotFound},
+    {"ValidateMacInTopologyVenueLookupFailure", TestValidateMacInTopologyVenueLookupFailure},
+    {"ValidateMacInTopologyBoardMissing", TestValidateMacInTopologyBoardMissing},
+    {"ValidateMacInTopologyTopologyFetchFailure", TestValidateMacInTopologyTopologyFetchFailure},
+    {"ValidateMacInTopologyMalformedTopology", TestValidateMacInTopologyMalformedTopology},
+    {"ValidateMacInTopologyMalformedNoFields", TestValidateMacInTopologyMalformedNoFields},
+    {"ValidateMacInTopologyMalformedHistoricalClientsNotArray", TestValidateMacInTopologyMalformedHistoricalClientsNotArray},
+    {"ValidateMacInTopologyMalformedHistoricalDevicesNotArray", TestValidateMacInTopologyMalformedHistoricalDevicesNotArray},
+    {"ValidateMacInTopologyMalformedHistoricalClientsElementNotObject", TestValidateMacInTopologyMalformedHistoricalClientsElementNotObject},
+    {"ValidateMacInTopologyMalformedHistoricalDevicesElementNotString", TestValidateMacInTopologyMalformedHistoricalDevicesElementNotString},
+    {"ValidateMacInTopologyMalformedNodesApsNotArray", TestValidateMacInTopologyMalformedNodesApsNotArray},
+    {"ValidateMacInTopologyMalformedNodesApsElementNotObject", TestValidateMacInTopologyMalformedNodesApsElementNotObject},
+    {"ValidateMacInTopologyMalformedNodesApsClientsNotArray", TestValidateMacInTopologyMalformedNodesApsClientsNotArray},
+    {"HandleValidateMacResult", TestHandleValidateMacResult},
     {"ParseTimeStringAcceptsMidnight", TestParseTimeStringAcceptsMidnight},
     {"ParseTimeStringAcceptsLastMinuteOfDay", TestParseTimeStringAcceptsLastMinuteOfDay},
     {"ParseTimeStringRejectsNonString", TestParseTimeStringRejectsNonString},
@@ -591,10 +1062,22 @@ namespace OpenWifi {
     Poco::Net::HTTPRequestHandler* RESTAPI_IntRouter(const std::string &, std::map<std::string, std::string> &, Poco::Logger &, RESTAPI_GenericServerAccounting &, unsigned long) {
         return nullptr;
     }
+
+    SubSystemServer::SubSystemServer(const std::string &Name, const std::string &LoggingPrefix,
+                                     const std::string &SubSystemConfigPrefix)
+        : Name_(Name), LoggerPrefix_(LoggingPrefix), SubSystemConfigPrefix_(SubSystemConfigPrefix),
+          Logger_(std::make_unique<LoggerWrapper>(Poco::Logger::get(LoggingPrefix))) {}
+
+    void SubSystemServer::initialize(Poco::Util::Application &) {}
+
     bool AllowExternalMicroServices() { return false; }
+    bool MicroServiceIsValidAPIKEY(const Poco::Net::HTTPServerRequest &) { return false; }
+    bool AuthClient::IsValidApiKey(const std::string &, SecurityObjects::UserInfoAndPolicy &, unsigned long, bool &, bool &, bool &) { return false; }
+    bool AuthClient::IsAuthorized(const std::string &, SecurityObjects::UserInfoAndPolicy &, unsigned long, bool &, bool &, bool) { return false; }
 }
 
 namespace OpenWifi::Utils {
+    std::string FormatIPv6(const std::string &addr) { return addr; }
     bool NormalizeMac(std::string &mac) {
         std::string normalized = StripMac(mac);
         if (!IsNormalizedMac(normalized)) {

--- a/tests/unit/test_sdk_parental_control.cpp
+++ b/tests/unit/test_sdk_parental_control.cpp
@@ -1,0 +1,410 @@
+/*
+ * SPDX-License-Identifier: AGPL-3.0 OR LicenseRef-Commercial
+ * Copyright (c) 2025 Infernet Systems Pvt Ltd
+ * Portions copyright (c) Telecom Infra Project (TIP), BSD-3-Clause
+ */
+
+#include <functional>
+#include <iostream>
+#include <sstream>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+#include "Poco/JSON/Array.h"
+#include "Poco/JSON/Object.h"
+#include "Poco/JSON/Stringifier.h"
+#include "Poco/Logger.h"
+#include "framework/RESTAPI_GenericServerAccounting.h"
+#include "sdks/SDK_parental_control.h"
+#include "framework/OpenAPIRequests.h"
+
+namespace {
+
+class TestFailure : public std::runtime_error {
+  public:
+    using std::runtime_error::runtime_error;
+};
+
+void Expect(bool condition, const std::string &message) {
+    if (!condition) {
+        throw TestFailure(message);
+    }
+}
+
+template <typename T, typename U> void ExpectEq(const T &actual, const U &expected, const std::string &message) {
+    if (!(actual == expected)) {
+        std::ostringstream os;
+        os << message << " expected=" << expected << " actual=" << actual;
+        throw TestFailure(os.str());
+    }
+}
+
+std::string ToJSONString(const Poco::JSON::Object &body) {
+    std::ostringstream os;
+    Poco::JSON::Stringifier::stringify(body, os);
+    return os.str();
+}
+
+class DummyClient final : public OpenWifi::RESTAPIHandler {
+  public:
+    DummyClient(Poco::Logger &logger, OpenWifi::RESTAPI_GenericServerAccounting &server)
+        : OpenWifi::RESTAPIHandler({}, logger,
+                                   {Poco::Net::HTTPRequest::HTTP_GET, Poco::Net::HTTPRequest::HTTP_POST,
+                                    Poco::Net::HTTPRequest::HTTP_PUT, Poco::Net::HTTPRequest::HTTP_DELETE},
+                                   server, 1, false, false) {}
+
+    void DoGet() override {}
+    void DoDelete() override {}
+    void DoPost() override {}
+    void DoPut() override {}
+};
+
+struct RequestStubState {
+    Poco::Net::HTTPResponse::HTTPStatus nextStatus = Poco::Net::HTTPResponse::HTTP_OK;
+    Poco::JSON::Object::Ptr nextObject = Poco::JSON::Object::Ptr(new Poco::JSON::Object());
+    Poco::JSON::Array::Ptr nextArray = Poco::JSON::Array::Ptr(new Poco::JSON::Array());
+    std::string nextRawBody;
+
+    std::string lastMethod;
+    std::string lastType;
+    std::string lastEndpoint;
+    std::string lastBearerToken;
+    std::string lastBodyJson;
+};
+
+RequestStubState g_state;
+
+void ResetState() {
+    g_state = RequestStubState{};
+    g_state.nextObject = Poco::JSON::Object::Ptr(new Poco::JSON::Object());
+    g_state.nextArray = Poco::JSON::Array::Ptr(new Poco::JSON::Array());
+}
+
+} // namespace
+
+
+namespace OpenWifi {
+
+Poco::Net::HTTPServerResponse::HTTPStatus
+OpenAPIRequestGet::Do(Poco::JSON::Object::Ptr &responseObject, const std::string &bearerToken) {
+    g_state.lastMethod = "GET_OBJECT";
+    g_state.lastType = Type_;
+    g_state.lastEndpoint = EndPoint_;
+    g_state.lastBearerToken = bearerToken;
+    responseObject = g_state.nextObject;
+    return g_state.nextStatus;
+}
+
+Poco::Net::HTTPServerResponse::HTTPStatus
+OpenAPIRequestGet::Do(Poco::JSON::Array::Ptr &responseArray, Poco::JSON::Object::Ptr &responseObject,
+                      const std::string &bearerToken) {
+    g_state.lastMethod = "GET_ARRAY";
+    g_state.lastType = Type_;
+    g_state.lastEndpoint = EndPoint_;
+    g_state.lastBearerToken = bearerToken;
+    responseArray = g_state.nextArray;
+    responseObject = g_state.nextObject;
+    return g_state.nextStatus;
+}
+
+Poco::Net::HTTPServerResponse::HTTPStatus
+OpenAPIRequestPost::Do(Poco::JSON::Object::Ptr &responseObject, const std::string &bearerToken) {
+    g_state.lastMethod = "POST";
+    g_state.lastType = Type_;
+    g_state.lastEndpoint = EndPoint_;
+    g_state.lastBearerToken = bearerToken;
+    g_state.lastBodyJson = ToJSONString(Body_);
+    responseObject = g_state.nextObject;
+    return g_state.nextStatus;
+}
+
+Poco::Net::HTTPServerResponse::HTTPStatus
+OpenAPIRequestPut::Do(Poco::JSON::Object::Ptr &responseObject, const std::string &bearerToken) {
+    g_state.lastMethod = "PUT";
+    g_state.lastType = Type_;
+    g_state.lastEndpoint = EndPoint_;
+    g_state.lastBearerToken = bearerToken;
+    g_state.lastBodyJson = ToJSONString(Body_);
+    responseObject = g_state.nextObject;
+    return g_state.nextStatus;
+}
+
+Poco::Net::HTTPServerResponse::HTTPStatus
+OpenAPIRequestDelete::Do(Poco::JSON::Object::Ptr &responseObject, const std::string &bearerToken) {
+    std::string rawBody;
+    return Do(responseObject, rawBody, bearerToken);
+}
+
+Poco::Net::HTTPServerResponse::HTTPStatus
+OpenAPIRequestDelete::Do(Poco::JSON::Object::Ptr &responseObject, std::string &rawResponseBody,
+                         const std::string &bearerToken) {
+    g_state.lastMethod = "DELETE";
+    g_state.lastType = Type_;
+    g_state.lastEndpoint = EndPoint_;
+    g_state.lastBearerToken = bearerToken;
+    responseObject = g_state.nextObject;
+    rawResponseBody = g_state.nextRawBody;
+    return g_state.nextStatus;
+}
+
+} // namespace OpenWifi
+
+#include "../../src/sdks/SDK_parental_control.cpp"
+
+namespace {
+
+void TestGetGroupDevicesSuccess() {
+    auto arrayResponse = Poco::JSON::Array::Ptr(new Poco::JSON::Array());
+    arrayResponse->add(Poco::JSON::Object::Ptr(new Poco::JSON::Object()));
+    g_state.nextArray = arrayResponse;
+    g_state.nextStatus = Poco::Net::HTTPResponse::HTTP_OK;
+
+    Poco::Net::HTTPResponse::HTTPStatus callStatus = Poco::Net::HTTPResponse::HTTP_INTERNAL_SERVER_ERROR;
+    Poco::JSON::Array::Ptr actualArray;
+    Poco::JSON::Object::Ptr actualObject;
+    Expect(OpenWifi::SDK::ParentalControl::GetGroupDevices(nullptr, "sub-1", "group-1", callStatus, actualArray, actualObject),
+           "GetGroupDevices should succeed on HTTP 200 with array");
+    ExpectEq(g_state.lastEndpoint, std::string("/api/v1/subscribers/sub-1/groups/group-1/devices"), "group devices endpoint");
+    ExpectEq(g_state.lastMethod, std::string("GET_ARRAY"), "GET array method");
+}
+
+void TestCreateGroupDeviceSuccess() {
+    Poco::JSON::Object body;
+    body.set("client_mac", "AA:BB:CC:DD:EE:FF");
+
+    auto response = Poco::JSON::Object::Ptr(new Poco::JSON::Object());
+    response->set("id", "gd-1");
+    g_state.nextObject = response;
+
+    Poco::Net::HTTPResponse::HTTPStatus callStatus = Poco::Net::HTTPResponse::HTTP_INTERNAL_SERVER_ERROR;
+    Poco::JSON::Object::Ptr actualResponse;
+    Expect(OpenWifi::SDK::ParentalControl::CreateGroupDevice(nullptr, "sub-1", "group-1", body, callStatus, actualResponse),
+           "CreateGroupDevice should succeed on HTTP 200 with object");
+    ExpectEq(g_state.lastEndpoint, std::string("/api/v1/subscribers/sub-1/groups/group-1/devices"), "create group device endpoint");
+    ExpectEq(g_state.lastMethod, std::string("POST"), "POST method should be used");
+    Expect(g_state.lastBodyJson.find("client_mac") != std::string::npos, "POST body should include client_mac");
+}
+
+void TestGetGroupDeviceSuccess() {
+    auto response = Poco::JSON::Object::Ptr(new Poco::JSON::Object());
+    response->set("client_mac", "AA:BB:CC:DD:EE:FF");
+    g_state.nextObject = response;
+
+    Poco::Net::HTTPResponse::HTTPStatus callStatus = Poco::Net::HTTPResponse::HTTP_INTERNAL_SERVER_ERROR;
+    Poco::JSON::Object::Ptr actualResponse;
+    Expect(OpenWifi::SDK::ParentalControl::GetGroupDevice(nullptr, "sub-1", "group-1", "AA:BB", callStatus, actualResponse),
+           "GetGroupDevice should succeed on HTTP 200 with object");
+    ExpectEq(g_state.lastEndpoint, std::string("/api/v1/subscribers/sub-1/groups/group-1/devices/AA:BB"), "single group device endpoint");
+    ExpectEq(g_state.lastMethod, std::string("GET_OBJECT"), "GET object method should be used");
+}
+
+void TestDeleteGroupDeviceSuccessRequiresRawBodyAndConfigRaw() {
+    auto response = Poco::JSON::Object::Ptr(new Poco::JSON::Object());
+    response->set("config-raw", Poco::JSON::Array::Ptr(new Poco::JSON::Array()));
+    g_state.nextObject = response;
+    g_state.nextRawBody = "{\"config-raw\":[]}";
+    g_state.nextStatus = Poco::Net::HTTPResponse::HTTP_OK;
+
+    Poco::Net::HTTPResponse::HTTPStatus callStatus = Poco::Net::HTTPResponse::HTTP_INTERNAL_SERVER_ERROR;
+    Poco::JSON::Object::Ptr actualResponse;
+    std::string rawResponseBody;
+    Expect(OpenWifi::SDK::ParentalControl::DeleteGroupDevice(nullptr, "sub-1", "group-1", "AA", callStatus, actualResponse, rawResponseBody),
+           "DeleteGroupDevice should require raw body and config-raw");
+    ExpectEq(rawResponseBody, std::string("{\"config-raw\":[]}"), "raw delete body should be passed through");
+}
+
+void TestDeleteGroupDeviceFailsWhenRawBodyIsEmpty() {
+    auto response = Poco::JSON::Object::Ptr(new Poco::JSON::Object());
+    response->set("config-raw", Poco::JSON::Array::Ptr(new Poco::JSON::Array()));
+    g_state.nextObject = response;
+    g_state.nextRawBody.clear();
+    g_state.nextStatus = Poco::Net::HTTPResponse::HTTP_OK;
+
+    Poco::Net::HTTPResponse::HTTPStatus callStatus = Poco::Net::HTTPResponse::HTTP_INTERNAL_SERVER_ERROR;
+    Poco::JSON::Object::Ptr actualResponse;
+    std::string rawResponseBody;
+    Expect(!OpenWifi::SDK::ParentalControl::DeleteGroupDevice(nullptr, "sub-1", "group-1", "AA", callStatus, actualResponse, rawResponseBody),
+           "DeleteGroupDevice should fail when raw body is empty");
+}
+
+void TestGetGroupSchedulesSuccess() {
+    auto arrayResponse = Poco::JSON::Array::Ptr(new Poco::JSON::Array());
+    arrayResponse->add(Poco::JSON::Object::Ptr(new Poco::JSON::Object()));
+    g_state.nextArray = arrayResponse;
+
+    Poco::Net::HTTPResponse::HTTPStatus callStatus = Poco::Net::HTTPResponse::HTTP_INTERNAL_SERVER_ERROR;
+    Poco::JSON::Array::Ptr actualArray;
+    Poco::JSON::Object::Ptr actualObject;
+    Expect(OpenWifi::SDK::ParentalControl::GetGroupSchedules(nullptr, "sub-1", "group-1", callStatus, actualArray, actualObject),
+           "GetGroupSchedules should succeed");
+    ExpectEq(g_state.lastEndpoint, std::string("/api/v1/subscribers/sub-1/groups/group-1/schedules"), "group schedules endpoint");
+}
+
+void TestCreateGroupScheduleSuccess() {
+    Poco::JSON::Object body;
+    body.set("schedule_id", "schedule-1");
+
+    auto response = Poco::JSON::Object::Ptr(new Poco::JSON::Object());
+    response->set("schedule_id", "schedule-1");
+    g_state.nextObject = response;
+
+    Poco::Net::HTTPResponse::HTTPStatus callStatus = Poco::Net::HTTPResponse::HTTP_INTERNAL_SERVER_ERROR;
+    Poco::JSON::Object::Ptr actualResponse;
+    Expect(OpenWifi::SDK::ParentalControl::CreateGroupSchedule(nullptr, "sub-1", "group-1", body, callStatus, actualResponse),
+           "CreateGroupSchedule should succeed");
+    ExpectEq(g_state.lastMethod, std::string("POST"), "POST should be used for CreateGroupSchedule");
+    ExpectEq(g_state.lastEndpoint, std::string("/api/v1/subscribers/sub-1/groups/group-1/schedules"), "create group schedule endpoint");
+}
+
+void TestGetGroupScheduleSuccess() {
+    auto response = Poco::JSON::Object::Ptr(new Poco::JSON::Object());
+    response->set("schedule_id", "schedule-1");
+    g_state.nextObject = response;
+
+    Poco::Net::HTTPResponse::HTTPStatus callStatus = Poco::Net::HTTPResponse::HTTP_INTERNAL_SERVER_ERROR;
+    Poco::JSON::Object::Ptr actualResponse;
+    Expect(OpenWifi::SDK::ParentalControl::GetGroupSchedule(nullptr, "sub-1", "group-1", "schedule-1", callStatus, actualResponse),
+           "GetGroupSchedule should succeed");
+    ExpectEq(g_state.lastEndpoint, std::string("/api/v1/subscribers/sub-1/groups/group-1/schedules/schedule-1"), "single group schedule endpoint");
+}
+
+void TestDeleteGroupScheduleSuccessRequiresConfigRaw() {
+    auto response = Poco::JSON::Object::Ptr(new Poco::JSON::Object());
+    response->set("config-raw", Poco::JSON::Array::Ptr(new Poco::JSON::Array()));
+    g_state.nextObject = response;
+    g_state.nextRawBody = "{\"config-raw\":[]}";
+
+    Poco::Net::HTTPResponse::HTTPStatus callStatus = Poco::Net::HTTPResponse::HTTP_INTERNAL_SERVER_ERROR;
+    Poco::JSON::Object::Ptr actualResponse;
+    std::string rawResponseBody;
+    Expect(OpenWifi::SDK::ParentalControl::DeleteGroupSchedule(nullptr, "sub-1", "group-1", "schedule-1", callStatus, actualResponse, rawResponseBody),
+           "DeleteGroupSchedule should require config-raw");
+    ExpectEq(g_state.lastEndpoint, std::string("/api/v1/subscribers/sub-1/groups/group-1/schedules/schedule-1"), "delete group schedule endpoint");
+}
+
+void TestDeleteGroupScheduleFailsWhenConfigRawIsMissing() {
+    g_state.nextObject = Poco::JSON::Object::Ptr(new Poco::JSON::Object());
+    g_state.nextRawBody = "{\"ok\":true}";
+
+    Poco::Net::HTTPResponse::HTTPStatus callStatus = Poco::Net::HTTPResponse::HTTP_INTERNAL_SERVER_ERROR;
+    Poco::JSON::Object::Ptr actualResponse;
+    std::string rawResponseBody;
+    Expect(!OpenWifi::SDK::ParentalControl::DeleteGroupSchedule(nullptr, "sub-1", "group-1", "schedule-1", callStatus, actualResponse, rawResponseBody),
+           "DeleteGroupSchedule should fail when config-raw is absent");
+}
+
+void TestReplaceGroupSchedulesSuccess() {
+    Poco::JSON::Object body;
+    auto ids = Poco::JSON::Array::Ptr(new Poco::JSON::Array());
+    ids->add("schedule-1");
+    body.set("schedule_ids", ids);
+
+    auto response = Poco::JSON::Object::Ptr(new Poco::JSON::Object());
+    response->set("count", 1);
+    g_state.nextObject = response;
+
+    Poco::Net::HTTPResponse::HTTPStatus callStatus = Poco::Net::HTTPResponse::HTTP_INTERNAL_SERVER_ERROR;
+    Poco::JSON::Object::Ptr actualResponse;
+    Expect(OpenWifi::SDK::ParentalControl::ReplaceGroupSchedules(nullptr, "sub-1", "group-1", body, callStatus, actualResponse),
+           "ReplaceGroupSchedules should succeed");
+    ExpectEq(g_state.lastMethod, std::string("PUT"), "PUT should be used for ReplaceGroupSchedules");
+    ExpectEq(g_state.lastEndpoint, std::string("/api/v1/subscribers/sub-1/groups/group-1/schedules"), "replace group schedules endpoint");
+}
+
+void TestNon200StatusFailsWrapper() {
+    g_state.nextStatus = Poco::Net::HTTPResponse::HTTP_BAD_REQUEST;
+    g_state.nextObject = Poco::JSON::Object::Ptr(new Poco::JSON::Object());
+
+    Poco::Net::HTTPResponse::HTTPStatus callStatus = Poco::Net::HTTPResponse::HTTP_INTERNAL_SERVER_ERROR;
+    Poco::JSON::Object::Ptr actualResponse;
+    Expect(!OpenWifi::SDK::ParentalControl::GetGroupDevice(nullptr, "sub-1", "group-1", "AA", callStatus, actualResponse),
+           "non-200 object response should fail wrapper");
+}
+
+void TestBearerTokenIsForwardedFromClient() {
+    static OpenWifi::RESTAPI_GenericServerAccounting server;
+    auto &logger = Poco::Logger::get("test_sdk_parental_control");
+    DummyClient client(logger, server);
+    client.UserInfo_.webtoken.access_token_ = "token-123";
+
+    auto response = Poco::JSON::Object::Ptr(new Poco::JSON::Object());
+    response->set("id", "device-1");
+    g_state.nextObject = response;
+
+    Poco::Net::HTTPResponse::HTTPStatus callStatus = Poco::Net::HTTPResponse::HTTP_INTERNAL_SERVER_ERROR;
+    Poco::JSON::Object::Ptr actualResponse;
+    Expect(OpenWifi::SDK::ParentalControl::GetGroupDevice(&client, "sub-1", "group-1", "AA", callStatus, actualResponse),
+           "GetGroupDevice should still succeed");
+    ExpectEq(g_state.lastBearerToken, std::string("token-123"), "bearer token should be forwarded");
+}
+
+const std::vector<std::pair<std::string, std::function<void()>>> kTests = {
+    {"GetGroupDevicesSuccess", TestGetGroupDevicesSuccess},
+    {"CreateGroupDeviceSuccess", TestCreateGroupDeviceSuccess},
+    {"GetGroupDeviceSuccess", TestGetGroupDeviceSuccess},
+    {"DeleteGroupDeviceSuccessRequiresRawBodyAndConfigRaw", TestDeleteGroupDeviceSuccessRequiresRawBodyAndConfigRaw},
+    {"DeleteGroupDeviceFailsWhenRawBodyIsEmpty", TestDeleteGroupDeviceFailsWhenRawBodyIsEmpty},
+    {"GetGroupSchedulesSuccess", TestGetGroupSchedulesSuccess},
+    {"CreateGroupScheduleSuccess", TestCreateGroupScheduleSuccess},
+    {"GetGroupScheduleSuccess", TestGetGroupScheduleSuccess},
+    {"DeleteGroupScheduleSuccessRequiresConfigRaw", TestDeleteGroupScheduleSuccessRequiresConfigRaw},
+    {"DeleteGroupScheduleFailsWhenConfigRawIsMissing", TestDeleteGroupScheduleFailsWhenConfigRawIsMissing},
+    {"ReplaceGroupSchedulesSuccess", TestReplaceGroupSchedulesSuccess},
+    {"Non200StatusFailsWrapper", TestNon200StatusFailsWrapper},
+    {"BearerTokenIsForwardedFromClient", TestBearerTokenIsForwardedFromClient},
+};
+
+
+} // namespace
+
+int main() {
+    int failures = 0;
+    for (const auto &test : kTests) {
+        try {
+            ResetState();
+            test.second();
+            std::cout << "[PASS] " << test.first << std::endl;
+        } catch (const std::exception &e) {
+            ++failures;
+            std::cerr << "[FAIL] " << test.first << ": " << e.what() << std::endl;
+        }
+    }
+
+    if (failures != 0) {
+        std::cerr << failures << " test(s) failed." << std::endl;
+        return 1;
+    }
+
+    std::cout << kTests.size() << " test(s) passed." << std::endl;
+    return 0;
+}
+
+namespace Poco::Util { class Application; }
+namespace Poco::Net { class HTTPRequestHandler; }
+namespace OpenWifi {
+    class RESTAPI_GenericServerAccounting;
+    void DaemonPostInitialization(Poco::Util::Application &) {}
+    Poco::Net::HTTPRequestHandler* RESTAPI_ExtRouter(const std::string &, std::map<std::string, std::string> &, Poco::Logger &, RESTAPI_GenericServerAccounting &, unsigned long) {
+        return nullptr;
+    }
+    Poco::Net::HTTPRequestHandler* RESTAPI_IntRouter(const std::string &, std::map<std::string, std::string> &, Poco::Logger &, RESTAPI_GenericServerAccounting &, unsigned long) {
+        return nullptr;
+    }
+
+    SubSystemServer::SubSystemServer(const std::string &Name, const std::string &LoggingPrefix,
+                                     const std::string &SubSystemConfigPrefix)
+        : Name_(Name), LoggerPrefix_(LoggingPrefix), SubSystemConfigPrefix_(SubSystemConfigPrefix),
+          Logger_(std::make_unique<LoggerWrapper>(Poco::Logger::get(LoggingPrefix))) {}
+
+    void SubSystemServer::initialize(Poco::Util::Application &) {}
+
+    bool AllowExternalMicroServices() { return false; }
+    bool MicroServiceIsValidAPIKEY(const Poco::Net::HTTPServerRequest &) { return false; }
+    bool AuthClient::IsValidApiKey(const std::string &, SecurityObjects::UserInfoAndPolicy &, unsigned long, bool &, bool &, bool &) { return false; }
+    bool AuthClient::IsAuthorized(const std::string &, SecurityObjects::UserInfoAndPolicy &, unsigned long, bool &, bool &, bool) { return false; }
+}
+
+namespace OpenWifi::Utils {
+    std::string FormatIPv6(const std::string &addr) { return addr; }
+}


### PR DESCRIPTION
Related to #49 

### Problem Fixed

UserPortal previously lacked support for the Parental Control group-device and group-schedule APIs. There was no UserPortal handling for assigning devices to parental-control groups, listing or reading those assignments, linking schedules to groups, replacing linked schedules, or unlinking schedules from groups. As a result, subscribers could not fully manage parental-control group membership and group-schedule associations through UserPortal.

This PR adds UserPortal support for the subscriber group-device and group-schedule APIs, extends the downstream parental-control SDK and router wiring, applies the required `config-raw` synchronization for the new write/delete flows, aligns previously implemented Groups and Schedules request validation with the current downstream parental-control contract, and adds PR-level contract and integration validation for both the new APIs and the updated existing APIs.

## Key Changes

### API support added

This PR adds UserPortal support for:

**Group-device APIs**

* `GET /api/v1/groups/{group_id}/devices`
* `POST /api/v1/groups/{group_id}/devices`
* `GET /api/v1/groups/{group_id}/devices/{client_mac}`
* `DELETE /api/v1/groups/{group_id}/devices/{client_mac}`

**Group-schedule APIs**

* `GET /api/v1/groups/{group_id}/schedules`
* `POST /api/v1/groups/{group_id}/schedules`
* `PUT /api/v1/groups/{group_id}/schedules`
* `GET /api/v1/groups/{group_id}/schedules/{schedule_id}`
* `DELETE /api/v1/groups/{group_id}/schedules/{schedule_id}`

### UserPortal implementation

* Adds dedicated REST handlers and router wiring for group-device APIs
* Adds dedicated REST handlers and router wiring for group-schedule APIs
* Extends `SDK_parental_control` for downstream group-device and group-schedule operations
* Reuses shared parental-control utility helpers for downstream validation and `config-raw` extraction
* Applies gateway `config-raw` synchronization for successful group-device and group-schedule write/delete flows
* Preserves documented downstream passthrough behavior for expected non-2xx downstream responses
* Aligns the parental-control service discovery name used by UserPortal with the current downstream service registration/configuration

### Existing API alignment updates

This PR also aligns previously implemented Groups and Schedules handling with the current downstream parental-control contract:

* `PUT /api/v1/groups/{group_id}` now accepts omitted `description`
* INTERNET schedule create/update now accepts omitted `target_value`
* `PUT /api/v1/schedules/{schedule_id}` now accepts omitted `description`

## CI Workflow Update

This PR updates the PR-specific test workflow and fake downstream environment so the new group-device and group-schedule APIs can be validated in CI.

For this PR, the relevant automated validation is the `PR Tests` workflow.

It:

* builds the implementation from this branch
* starts the local fake downstream test environment in CI
* updates the fake parental-control service override key to match the corrected service discovery name
* runs the updated Groups and Schedules test suites
* runs the new Group Devices and Group Schedules contract/integration test suites

## Test Coverage

### Updated existing coverage

Existing Groups and Schedules tests are updated to reflect the current downstream parental-control contract:

* Groups PUT accepts omitted `description`
* INTERNET schedule requests may omit `target_value`
* Schedule PUT accepts omitted `description`

### New API coverage

This PR adds contract and integration validation for:

* Group Devices APIs
* Group Schedules APIs

Coverage includes:

* auth rejection behavior
* invalid path/body validation behavior
* malformed JSON and missing body handling
* no-downstream-call behavior for local validation failures
* lifecycle validation through the repo-local fake downstream environment
* downstream passthrough failures
* `config-raw` orchestration behavior
* orchestration failure handling

### Stateful fake-downstream integration

The fake downstream test environment has been extended with Postgres-backed state for:

* groups
* schedules
* group-device links
* group-schedule links

This allows PR-level lifecycle validation against persisted fake state without requiring the real downstream service.

## Test Evidence

PR validation now covers:

* updated contract and integration tests for existing Groups and Schedules behavior
* contract and integration tests for Group Devices APIs
* contract and integration tests for Group Schedules APIs
* stateful fake-downstream CRUD validation backed by Postgres
* negative coverage for validation failures, downstream passthrough failures, and `config-raw` orchestration failure handling

Current status:

* PR Tests passing

## Reviewer Guidance

Please review this PR against the approved [UserPortal parental-control API contracts](https://github.com/routerarchitects/mango-cloud-yaml/blob/main/userportal/rest/RESTAPI/) and the intended UserPortal behavior for downstream parental-control operations.

Primary review focus areas:

* verify that the new Group Devices and Group Schedules handlers match the documented request and response behavior
* verify that local validation is enforced in UserPortal for invalid path/body inputs
* verify that downstream parental-control operations and related pre-validation/orchestration flows match the documented UserPortal behavior
* verify that downstream passthrough behavior is preserved for documented non-2xx cases
* verify that `config-raw` handling is correctly applied for the new write/delete flows
* verify that the updated Groups and Schedules validation matches the current downstream contract
* verify that the PR-specific test workflow provides the intended contract and integration validation for the documented behavior

