### PR TITLE
[PARENTAL-CONTROL] Fix subscriber auth, SDK auth, and topology null handling

### DIFF
--- a/src/RESTAPI/RESTAPI_group_devices_handler.h
+++ b/src/RESTAPI/RESTAPI_group_devices_handler.h
@@ -18,7 +18,7 @@ namespace OpenWifi {
 							 std::vector<std::string>{Poco::Net::HTTPRequest::HTTP_GET,
 													  Poco::Net::HTTPRequest::HTTP_DELETE,
 													  Poco::Net::HTTPRequest::HTTP_OPTIONS},
-							 Server, TransactionId, Internal) {}
+							 Server, TransactionId, Internal, true, false, RESTAPIHandler::RateLimit{.Interval = 1000, .MaxCalls = 100}, true) {}
 
 		static auto PathName() { return std::list<std::string>{"/api/v1/groups/{group_id}/devices/{client_mac}"}; }
 

--- a/src/RESTAPI/RESTAPI_group_devices_list_handler.h
+++ b/src/RESTAPI/RESTAPI_group_devices_list_handler.h
@@ -18,7 +18,7 @@ namespace OpenWifi {
 							 std::vector<std::string>{Poco::Net::HTTPRequest::HTTP_GET,
 													  Poco::Net::HTTPRequest::HTTP_POST,
 													  Poco::Net::HTTPRequest::HTTP_OPTIONS},
-							 Server, TransactionId, Internal) {}
+							 Server, TransactionId, Internal, true, false, RESTAPIHandler::RateLimit{.Interval = 1000, .MaxCalls = 100}, true) {}
 
 		static auto PathName() { return std::list<std::string>{"/api/v1/groups/{group_id}/devices"}; }
 

--- a/src/RESTAPI/RESTAPI_group_schedules_handler.h
+++ b/src/RESTAPI/RESTAPI_group_schedules_handler.h
@@ -18,7 +18,7 @@ namespace OpenWifi {
 							 std::vector<std::string>{Poco::Net::HTTPRequest::HTTP_GET,
 													  Poco::Net::HTTPRequest::HTTP_DELETE,
 													  Poco::Net::HTTPRequest::HTTP_OPTIONS},
-							 Server, TransactionId, Internal) {}
+							 Server, TransactionId, Internal, true, false, RESTAPIHandler::RateLimit{.Interval = 1000, .MaxCalls = 100}, true) {}
 
 		static auto PathName() { return std::list<std::string>{"/api/v1/groups/{group_id}/schedules/{schedule_id}"}; }
 

--- a/src/RESTAPI/RESTAPI_group_schedules_list_handler.h
+++ b/src/RESTAPI/RESTAPI_group_schedules_list_handler.h
@@ -19,7 +19,7 @@ namespace OpenWifi {
 													  Poco::Net::HTTPRequest::HTTP_POST,
 													  Poco::Net::HTTPRequest::HTTP_PUT,
 													  Poco::Net::HTTPRequest::HTTP_OPTIONS},
-							 Server, TransactionId, Internal) {}
+							 Server, TransactionId, Internal, true, false, RESTAPIHandler::RateLimit{.Interval = 1000, .MaxCalls = 100}, true) {}
 
 		static auto PathName() { return std::list<std::string>{"/api/v1/groups/{group_id}/schedules"}; }
 

--- a/src/RESTAPI/RESTAPI_groups_handler.h
+++ b/src/RESTAPI/RESTAPI_groups_handler.h
@@ -19,7 +19,7 @@ namespace OpenWifi {
 		                                              Poco::Net::HTTPRequest::HTTP_PUT,
 		                                              Poco::Net::HTTPRequest::HTTP_DELETE,
 		                                              Poco::Net::HTTPRequest::HTTP_OPTIONS},
-		                     Server, TransactionId, Internal) {}
+		                     Server, TransactionId, Internal, true, false, RESTAPIHandler::RateLimit{.Interval = 1000, .MaxCalls = 100}, true) {}
 
 		static auto PathName() { return std::list<std::string>{"/api/v1/groups/{group_id}"}; }
 

--- a/src/RESTAPI/RESTAPI_groups_list_handler.h
+++ b/src/RESTAPI/RESTAPI_groups_list_handler.h
@@ -18,7 +18,7 @@ namespace OpenWifi {
 		                     std::vector<std::string>{Poco::Net::HTTPRequest::HTTP_GET,
 		                                              Poco::Net::HTTPRequest::HTTP_POST,
 		                                              Poco::Net::HTTPRequest::HTTP_OPTIONS},
-		                     Server, TransactionId, Internal) {}
+		                     Server, TransactionId, Internal, true, false, RESTAPIHandler::RateLimit{.Interval = 1000, .MaxCalls = 100}, true) {}
 
 		static auto PathName() { return std::list<std::string>{"/api/v1/groups"}; }
 

--- a/src/RESTAPI/RESTAPI_parental_control_utils.cpp
+++ b/src/RESTAPI/RESTAPI_parental_control_utils.cpp
@@ -122,9 +122,9 @@ namespace OpenWifi::RESTAPI::ParentalControl {
 			}
 
 			// Check structures
-			bool hasNodes = topologyResponse->has("nodes");
-			bool hasHistClients = topologyResponse->has("historicalClients");
-			bool hasHistDevs = topologyResponse->has("historicalDevices");
+			bool hasNodes = topologyResponse->has("nodes") && !topologyResponse->isNull("nodes");
+			bool hasHistClients = topologyResponse->has("historicalClients") && !topologyResponse->isNull("historicalClients");
+			bool hasHistDevs = topologyResponse->has("historicalDevices") && !topologyResponse->isNull("historicalDevices");
 
 			if ((hasNodes && !topologyResponse->isArray("nodes")) ||
 				(hasHistClients && !topologyResponse->isArray("historicalClients")) ||
@@ -189,7 +189,7 @@ namespace OpenWifi::RESTAPI::ParentalControl {
 					if (!node) {
 						return ValidateMacResult::TopologyUnusable;
 					}
-					if (node->has("aps")) {
+					if (node->has("aps") && !node->isNull("aps")) {
 						if (!node->isArray("aps")) {
 							return ValidateMacResult::TopologyUnusable;
 						}
@@ -199,7 +199,7 @@ namespace OpenWifi::RESTAPI::ParentalControl {
 							if (!ap) {
 								return ValidateMacResult::TopologyUnusable;
 							}
-							if (ap->has("clients")) {
+							if (ap->has("clients") && !ap->isNull("clients")) {
 								if (!ap->isArray("clients")) {
 									return ValidateMacResult::TopologyUnusable;
 								}

--- a/src/RESTAPI/RESTAPI_schedules_handler.h
+++ b/src/RESTAPI/RESTAPI_schedules_handler.h
@@ -19,7 +19,7 @@ namespace OpenWifi {
 													  Poco::Net::HTTPRequest::HTTP_PUT,
 													  Poco::Net::HTTPRequest::HTTP_DELETE,
 													  Poco::Net::HTTPRequest::HTTP_OPTIONS},
-							 Server, TransactionId, Internal) {}
+							 Server, TransactionId, Internal, true, false, RESTAPIHandler::RateLimit{.Interval = 1000, .MaxCalls = 100}, true) {}
 
 		static auto PathName() { return std::list<std::string>{"/api/v1/schedules/{schedule_id}"}; }
 

--- a/src/RESTAPI/RESTAPI_schedules_list_handler.h
+++ b/src/RESTAPI/RESTAPI_schedules_list_handler.h
@@ -18,7 +18,7 @@ namespace OpenWifi {
 							 std::vector<std::string>{Poco::Net::HTTPRequest::HTTP_GET,
 													  Poco::Net::HTTPRequest::HTTP_POST,
 													  Poco::Net::HTTPRequest::HTTP_OPTIONS},
-							 Server, TransactionId, Internal) {}
+							 Server, TransactionId, Internal, true, false, RESTAPIHandler::RateLimit{.Interval = 1000, .MaxCalls = 100}, true) {}
 
 		static auto PathName() { return std::list<std::string>{"/api/v1/schedules"}; }
 

--- a/src/sdks/SDK_parental_control.cpp
+++ b/src/sdks/SDK_parental_control.cpp
@@ -26,8 +26,7 @@ namespace OpenWifi::SDK::ParentalControl {
 							 Poco::JSON::Array::Ptr &ArrayResponse,
 							 Poco::JSON::Object::Ptr &ObjectResponse) {
 			auto API = OpenAPIRequestGet(uSERVICE_MANGO_PARENTAL_CONTROL, endpoint, {}, 60000);
-			CallStatus = API.Do(ArrayResponse, ObjectResponse,
-								client ? client->UserInfo_.webtoken.access_token_ : "");
+			CallStatus = API.Do(ArrayResponse, ObjectResponse, "");
 			return IsParsedArraySuccess(CallStatus, ArrayResponse);
 		}
 
@@ -35,7 +34,7 @@ namespace OpenWifi::SDK::ParentalControl {
 							  Poco::Net::HTTPResponse::HTTPStatus &CallStatus,
 							  Poco::JSON::Object::Ptr &CallResponse) {
 			auto API = OpenAPIRequestGet(uSERVICE_MANGO_PARENTAL_CONTROL, endpoint, {}, 60000);
-			CallStatus = API.Do(CallResponse, client ? client->UserInfo_.webtoken.access_token_ : "");
+			CallStatus = API.Do(CallResponse, "");
 			return IsParsedObjectSuccess(CallStatus, CallResponse);
 		}
 
@@ -44,7 +43,7 @@ namespace OpenWifi::SDK::ParentalControl {
 							   Poco::Net::HTTPResponse::HTTPStatus &CallStatus,
 							   Poco::JSON::Object::Ptr &CallResponse) {
 			auto API = OpenAPIRequestPost(uSERVICE_MANGO_PARENTAL_CONTROL, endpoint, {}, Body, TimeoutMs);
-			CallStatus = API.Do(CallResponse, client ? client->UserInfo_.webtoken.access_token_ : "");
+			CallStatus = API.Do(CallResponse, "");
 			return IsParsedObjectSuccess(CallStatus, CallResponse);
 		}
 
@@ -53,7 +52,7 @@ namespace OpenWifi::SDK::ParentalControl {
 							  Poco::Net::HTTPResponse::HTTPStatus &CallStatus,
 							  Poco::JSON::Object::Ptr &CallResponse) {
 			auto API = OpenAPIRequestPut(uSERVICE_MANGO_PARENTAL_CONTROL, endpoint, {}, Body, TimeoutMs);
-			CallStatus = API.Do(CallResponse, client ? client->UserInfo_.webtoken.access_token_ : "");
+			CallStatus = API.Do(CallResponse, "");
 			return IsParsedObjectSuccess(CallStatus, CallResponse);
 		}
 
@@ -61,8 +60,7 @@ namespace OpenWifi::SDK::ParentalControl {
 						   Poco::Net::HTTPResponse::HTTPStatus &CallStatus,
 						   Poco::JSON::Object::Ptr &CallResponse, std::string &RawResponseBody) {
 			auto API = OpenAPIRequestDelete(uSERVICE_MANGO_PARENTAL_CONTROL, endpoint, {}, TimeoutMs);
-			CallStatus = API.Do(CallResponse, RawResponseBody,
-								client ? client->UserInfo_.webtoken.access_token_ : "");
+			CallStatus = API.Do(CallResponse, RawResponseBody, "");
 			return CallStatus == Poco::Net::HTTPResponse::HTTP_OK;
 		}
 	} // namespace

--- a/tests/unit/test_parental_control_utils.cpp
+++ b/tests/unit/test_parental_control_utils.cpp
@@ -969,6 +969,248 @@ void TestValidateMacInTopologyMalformedNodesApsClientsNotArray() {
     );
 }
 
+void TestValidateMacInTopologyNullArrays() {
+    g_state.subscriberDevices = {{"olg", "112233445566"}};
+
+    // 1. All three arrays are null
+    {
+        auto topo = Poco::JSON::Object::Ptr(new Poco::JSON::Object());
+        topo->set("nodes", Poco::Dynamic::Var());
+        topo->set("historicalClients", Poco::Dynamic::Var());
+        topo->set("historicalDevices", Poco::Dynamic::Var());
+        g_state.topologyResponse = topo;
+
+        std::string gatewaySerial;
+        FakeResponse response;
+        FakeRequest request("GET", "/test", "", response);
+        FakeRESTAPIHandler handler(Poco::Logger::get("test"), &request, &response);
+
+        ExpectEq(
+            (int)OpenWifi::RESTAPI::ParentalControl::ValidateMacInTopology(handler, "sub-1", "op-1", "112233445566", gatewaySerial),
+            (int)OpenWifi::RESTAPI::ParentalControl::ValidateMacResult::TopologyUnusable,
+            "all null arrays should return TopologyUnusable"
+        );
+    }
+
+    // 2. Nodes is empty array, historicalClients/historicalDevices are null
+    {
+        auto topo = Poco::JSON::Object::Ptr(new Poco::JSON::Object());
+        topo->set("nodes", Poco::JSON::Array::Ptr(new Poco::JSON::Array()));
+        topo->set("historicalClients", Poco::Dynamic::Var());
+        topo->set("historicalDevices", Poco::Dynamic::Var());
+        g_state.topologyResponse = topo;
+
+        std::string gatewaySerial;
+        FakeResponse response;
+        FakeRequest request("GET", "/test", "", response);
+        FakeRESTAPIHandler handler(Poco::Logger::get("test"), &request, &response);
+
+        ExpectEq(
+            (int)OpenWifi::RESTAPI::ParentalControl::ValidateMacInTopology(handler, "sub-1", "op-1", "112233445566", gatewaySerial),
+            (int)OpenWifi::RESTAPI::ParentalControl::ValidateMacResult::MacNotPresentInTopology,
+            "empty nodes array with other nulls should return MacNotPresentInTopology"
+        );
+    }
+
+    // 3. historicalClients is empty array, nodes/historicalDevices are null
+    {
+        auto topo = Poco::JSON::Object::Ptr(new Poco::JSON::Object());
+        topo->set("nodes", Poco::Dynamic::Var());
+        topo->set("historicalClients", Poco::JSON::Array::Ptr(new Poco::JSON::Array()));
+        topo->set("historicalDevices", Poco::Dynamic::Var());
+        g_state.topologyResponse = topo;
+
+        std::string gatewaySerial;
+        FakeResponse response;
+        FakeRequest request("GET", "/test", "", response);
+        FakeRESTAPIHandler handler(Poco::Logger::get("test"), &request, &response);
+
+        ExpectEq(
+            (int)OpenWifi::RESTAPI::ParentalControl::ValidateMacInTopology(handler, "sub-1", "op-1", "112233445566", gatewaySerial),
+            (int)OpenWifi::RESTAPI::ParentalControl::ValidateMacResult::MacNotPresentInTopology,
+            "empty historicalClients array with other nulls should return MacNotPresentInTopology"
+        );
+    }
+
+    // 4. historicalDevices is empty array, nodes/historicalClients are null
+    {
+        auto topo = Poco::JSON::Object::Ptr(new Poco::JSON::Object());
+        topo->set("nodes", Poco::Dynamic::Var());
+        topo->set("historicalClients", Poco::Dynamic::Var());
+        topo->set("historicalDevices", Poco::JSON::Array::Ptr(new Poco::JSON::Array()));
+        g_state.topologyResponse = topo;
+
+        std::string gatewaySerial;
+        FakeResponse response;
+        FakeRequest request("GET", "/test", "", response);
+        FakeRESTAPIHandler handler(Poco::Logger::get("test"), &request, &response);
+
+        ExpectEq(
+            (int)OpenWifi::RESTAPI::ParentalControl::ValidateMacInTopology(handler, "sub-1", "op-1", "112233445566", gatewaySerial),
+            (int)OpenWifi::RESTAPI::ParentalControl::ValidateMacResult::MacNotPresentInTopology,
+            "empty historicalDevices array with other nulls should return MacNotPresentInTopology"
+        );
+    }
+}
+
+void TestValidateMacInTopologyNestedNullApsAndClients() {
+    g_state.subscriberDevices = {{"olg", "112233445566"}};
+
+    // 1. aps is explicitly null inside a node
+    {
+        auto topo = Poco::JSON::Object::Ptr(new Poco::JSON::Object());
+        auto nodes = Poco::JSON::Array::Ptr(new Poco::JSON::Array());
+        auto node = Poco::JSON::Object::Ptr(new Poco::JSON::Object());
+        node->set("aps", Poco::Dynamic::Var()); // explicitly null
+        nodes->add(node);
+        topo->set("nodes", nodes);
+        g_state.topologyResponse = topo;
+
+        std::string gatewaySerial;
+        FakeResponse response;
+        FakeRequest request("GET", "/test", "", response);
+        FakeRESTAPIHandler handler(Poco::Logger::get("test"), &request, &response);
+
+        ExpectEq(
+            (int)OpenWifi::RESTAPI::ParentalControl::ValidateMacInTopology(handler, "sub-1", "op-1", "112233445566", gatewaySerial),
+            (int)OpenWifi::RESTAPI::ParentalControl::ValidateMacResult::MacNotPresentInTopology,
+            "explicitly null nested aps should be tolerated and return MacNotPresentInTopology"
+        );
+    }
+
+    // 2. clients is explicitly null inside an ap
+    {
+        auto topo = Poco::JSON::Object::Ptr(new Poco::JSON::Object());
+        auto nodes = Poco::JSON::Array::Ptr(new Poco::JSON::Array());
+        auto node = Poco::JSON::Object::Ptr(new Poco::JSON::Object());
+        auto aps = Poco::JSON::Array::Ptr(new Poco::JSON::Array());
+        auto ap = Poco::JSON::Object::Ptr(new Poco::JSON::Object());
+        ap->set("clients", Poco::Dynamic::Var()); // explicitly null
+        aps->add(ap);
+        node->set("aps", aps);
+        nodes->add(node);
+        topo->set("nodes", nodes);
+        g_state.topologyResponse = topo;
+
+        std::string gatewaySerial;
+        FakeResponse response;
+        FakeRequest request("GET", "/test", "", response);
+        FakeRESTAPIHandler handler(Poco::Logger::get("test"), &request, &response);
+
+        ExpectEq(
+            (int)OpenWifi::RESTAPI::ParentalControl::ValidateMacInTopology(handler, "sub-1", "op-1", "112233445566", gatewaySerial),
+            (int)OpenWifi::RESTAPI::ParentalControl::ValidateMacResult::MacNotPresentInTopology,
+            "explicitly null nested clients should be tolerated and return MacNotPresentInTopology"
+        );
+    }
+}
+
+void TestValidateMacInTopologyNegativeNonNullNonArray() {
+    g_state.subscriberDevices = {{"olg", "112233445566"}};
+
+    // 1. nodes is boolean
+    {
+        auto topo = Poco::JSON::Object::Ptr(new Poco::JSON::Object());
+        topo->set("nodes", true);
+        g_state.topologyResponse = topo;
+
+        std::string gatewaySerial;
+        FakeResponse response;
+        FakeRequest request("GET", "/test", "", response);
+        FakeRESTAPIHandler handler(Poco::Logger::get("test"), &request, &response);
+
+        ExpectEq(
+            (int)OpenWifi::RESTAPI::ParentalControl::ValidateMacInTopology(handler, "sub-1", "op-1", "112233445566", gatewaySerial),
+            (int)OpenWifi::RESTAPI::ParentalControl::ValidateMacResult::TopologyUnusable,
+            "non-array nodes should return TopologyUnusable"
+        );
+    }
+
+    // 2. historicalClients is string
+    {
+        auto topo = Poco::JSON::Object::Ptr(new Poco::JSON::Object());
+        topo->set("historicalClients", "not-an-array");
+        g_state.topologyResponse = topo;
+
+        std::string gatewaySerial;
+        FakeResponse response;
+        FakeRequest request("GET", "/test", "", response);
+        FakeRESTAPIHandler handler(Poco::Logger::get("test"), &request, &response);
+
+        ExpectEq(
+            (int)OpenWifi::RESTAPI::ParentalControl::ValidateMacInTopology(handler, "sub-1", "op-1", "112233445566", gatewaySerial),
+            (int)OpenWifi::RESTAPI::ParentalControl::ValidateMacResult::TopologyUnusable,
+            "non-array historicalClients should return TopologyUnusable"
+        );
+    }
+
+    // 3. historicalDevices is object
+    {
+        auto topo = Poco::JSON::Object::Ptr(new Poco::JSON::Object());
+        topo->set("historicalDevices", Poco::JSON::Object::Ptr(new Poco::JSON::Object()));
+        g_state.topologyResponse = topo;
+
+        std::string gatewaySerial;
+        FakeResponse response;
+        FakeRequest request("GET", "/test", "", response);
+        FakeRESTAPIHandler handler(Poco::Logger::get("test"), &request, &response);
+
+        ExpectEq(
+            (int)OpenWifi::RESTAPI::ParentalControl::ValidateMacInTopology(handler, "sub-1", "op-1", "112233445566", gatewaySerial),
+            (int)OpenWifi::RESTAPI::ParentalControl::ValidateMacResult::TopologyUnusable,
+            "non-array historicalDevices should return TopologyUnusable"
+        );
+    }
+
+    // 4. Nested aps is number
+    {
+        auto topo = Poco::JSON::Object::Ptr(new Poco::JSON::Object());
+        auto nodes = Poco::JSON::Array::Ptr(new Poco::JSON::Array());
+        auto node = Poco::JSON::Object::Ptr(new Poco::JSON::Object());
+        node->set("aps", 42); // not an array
+        nodes->add(node);
+        topo->set("nodes", nodes);
+        g_state.topologyResponse = topo;
+
+        std::string gatewaySerial;
+        FakeResponse response;
+        FakeRequest request("GET", "/test", "", response);
+        FakeRESTAPIHandler handler(Poco::Logger::get("test"), &request, &response);
+
+        ExpectEq(
+            (int)OpenWifi::RESTAPI::ParentalControl::ValidateMacInTopology(handler, "sub-1", "op-1", "112233445566", gatewaySerial),
+            (int)OpenWifi::RESTAPI::ParentalControl::ValidateMacResult::TopologyUnusable,
+            "non-array nested aps should return TopologyUnusable"
+        );
+    }
+
+    // 5. Nested clients is object
+    {
+        auto topo = Poco::JSON::Object::Ptr(new Poco::JSON::Object());
+        auto nodes = Poco::JSON::Array::Ptr(new Poco::JSON::Array());
+        auto node = Poco::JSON::Object::Ptr(new Poco::JSON::Object());
+        auto aps = Poco::JSON::Array::Ptr(new Poco::JSON::Array());
+        auto ap = Poco::JSON::Object::Ptr(new Poco::JSON::Object());
+        ap->set("clients", Poco::JSON::Object::Ptr(new Poco::JSON::Object())); // not an array
+        aps->add(ap);
+        node->set("aps", aps);
+        nodes->add(node);
+        topo->set("nodes", nodes);
+        g_state.topologyResponse = topo;
+
+        std::string gatewaySerial;
+        FakeResponse response;
+        FakeRequest request("GET", "/test", "", response);
+        FakeRESTAPIHandler handler(Poco::Logger::get("test"), &request, &response);
+
+        ExpectEq(
+            (int)OpenWifi::RESTAPI::ParentalControl::ValidateMacInTopology(handler, "sub-1", "op-1", "112233445566", gatewaySerial),
+            (int)OpenWifi::RESTAPI::ParentalControl::ValidateMacResult::TopologyUnusable,
+            "non-array nested clients should return TopologyUnusable"
+        );
+    }
+}
+
 void TestHandleValidateMacResult() {
     using namespace OpenWifi::RESTAPI::ParentalControl;
 
@@ -1042,6 +1284,9 @@ const std::vector<std::pair<std::string, std::function<void()>>> kTests = {
     {"ValidateMacInTopologyMalformedNodesApsNotArray", TestValidateMacInTopologyMalformedNodesApsNotArray},
     {"ValidateMacInTopologyMalformedNodesApsElementNotObject", TestValidateMacInTopologyMalformedNodesApsElementNotObject},
     {"ValidateMacInTopologyMalformedNodesApsClientsNotArray", TestValidateMacInTopologyMalformedNodesApsClientsNotArray},
+    {"ValidateMacInTopologyNullArrays", TestValidateMacInTopologyNullArrays},
+    {"ValidateMacInTopologyNestedNullApsAndClients", TestValidateMacInTopologyNestedNullApsAndClients},
+    {"ValidateMacInTopologyNegativeNonNullNonArray", TestValidateMacInTopologyNegativeNonNullNonArray},
     {"HandleValidateMacResult", TestHandleValidateMacResult},
     {"ParseTimeStringAcceptsMidnight", TestParseTimeStringAcceptsMidnight},
     {"ParseTimeStringAcceptsLastMinuteOfDay", TestParseTimeStringAcceptsLastMinuteOfDay},

--- a/tests/unit/test_sdk_parental_control.cpp
+++ b/tests/unit/test_sdk_parental_control.cpp
@@ -322,7 +322,7 @@ void TestNon200StatusFailsWrapper() {
            "non-200 object response should fail wrapper");
 }
 
-void TestBearerTokenIsForwardedFromClient() {
+void TestBearerTokenIsNotForwardedFromClient() {
     static OpenWifi::RESTAPI_GenericServerAccounting server;
     auto &logger = Poco::Logger::get("test_sdk_parental_control");
     DummyClient client(logger, server);
@@ -336,7 +336,7 @@ void TestBearerTokenIsForwardedFromClient() {
     Poco::JSON::Object::Ptr actualResponse;
     Expect(OpenWifi::SDK::ParentalControl::GetGroupDevice(&client, "sub-1", "group-1", "AA", callStatus, actualResponse),
            "GetGroupDevice should still succeed");
-    ExpectEq(g_state.lastBearerToken, std::string("token-123"), "bearer token should be forwarded");
+    ExpectEq(g_state.lastBearerToken, std::string(""), "bearer token should not be forwarded");
 }
 
 const std::vector<std::pair<std::string, std::function<void()>>> kTests = {
@@ -352,7 +352,7 @@ const std::vector<std::pair<std::string, std::function<void()>>> kTests = {
     {"DeleteGroupScheduleFailsWhenConfigRawIsMissing", TestDeleteGroupScheduleFailsWhenConfigRawIsMissing},
     {"ReplaceGroupSchedulesSuccess", TestReplaceGroupSchedulesSuccess},
     {"Non200StatusFailsWrapper", TestNon200StatusFailsWrapper},
-    {"BearerTokenIsForwardedFromClient", TestBearerTokenIsForwardedFromClient},
+    {"BearerTokenIsNotForwardedFromClient", TestBearerTokenIsNotForwardedFromClient},
 };
 
 


### PR DESCRIPTION
### Problem Fixed

Subscriber-facing parental-control APIs in UserPortal were failing because the request flow could break at three integration points.

First, subscriber-facing parental-control handlers were not consistently configured to use subscriber-only authentication behavior. This caused valid subscriber bearer tokens to be rejected before the request reached handler logic.

Second, downstream calls from UserPortal to the parental-control service were forwarding the subscriber bearer token to the internal/private service path. Those internal calls are intended to use service-to-service authentication, so forwarding subscriber bearer auth caused downstream authorization failures.

Third, parental-control topology validation was too strict when upstream topology payloads contained nullable structures. In those cases, otherwise usable topology responses could be treated as invalid and cause request failures.

This PR fixes those integration issues for subscriber-facing parental-control flows through UserPortal.

## Key Changes

### Subscriber-only auth enabled for subscriber-facing parental-control handlers

This PR updates subscriber-facing parental-control handlers to explicitly use subscriber-only authentication behavior in the base `RESTAPIHandler` constructor.

Affected handler families include:

* Groups
* Group Devices
* Group Schedules
* Schedules

This ensures valid subscriber bearer tokens are validated using the intended subscriber auth flow instead of the default non-subscriber flow.

### Downstream parental-control SDK auth alignment

This PR updates `SDK_parental_control.cpp` so internal calls from UserPortal to the parental-control service no longer forward the subscriber bearer token.

Instead, the SDK now follows the internal service-call path expected for private service communication, allowing the framework to use internal service authentication for downstream parental-control requests.

This fixes downstream authorization failures during subscriber parental-control operations routed through UserPortal.

### Defensive topology null handling

This PR hardens parental-control topology validation in `RESTAPI_parental_control_utils.cpp` so nullable topology fields do not incorrectly cause the topology payload to be treated as unusable.

This includes defensive handling for nullable structures such as:

* `nodes`
* `historicalClients`
* `historicalDevices`
* nested `aps`
* nested `clients`

This prevents valid flows from failing when upstream services return nullable arrays instead of populated or empty arrays.

## Scope of Behavior Fixed

This PR is focused on UserPortal integration behavior for subscriber-facing parental-control APIs, specifically:

* subscriber auth handling at the UserPortal entry point
* internal downstream auth behavior for parental-control SDK calls
* topology/device validation resilience for nullable upstream payloads

The intended result is that valid subscriber parental-control requests can proceed successfully through UserPortal without failing because of auth-context mismatches or brittle topology parsing.

## Test Evidence

Validated by reproducing the subscriber parental-control request failures and verifying the corrected behavior after applying the code changes in this PR.

## Reviewer Guidance

Please review this PR against the intended UserPortal subscriber parental-control flow.

Primary review focus areas:

* verify that all subscriber-facing parental-control handlers now use subscriber-only auth behavior consistently
* verify that downstream parental-control SDK calls no longer forward subscriber bearer tokens to the internal/private service path
* verify that topology validation correctly tolerates nullable upstream array fields without masking genuinely invalid payloads
* verify that the changes remain limited to subscriber parental-control integration behavior and do not alter unrelated request flows
