### PR TITLE
Update action=configure for pause/unpause and topology blocked status

### DIFF
--- a/openapi/userportal.yaml
+++ b/openapi/userportal.yaml
@@ -1329,7 +1329,7 @@ paths:
       tags:
         - Device Topology
       summary: Retrieve the network topology for the subscriber
-      description: Retrieve the network topology for the subscriber. Evaluates active parental control rules in real-time (combining date-bounded client access rules and recurring group schedule weekday rules) to set the 'blocked' status ("0" or "1") on historical and connected clients.
+      description: Retrieve the network topology for the subscriber. Evaluates active date-bounded client-access parental-control rules in real time to set the 'blocked' status ("0" or "1") on historical and connected clients.
       operationId: getTopology
       security:
         - bearerAuth: []

--- a/openapi/userportal.yaml
+++ b/openapi/userportal.yaml
@@ -1,4 +1,4 @@
-openapi: 3.1.0
+openapi: 3.2.0
 info:
   title: OpenWiFi User Portal
   description: API describing User Self Care interaction with OpenWifi.
@@ -27,13 +27,15 @@ components:
 
   responses:
     NotFound:
-      $ref: https://raw.githubusercontent.com/routerarchitects/ra-wlan-cloud-ucentralsec/main/openpapi/owsec.yaml#/components/responses/NotFound
+      $ref: https://raw.githubusercontent.com/routerarchitects/ra-wlan-cloud-ucentralsec/main/openapi/owsec.yaml#/components/responses/NotFound
     Unauthorized:
-      $ref: https://raw.githubusercontent.com/routerarchitects/ra-wlan-cloud-ucentralsec/main/openpapi/owsec.yaml#/components/responses/Unauthorized
+      $ref: https://raw.githubusercontent.com/routerarchitects/ra-wlan-cloud-ucentralsec/main/openapi/owsec.yaml#/components/responses/Unauthorized
     Success:
-      $ref: https://raw.githubusercontent.com/routerarchitects/ra-wlan-cloud-ucentralsec/main/openpapi/owsec.yaml#/components/responses/Success
+      $ref: https://raw.githubusercontent.com/routerarchitects/ra-wlan-cloud-ucentralsec/main/openapi/owsec.yaml#/components/responses/Success
+    EmptySuccess:
+      description: The operation was completed successfully (returns an empty response body).
     BadRequest:
-      $ref: https://raw.githubusercontent.com/routerarchitects/ra-wlan-cloud-ucentralsec/main/openpapi/owsec.yaml#/components/responses/BadRequest
+      $ref: https://raw.githubusercontent.com/routerarchitects/ra-wlan-cloud-ucentralsec/main/openapi/owsec.yaml#/components/responses/BadRequest
     InternalError:
       description: The request failed because UserPortal encountered an internal error.
       content:
@@ -634,6 +636,15 @@ components:
         updated_at:
           type: string
           format: date-time
+        config-raw:
+          oneOf:
+            - type: array
+              description: Raw UCI configuration commands generated for the group.
+              items:
+                type: array
+                items:
+                  type: string
+            - type: 'null'
       additionalProperties: false
 
     GroupCreateRequest:
@@ -1181,13 +1192,13 @@ paths:
             default: false
           required: false
       responses:
-        200:
+        '200':
           description: Signup request accepted or existing pending signup returned.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/SignupResponse'
-        400:
+        '400':
           $ref: '#/components/responses/BadRequest'
     delete:
       tags:
@@ -1197,13 +1208,13 @@ paths:
       security:
         - bearerAuth: []
       responses:
-        200:
-          $ref: '#/components/responses/Success'
-        400:
+        '200':
+          $ref: '#/components/responses/EmptySuccess'
+        '400':
           $ref: '#/components/responses/BadRequest'
-        401:
+        '401':
           $ref: '#/components/responses/Unauthorized'
-        404:
+        '404':
           $ref: '#/components/responses/NotFound'
 
   /subscriber/devices/{mac}:
@@ -1223,15 +1234,15 @@ paths:
           required: true
           example: aa:bb:cc:dd:ee:ff
       responses:
-        200:
+        '200':
           $ref: '#/components/responses/Success'
-        400:
+        '400':
           $ref: '#/components/responses/BadRequest'
-        401:
+        '401':
           $ref: '#/components/responses/Unauthorized'
-        404:
+        '404':
           $ref: '#/components/responses/NotFound'
-        500:
+        '500':
           $ref: '#/components/responses/InternalError'
     delete:
       tags:
@@ -1249,15 +1260,15 @@ paths:
           required: true
           example: aa:bb:cc:dd:ee:ff
       responses:
-        200:
-          $ref: '#/components/responses/Success'
-        400:
+        '200':
+          $ref: '#/components/responses/EmptySuccess'
+        '400':
           $ref: '#/components/responses/BadRequest'
-        401:
+        '401':
           $ref: '#/components/responses/Unauthorized'
-        404:
+        '404':
           $ref: '#/components/responses/NotFound'
-        500:
+        '500':
           $ref: '#/components/responses/InternalError'
 
   /action:
@@ -1307,21 +1318,21 @@ paths:
               $ref: '#/components/schemas/ActionRequestBody'
 
       responses:
-        200:
+        '200':
           description: Action completed successfully.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ActionResponse'
-        400:
+        '400':
           $ref: '#/components/responses/BadRequest'
-        401:
+        '401':
           $ref: '#/components/responses/Unauthorized'
-        403:
+        '403':
           $ref: '#/components/responses/Unauthorized'
-        404:
+        '404':
           $ref: '#/components/responses/NotFound'
-        500:
+        '500':
           $ref: '#/components/responses/InternalError'
 
   /topology:
@@ -1334,7 +1345,7 @@ paths:
       security:
         - bearerAuth: []
       responses:
-        200:
+        '200':
           description: Topology graph
           content:
             application/json:
@@ -1342,13 +1353,13 @@ paths:
                 oneOf:
                   - $ref: '#/components/schemas/TopologyResponse'
                   - $ref: '#/components/schemas/TopologyEmptyResponse'
-        400:
+        '400':
           $ref: '#/components/responses/BadRequest'
-        401:
+        '401':
           $ref: '#/components/responses/Unauthorized'
-        404:
+        '404':
           $ref: '#/components/responses/NotFound'
-        500:
+        '500':
           $ref: '#/components/responses/InternalError'
 
   /system:
@@ -1365,15 +1376,15 @@ paths:
             schema:
               $ref: '#/components/schemas/SystemCommandRequest'
       responses:
-        200:
+        '200':
           description: Successful command execution
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/SystemCommandPostResponse'
-        400:
+        '400':
           $ref: '#/components/responses/BadRequest'
-        403:
+        '403':
           $ref: '#/components/responses/Unauthorized'
     get:
       tags:
@@ -1392,15 +1403,15 @@ paths:
               - resources
           required: true
       responses:
-        200:
+        '200':
           description: successful operation
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/SystemCommandGetResponse'
-        400:
+        '400':
           $ref: '#/components/responses/BadRequest'
-        403:
+        '403':
           $ref: '#/components/responses/Unauthorized'
 
   /systemConfiguration:
@@ -1419,15 +1430,15 @@ paths:
             example: element1,element2,element3
           required: true
       responses:
-        200:
+        '200':
           description: List of configuration elements
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/SystemConfigurationResponse'
-        400:
+        '400':
           $ref: '#/components/responses/BadRequest'
-        403:
+        '403':
           $ref: '#/components/responses/Unauthorized'
 
     put:
@@ -1437,9 +1448,9 @@ paths:
       operationId: updateSystemConfiguration
 
       responses:
-        400:
+        '400':
           $ref: '#/components/responses/BadRequest'
-        403:
+        '403':
           $ref: '#/components/responses/Unauthorized'
 
     delete:
@@ -1449,9 +1460,9 @@ paths:
       operationId: deleteSystemConfiguration
 
       responses:
-        400:
+        '400':
           $ref: '#/components/responses/BadRequest'
-        403:
+        '403':
           $ref: '#/components/responses/Unauthorized'
 
   /groups:
@@ -1595,7 +1606,7 @@ paths:
             format: uuid
       responses:
         '200':
-          $ref: '#/components/responses/Success'
+          $ref: '#/components/responses/EmptySuccess'
         '400':
           $ref: '#/components/responses/BadRequest'
         '401':
@@ -1749,7 +1760,7 @@ paths:
             pattern: '^(?:[0-9A-Fa-f]{12}|(?:[0-9A-Fa-f]{2}[:-]){5}[0-9A-Fa-f]{2})$'
       responses:
         '200':
-          $ref: '#/components/responses/Success'
+          $ref: '#/components/responses/EmptySuccess'
         '400':
           $ref: '#/components/responses/BadRequest'
         '401':
@@ -1949,7 +1960,7 @@ paths:
             format: uuid
       responses:
         '200':
-          $ref: '#/components/responses/Success'
+          $ref: '#/components/responses/EmptySuccess'
         '400':
           $ref: '#/components/responses/BadRequest'
         '401':
@@ -2137,7 +2148,7 @@ paths:
             format: uuid
       responses:
         '200':
-          $ref: '#/components/responses/Success'
+          $ref: '#/components/responses/EmptySuccess'
         '400':
           $ref: '#/components/responses/BadRequest'
         '401':

--- a/openapi/userportal.yaml
+++ b/openapi/userportal.yaml
@@ -198,7 +198,7 @@ components:
           type: integer
           format: int64
           minimum: 1
-          description: Optional duration in seconds for client block (access = deny). If omitted, block is treated as indefinite/permanent for whole day.
+          description: Optional duration in seconds for client block (access = deny). If omitted, block applies for remainder of current day (until 23:59:59).
       additionalProperties: false
 
     ActionSuccessResponse:

--- a/openapi/userportal.yaml
+++ b/openapi/userportal.yaml
@@ -198,7 +198,7 @@ components:
           type: integer
           format: int64
           minimum: 1
-          description: Optional duration in seconds for client block (access = deny). If omitted, block applies for remainder of current day (until 23:59:59).
+          description: Optional duration in minutes for client block (access = deny). If omitted, block applies for remainder of current day (until 23:59:59).
       additionalProperties: false
 
     ActionSuccessResponse:
@@ -1297,7 +1297,7 @@ paths:
                       access: allow
                     - mac: f0:09:0d:2d:b4:9c
                       access: deny
-                      duration: 1800
+                      duration: 30
               blink:
                 value:
                   mac: f0:09:0d:2d:b4:9c

--- a/openapi/userportal.yaml
+++ b/openapi/userportal.yaml
@@ -194,6 +194,11 @@ components:
           enum:
             - allow
             - deny
+        duration:
+          type: integer
+          format: int64
+          minimum: 1
+          description: Optional duration in seconds for client block (access = deny). If omitted, block is treated as indefinite/permanent for whole day.
       additionalProperties: false
 
     ActionSuccessResponse:
@@ -1260,6 +1265,7 @@ paths:
       tags:
         - Device Commands
       summary: Sending different commands to a device
+      description: Executes device control commands (configure, reboot, blink, upgrade, factory). For action=configure, applies network configuration changes including SSID overrides and client-access parental control rules to the gateway.
       operationId: performAnAction
       security:
         - bearerAuth: []
@@ -1291,6 +1297,7 @@ paths:
                       access: allow
                     - mac: f0:09:0d:2d:b4:9c
                       access: deny
+                      duration: 1800
               blink:
                 value:
                   mac: f0:09:0d:2d:b4:9c
@@ -1322,6 +1329,7 @@ paths:
       tags:
         - Device Topology
       summary: Retrieve the network topology for the subscriber
+      description: Retrieve the network topology for the subscriber. Evaluates active parental control rules in real-time (combining date-bounded client access rules and recurring group schedule weekday rules) to set the 'blocked' status ("0" or "1") on historical and connected clients.
       operationId: getTopology
       security:
         - bearerAuth: []

--- a/src/ConfigMaker.cpp
+++ b/src/ConfigMaker.cpp
@@ -342,24 +342,10 @@ namespace OpenWifi {
 				}
 			}
 
-			// If config-raw contains our block-clients rule, don't send config-raw to mesh devices.
+			// Parental control rules in config-raw are gateway-only; strip config-raw for mesh devices.
 			if (cfg.contains("config-raw")) {
-				for (const auto &cmd : cfg["config-raw"]) {
-					if (!cmd.is_array() || cmd.size() < 3) {
-						continue;
-					}
-					if (cmd[0] != "set" || cmd[1] != "firewall.@rule[-1].name" ||
-						!cmd[2].is_string()) {
-						continue;
-					}
-					if (cmd[2].get<std::string>() == "Block_Clients") {
-						Logger_.information(
-							"Removing firewall-rule [Block_Clients] from config-raw for mesh "
-							"device.");
-						cfg.erase("config-raw");
-						break;
-					}
-				}
+				Logger_.information("Removing config-raw section for mesh device.");
+				cfg.erase("config-raw");
 			}
 
 			Poco::JSON::Parser parser;

--- a/src/RESTAPI/RESTAPI_action_handler.cpp
+++ b/src/RESTAPI/RESTAPI_action_handler.cpp
@@ -143,8 +143,15 @@ namespace OpenWifi {
 			Poco::Net::HTTPResponse::HTTP_INTERNAL_SERVER_ERROR;
 		Poco::JSON::Object::Ptr callResponse;
 
-		SDK::GW::Device::SetConfig(nullptr, ParsedBody_, ctx.SubscriberDevices, ctx.GatewaySerial,
-								   callStatus, callResponse);
+		Logger().information(fmt::format("Processing configure request for subscriber: [{}] gateway: [{}]", UserInfo_.userinfo.id, ctx.GatewaySerial));
+
+		SDK::GW::Device::SetConfig(this, ParsedBody_, ctx.SubscriberDevices, ctx.GatewaySerial, UserInfo_.userinfo.id, callStatus, callResponse);
+		if (callStatus != Poco::Net::HTTPResponse::HTTP_OK) {
+			Logger().error(fmt::format("SetConfig failed for subscriber: [{}] gateway: [{}], Status={}",
+									   UserInfo_.userinfo.id, ctx.GatewaySerial, static_cast<int>(callStatus)));
+		} else {
+			Logger().information(fmt::format("SetConfig succeeded for subscriber: [{}] gateway: [{}]", UserInfo_.userinfo.id, ctx.GatewaySerial));
+		}
 		ReturnSDKResponse(callStatus, callResponse);
 		return callStatus == Poco::Net::HTTPResponse::HTTP_OK;
 	}

--- a/src/RESTAPI/RESTAPI_action_handler.cpp
+++ b/src/RESTAPI/RESTAPI_action_handler.cpp
@@ -145,7 +145,7 @@ namespace OpenWifi {
 
 		Logger().information(fmt::format("Processing configure request for subscriber: [{}] gateway: [{}]", UserInfo_.userinfo.id, ctx.GatewaySerial));
 
-		SDK::GW::Device::SetConfig(this, ParsedBody_, ctx.SubscriberDevices, ctx.GatewaySerial, UserInfo_.userinfo.id, callStatus, callResponse);
+		SDK::GW::Device::SetConfig(nullptr, ParsedBody_, ctx.SubscriberDevices, ctx.GatewaySerial, UserInfo_.userinfo.id, callStatus, callResponse);
 		if (callStatus != Poco::Net::HTTPResponse::HTTP_OK) {
 			Logger().error(fmt::format("SetConfig failed for subscriber: [{}] gateway: [{}], Status={}",
 									   UserInfo_.userinfo.id, ctx.GatewaySerial, static_cast<int>(callStatus)));

--- a/src/RESTAPI/RESTAPI_parental_control_utils.cpp
+++ b/src/RESTAPI/RESTAPI_parental_control_utils.cpp
@@ -716,64 +716,22 @@ namespace OpenWifi::RESTAPI::ParentalControl {
 			std::string stopDate;
 			std::string startTime;
 			std::string stopTime;
-			std::string weekdays;
 			std::vector<std::string> macs;
 		};
 
 		/*
-			ParseWeekdays: Converts space-separated day names (e.g. "Mon Wed") into day numbers (0=Sun..6=Sat).
-			Uses istringstream (iss) to split the string into individual day tokens (e.g. token = "Mon").
+			IsRuleActive: Checks if a client-access firewall block rule is currently active.
+			Client-access rules have start_date/stop_date + start_time/stop_time.
+			Active if current date/time is between start date/time and stop date/time.
+			For same-day time windows (stopTime >= startTime), the stop threshold uses
+			startDate because stop_date is intentionally set to the next calendar date
+			by mango-parental-control.
 		*/
-		std::set<int> ParseWeekdays(const std::string &weekdaysStr) {
-			static const std::vector<std::string> names = {"Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"};
-			std::set<int> days;
-			if (weekdaysStr.empty()) {
-				return days;
-			}
-			std::istringstream iss(weekdaysStr);
-			std::string token;
-			while (iss >> token) {
-				for (int i = 0; i < static_cast<int>(names.size()); ++i) {
-					if (token == names[i]) {
-						days.insert(i);
-						break;
-					}
-				}
-			}
-			return days;
-		}
-
-		/*
-			IsRuleActive: Checks if a firewall block rule is currently active.
-			- Group-Schedule rules (recurring weekly): Active if today's day-of-week matches and current time is within start/stop time window.
-			- Client-Access rules (temporary/one-time): Active if current date/time is between start date/time and stop date/time.
-		*/
-		bool IsRuleActive(const Poco::DateTime &now, const std::string &nowDateStr,
-						  const std::string &nowTimeStr, const FirewallRuleInfo &rule) {
+		bool IsRuleActive(const std::string &nowDateStr, const std::string &nowTimeStr, const FirewallRuleInfo &rule) {
 			if (!rule.enabled) {
 				return false;
 			}
 
-			// Group-schedule rules: have weekdays but no start_date/stop_date.
-			if (!rule.weekdays.empty() && rule.startDate.empty() && rule.stopDate.empty()) {
-				auto allowedDays = ParseWeekdays(rule.weekdays);
-				if (allowedDays.empty()) {
-					return false;
-				}
-				int todayDow = now.dayOfWeek(); // 0=Sun, 1=Mon, ..., 6=Sat
-				if (allowedDays.find(todayDow) == allowedDays.end()) {
-					return false;
-				}
-				if (!rule.startTime.empty() && nowTimeStr < rule.startTime) {
-					return false;
-				}
-				if (!rule.stopTime.empty() && nowTimeStr > rule.stopTime) {
-					return false;
-				}
-				return true;
-			}
-
-			// Client-access rules: have start_date/stop_date + start_time/stop_time.
 			std::string nowStr = nowDateStr + " " + nowTimeStr;
 
 			if (!rule.startDate.empty() && !rule.startTime.empty()) {
@@ -835,6 +793,10 @@ namespace OpenWifi::RESTAPI::ParentalControl {
 					std::string section = key.substr(0, dotPos);
 					std::string param = key.substr(dotPos + 1);
 
+					if (section.find("pc_client_access_") == std::string::npos) {
+						continue;
+					}
+
 					if (param == "enabled") {
 						rules[section].enabled = (val == "1");
 					} else if (param == "start_date") {
@@ -845,8 +807,6 @@ namespace OpenWifi::RESTAPI::ParentalControl {
 						rules[section].startTime = val;
 					} else if (param == "stop_time") {
 						rules[section].stopTime = val;
-					} else if (param == "weekdays") {
-						rules[section].weekdays = val;
 					} else if (op == "add_list" && param == "src_mac") {
 						rules[section].macs.push_back(val);
 					}
@@ -858,7 +818,7 @@ namespace OpenWifi::RESTAPI::ParentalControl {
 
 		auto &logger = Poco::Logger::get("ParentalControl");
 		for (const auto &[section, rule] : rules) {
-			if (IsRuleActive(now, nowDateStr, nowTimeStr, rule)) {
+			if (IsRuleActive(nowDateStr, nowTimeStr, rule)) {
 				for (auto mac : rule.macs) {
 					if (Utils::NormalizeMac(mac)) {
 						blockedMacs.push_back(mac);

--- a/src/RESTAPI/RESTAPI_parental_control_utils.cpp
+++ b/src/RESTAPI/RESTAPI_parental_control_utils.cpp
@@ -8,6 +8,7 @@
 #include "Poco/Format.h"
 #include "Poco/DateTime.h"
 #include "Poco/DateTimeFormatter.h"
+#include "Poco/DateTimeParser.h"
 #include "Poco/String.h"
 #include "fmt/format.h"
 #include "sdks/SDK_gw.h"
@@ -711,13 +712,33 @@ namespace OpenWifi::RESTAPI::ParentalControl {
 
 	namespace {
 		struct FirewallRuleInfo {
-			bool enabled = true;
+			bool enabled = false;
+			bool hasSection = false;
+			bool hasEnabled = false;
+			bool hasStartDate = false;
+			bool hasStopDate = false;
+			bool hasStartTime = false;
+			bool hasStopTime = false;
 			std::string startDate;
 			std::string stopDate;
 			std::string startTime;
 			std::string stopTime;
 			std::vector<std::string> macs;
 		};
+
+		bool IsValidDate(const std::string &date) {
+			if (date.size() != 10) return false;
+			Poco::DateTime dt;
+			int tz = 0;
+			return Poco::DateTimeParser::tryParse("%Y-%m-%d", date, dt, tz);
+		}
+
+		bool IsValidTime(const std::string &time) {
+			if (time.size() != 8) return false;
+			Poco::DateTime dt;
+			int tz = 0;
+			return Poco::DateTimeParser::tryParse("%H:%M:%S", time, dt, tz);
+		}
 
 		/*
 			IsRuleActive: Checks if a client-access firewall block rule is currently active.
@@ -728,33 +749,35 @@ namespace OpenWifi::RESTAPI::ParentalControl {
 			by mango-parental-control.
 		*/
 		bool IsRuleActive(const std::string &nowDateStr, const std::string &nowTimeStr, const FirewallRuleInfo &rule) {
-			if (!rule.enabled) {
+			if (!rule.hasSection || !rule.hasEnabled || !rule.enabled) {
+				return false;
+			}
+
+			if (!rule.hasStartDate || !rule.hasStopDate || !rule.hasStartTime || !rule.hasStopTime) {
+				return false;
+			}
+
+			if (rule.macs.empty()) {
 				return false;
 			}
 
 			std::string nowStr = nowDateStr + " " + nowTimeStr;
-
-			if (!rule.startDate.empty() && !rule.startTime.empty()) {
-				std::string startStr = rule.startDate + " " + rule.startTime;
-				if (nowStr < startStr) {
-					return false;
-				}
+			std::string startStr = rule.startDate + " " + rule.startTime;
+			if (nowStr < startStr) {
+				return false;
 			}
 
-			if (!rule.stopTime.empty()) {
-				// For same-day time windows (stopTime >= startTime), the daily stop
-				// threshold uses startDate because stop_date is intentionally set to
-				// the next calendar date by mango-parental-control.
-				std::string stopDate = rule.stopDate;
-				if (!rule.startTime.empty() && rule.stopTime >= rule.startTime && !rule.startDate.empty()) {
-					stopDate = rule.startDate;
-				}
-				if (!stopDate.empty()) {
-					std::string stopStr = stopDate + " " + rule.stopTime;
-					if (nowStr > stopStr) {
-						return false;
-					}
-				}
+			// For same-day time windows (stopTime >= startTime), the daily stop
+			// threshold uses startDate because stop_date is intentionally set to
+			// the next calendar date by mango-parental-control.
+			std::string stopDate = rule.stopDate;
+			if (rule.stopTime >= rule.startTime) {
+				stopDate = rule.startDate;
+			}
+
+			std::string stopStr = stopDate + " " + rule.stopTime;
+			if (nowStr > stopStr) {
+				return false;
 			}
 
 			return true;
@@ -788,27 +811,40 @@ namespace OpenWifi::RESTAPI::ParentalControl {
 				auto key = cmd->getElement<std::string>(1);
 				auto val = cmd->getElement<std::string>(2);
 
-				auto dotPos = key.rfind('.');
-				if (dotPos != std::string::npos) {
-					std::string section = key.substr(0, dotPos);
-					std::string param = key.substr(dotPos + 1);
+				if (key.rfind("firewall.pc_client_access_", 0) == 0) {
+					std::string prefix = "firewall.pc_client_access_";
+					auto nextDot = key.find('.', prefix.size());
+					if (nextDot == std::string::npos) {
+						if (op == "set" && val == "rule") {
+							rules[key].hasSection = true;
+						}
+					} else {
+						std::string section = key.substr(0, nextDot);
+						std::string param = key.substr(nextDot + 1);
 
-					if (section.find("pc_client_access_") == std::string::npos) {
-						continue;
-					}
-
-					if (param == "enabled") {
-						rules[section].enabled = (val == "1");
-					} else if (param == "start_date") {
-						rules[section].startDate = val;
-					} else if (param == "stop_date") {
-						rules[section].stopDate = val;
-					} else if (param == "start_time") {
-						rules[section].startTime = val;
-					} else if (param == "stop_time") {
-						rules[section].stopTime = val;
-					} else if (op == "add_list" && param == "src_mac") {
-						rules[section].macs.push_back(val);
+						if (op == "set") {
+							if (param == "enabled") {
+								rules[section].enabled = (val == "1");
+								rules[section].hasEnabled = true;
+							} else if (param == "start_date") {
+								rules[section].startDate = val;
+								rules[section].hasStartDate = IsValidDate(val);
+							} else if (param == "stop_date") {
+								rules[section].stopDate = val;
+								rules[section].hasStopDate = IsValidDate(val);
+							} else if (param == "start_time") {
+								rules[section].startTime = val;
+								rules[section].hasStartTime = IsValidTime(val);
+							} else if (param == "stop_time") {
+								rules[section].stopTime = val;
+								rules[section].hasStopTime = IsValidTime(val);
+							}
+						} else if (op == "add_list" && param == "src_mac") {
+							std::string normalizedMac = val;
+							if (Utils::NormalizeMac(normalizedMac)) {
+								rules[section].macs.push_back(normalizedMac);
+							}
+						}
 					}
 				}
 			} catch (...) {

--- a/src/RESTAPI/RESTAPI_parental_control_utils.cpp
+++ b/src/RESTAPI/RESTAPI_parental_control_utils.cpp
@@ -6,6 +6,9 @@
 
 #include "RESTAPI_parental_control_utils.h"
 #include "Poco/Format.h"
+#include "Poco/DateTime.h"
+#include "Poco/DateTimeFormatter.h"
+#include "Poco/String.h"
 #include "fmt/format.h"
 #include "sdks/SDK_gw.h"
 #include "sdks/SDK_prov.h"
@@ -13,7 +16,10 @@
 #include "framework/utils.h"
 #include "framework/ow_constants.h"
 #include <cctype>
+#include <list>
+#include <map>
 #include <set>
+#include <sstream>
 #include <vector>
 
 namespace OpenWifi::RESTAPI::ParentalControl {
@@ -104,7 +110,7 @@ namespace OpenWifi::RESTAPI::ParentalControl {
 											 Poco::JSON::Object::Ptr &topologyResponse) {
 			Poco::Net::HTTPServerResponse::HTTPStatus topoStatus = Poco::Net::HTTPServerResponse::HTTP_INTERNAL_SERVER_ERROR;
 			topologyResponse = Poco::makeShared<Poco::JSON::Object>();
-			if (!SDK::Topology::Get(&handler, boardId, topoStatus, topologyResponse)) {
+			if (!SDK::Topology::Get(nullptr, boardId, topoStatus, topologyResponse)) {
 				return ValidateMacResult::TopologyNotFound;
 			}
 
@@ -698,6 +704,170 @@ namespace OpenWifi::RESTAPI::ParentalControl {
 		}
 		handler.InternalError(RESTAPI::Errors::InternalError);
 		return false;
+	}
+	// =========================================================================
+	// Blocked-Client Evaluation (used by topology response)
+	// =========================================================================
+
+	namespace {
+		struct FirewallRuleInfo {
+			bool enabled = true;
+			std::string startDate;
+			std::string stopDate;
+			std::string startTime;
+			std::string stopTime;
+			std::string weekdays;
+			std::vector<std::string> macs;
+		};
+
+		/*
+			ParseWeekdays: Converts space-separated day names (e.g. "Mon Wed") into day numbers (0=Sun..6=Sat).
+			Uses istringstream (iss) to split the string into individual day tokens (e.g. token = "Mon").
+		*/
+		std::set<int> ParseWeekdays(const std::string &weekdaysStr) {
+			static const std::vector<std::string> names = {"Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"};
+			std::set<int> days;
+			if (weekdaysStr.empty()) {
+				return days;
+			}
+			std::istringstream iss(weekdaysStr);
+			std::string token;
+			while (iss >> token) {
+				for (int i = 0; i < static_cast<int>(names.size()); ++i) {
+					if (token == names[i]) {
+						days.insert(i);
+						break;
+					}
+				}
+			}
+			return days;
+		}
+
+		/*
+			IsRuleActive: Checks if a firewall block rule is currently active.
+			- Group-Schedule rules (recurring weekly): Active if today's day-of-week matches and current time is within start/stop time window.
+			- Client-Access rules (temporary/one-time): Active if current date/time is between start date/time and stop date/time.
+		*/
+		bool IsRuleActive(const Poco::DateTime &now, const std::string &nowDateStr,
+						  const std::string &nowTimeStr, const FirewallRuleInfo &rule) {
+			if (!rule.enabled) {
+				return false;
+			}
+
+			// Group-schedule rules: have weekdays but no start_date/stop_date.
+			if (!rule.weekdays.empty() && rule.startDate.empty() && rule.stopDate.empty()) {
+				auto allowedDays = ParseWeekdays(rule.weekdays);
+				if (allowedDays.empty()) {
+					return false;
+				}
+				int todayDow = now.dayOfWeek(); // 0=Sun, 1=Mon, ..., 6=Sat
+				if (allowedDays.find(todayDow) == allowedDays.end()) {
+					return false;
+				}
+				if (!rule.startTime.empty() && nowTimeStr < rule.startTime) {
+					return false;
+				}
+				if (!rule.stopTime.empty() && nowTimeStr > rule.stopTime) {
+					return false;
+				}
+				return true;
+			}
+
+			// Client-access rules: have start_date/stop_date + start_time/stop_time.
+			std::string nowStr = nowDateStr + " " + nowTimeStr;
+
+			if (!rule.startDate.empty() && !rule.startTime.empty()) {
+				std::string startStr = rule.startDate + " " + rule.startTime;
+				if (nowStr < startStr) {
+					return false;
+				}
+			}
+
+			if (!rule.stopTime.empty()) {
+				// For same-day time windows (stopTime >= startTime), the daily stop
+				// threshold uses startDate because stop_date is intentionally set to
+				// the next calendar date by mango-parental-control.
+				std::string stopDate = rule.stopDate;
+				if (!rule.startTime.empty() && rule.stopTime >= rule.startTime && !rule.startDate.empty()) {
+					stopDate = rule.startDate;
+				}
+				if (!stopDate.empty()) {
+					std::string stopStr = stopDate + " " + rule.stopTime;
+					if (nowStr > stopStr) {
+						return false;
+					}
+				}
+			}
+
+			return true;
+		}
+	} // namespace
+
+	bool GetBlockedClients(const Poco::JSON::Object::Ptr &config,
+						   std::list<std::string> &blockedMacs) {
+		blockedMacs.clear();
+		if (!config || !config->has("config-raw") || !config->isArray("config-raw")) {
+			return config != nullptr;
+		}
+
+		auto configRaw = config->getArray("config-raw");
+		if (!configRaw) {
+			return true;
+		}
+
+		Poco::DateTime now;
+		std::string nowDateStr = Poco::DateTimeFormatter::format(now, "%Y-%m-%d");
+		std::string nowTimeStr = Poco::DateTimeFormatter::format(now, "%H:%M:%S");
+
+		std::map<std::string, FirewallRuleInfo> rules;
+		for (std::size_t i = 0; i < configRaw->size(); ++i) {
+			try {
+				auto cmd = configRaw->getArray(i);
+				if (!cmd || cmd->size() != 3)
+					continue;
+
+				auto op = cmd->getElement<std::string>(0);
+				auto key = cmd->getElement<std::string>(1);
+				auto val = cmd->getElement<std::string>(2);
+
+				auto dotPos = key.rfind('.');
+				if (dotPos != std::string::npos) {
+					std::string section = key.substr(0, dotPos);
+					std::string param = key.substr(dotPos + 1);
+
+					if (param == "enabled") {
+						rules[section].enabled = (val == "1");
+					} else if (param == "start_date") {
+						rules[section].startDate = val;
+					} else if (param == "stop_date") {
+						rules[section].stopDate = val;
+					} else if (param == "start_time") {
+						rules[section].startTime = val;
+					} else if (param == "stop_time") {
+						rules[section].stopTime = val;
+					} else if (param == "weekdays") {
+						rules[section].weekdays = val;
+					} else if (op == "add_list" && param == "src_mac") {
+						rules[section].macs.push_back(val);
+					}
+				}
+			} catch (...) {
+				continue;
+			}
+		}
+
+		auto &logger = Poco::Logger::get("ParentalControl");
+		for (const auto &[section, rule] : rules) {
+			if (IsRuleActive(now, nowDateStr, nowTimeStr, rule)) {
+				for (auto mac : rule.macs) {
+					if (Utils::NormalizeMac(mac)) {
+						blockedMacs.push_back(mac);
+						logger.debug(fmt::format("Active blocked client MAC found: {}", Utils::SerialToMAC(mac)));
+					}
+				}
+			}
+		}
+		return true;
 	}
 
 } // namespace OpenWifi::RESTAPI::ParentalControl

--- a/src/RESTAPI/RESTAPI_parental_control_utils.h
+++ b/src/RESTAPI/RESTAPI_parental_control_utils.h
@@ -9,10 +9,17 @@
 #include "Poco/JSON/Array.h"
 #include "Poco/JSON/Object.h"
 #include "framework/RESTAPI_Handler.h"
+#include <list>
 #include <optional>
 #include <string>
 
 namespace OpenWifi::RESTAPI::ParentalControl {
+
+	// =========================================================================
+	// Blocked-Client Evaluation (used by topology response)
+	// =========================================================================
+
+	bool GetBlockedClients(const Poco::JSON::Object::Ptr &config, std::list<std::string> &blockedMacs);
 
 	// =========================================================================
 	// Schedule Helpers

--- a/src/RESTAPI/RESTAPI_topology_handler.cpp
+++ b/src/RESTAPI/RESTAPI_topology_handler.cpp
@@ -9,6 +9,7 @@
 #include "sdks/SDK_gw.h"
 
 #include "RESTAPI_topology_handler.h"
+#include "RESTAPI_parental_control_utils.h"
 
 #include "Poco/String.h"
 #include "framework/ow_constants.h"
@@ -151,67 +152,6 @@ namespace OpenWifi {
 		return true;
 	}
 
-	/*
-		GetBlockedClients():
-		1. Read Config["config-raw"] (if missing/empty, return an empty list).
-		2. Walk firewall rule blocks (started by ["add","firewall","rule"]).
-		3. Detect our block-clients rule by name "Block_Clients".
-		4. Collect all src_mac entries from that rule into blockedMacs (normalized).
-	*/
-	bool GetBlockedClients(const Poco::JSON::Object::Ptr &config, std::list<std::string> &blockedMacs) {
-		blockedMacs.clear();
-		if (!config) {
-			return false;
-		}
-
-		if (!config->has("config-raw") || !config->isArray("config-raw")) {
-			return true;
-		}
-
-		auto configRaw = config->getArray("config-raw");
-		if (!configRaw || configRaw->size() == 0)
-			return true;
-
-		bool inFirewallRule = false;
-		bool isBlockRule = false;
-
-		for (std::size_t i = 0; i < configRaw->size(); ++i) {
-			try {
-				auto cmd = configRaw->getArray(i);
-				if (!cmd || cmd->size() != 3)
-					continue;
-
-				auto op = cmd->getElement<std::string>(0);
-				auto key = cmd->getElement<std::string>(1);
-				auto val = cmd->getElement<std::string>(2);
-
-				if (op == "add" && key == "firewall" && val == "rule") {
-					inFirewallRule = true;
-					isBlockRule = false;
-					continue;
-				}
-
-				if (!inFirewallRule)
-					continue;
-
-				if (op == "set" && key == "firewall.@rule[-1].name") {
-					isBlockRule = (val == "Block_Clients");
-					continue;
-				}
-
-				if (isBlockRule && op == "add_list" && key == "firewall.@rule[-1].src_mac") {
-					std::string mac = val;
-					if (Utils::NormalizeMac(mac)) {
-						blockedMacs.push_back(mac);
-						Poco::Logger::get("SDK_gw").debug(fmt::format("Blocked client MAC found: {}", Utils::SerialToMAC(mac)));
-					}
-				}
-			} catch (...) {
-				continue;
-			}
-		}
-		return true;
-	}
 
 	/*
 		FinalizeTopologyResponse:
@@ -368,7 +308,7 @@ namespace OpenWifi {
 			config = deviceObj->getObject("configuration");
 		}
 
-		if (!config || !GetBlockedClients(config, blockedMacs)) {
+		if (!config || !RESTAPI::ParentalControl::GetBlockedClients(config, blockedMacs)) {
 			Logger().debug(fmt::format("[GET-TOPOLOGY] Failed to fetch config for {}.", gatewaySerial));
 		}
 
@@ -387,9 +327,11 @@ namespace OpenWifi {
 				} catch (...) {
 					continue;
 				}
+				std::string normalizedStation = station;
+				Poco::toLowerInPlace(normalizedStation);
 				auto entry = Poco::makeShared<Poco::JSON::Object>();
 				entry->set("station", station);
-				entry->set("blocked", blockedMacSet.count(station) ? "1" : "0");
+				entry->set("blocked", blockedMacSet.count(normalizedStation) ? "1" : "0");
 				historicalClientsWithFlags->add(entry);
 			}
 			topologyResponse->set("historicalClients", historicalClientsWithFlags);
@@ -418,7 +360,9 @@ namespace OpenWifi {
 							continue;
 						}
 						const auto station = client->getValue<std::string>("station");
-						client->set("blocked", blockedMacSet.count(station) ? "1" : "0");
+						std::string normalizedStation = station;
+						Poco::toLowerInPlace(normalizedStation);
+						client->set("blocked", blockedMacSet.count(normalizedStation) ? "1" : "0");
 					}
 				}
 			}

--- a/src/framework/RESTAPI_Handler.h
+++ b/src/framework/RESTAPI_Handler.h
@@ -396,11 +396,9 @@ namespace OpenWifi {
 											const Poco::JSON::Object::Ptr &callResponse) {
 			auto Forward = callResponse ? callResponse : Poco::makeShared<Poco::JSON::Object>();
 			auto *target = client ? client : this;
-			target->Response->setStatus(callStatus);
+			target->PrepareResponse(callStatus);
 			std::stringstream ss;
 			Poco::JSON::Stringifier::condense(Forward, ss);
-			target->Response->setContentType("application/json");
-			target->Response->setContentLength(ss.str().size());
 			auto &os = target->Response->send();
 			os << ss.str();
 			os.flush();

--- a/src/framework/ow_constants.h
+++ b/src/framework/ow_constants.h
@@ -456,10 +456,10 @@ namespace OpenWifi::RESTAPI::Errors {
 	static const struct msg MacNotPresentInTopology { 1198, "MAC address is not present in subscriber topology." };
 	static const struct msg GatewayInventoryNotFound { 1199, "Gateway inventory record not found." };
 	static const struct msg VenueMissingBoardId { 1200, "Venue record does not contain a usable Board ID." };
-	static const struct msg ParentalControlDurationCrossesMidnight { 1201, "Duration crosses midnight. Duration-based client blocking is limited to the current block day." };
-	static const struct msg ParentalControlDurationNotAllowedForAllow { 1202, "Duration is not allowed when access is set to 'allow'." };
-	static const struct msg ParentalControlInvalidDuration { 1203, "Duration must be a positive integer greater than or equal to 1." };
-	static const struct msg ParentalControlInvalidAccess { 1204, "Access must be 'allow' or 'deny'." };
+	static const struct msg DurationCrossesMidnight { 1201, "Duration crosses midnight. Duration-based client blocking is limited to the current block day." };
+	static const struct msg DurationNotAllowedForAllow { 1202, "Duration is not allowed when access is set to 'allow'." };
+	static const struct msg InvalidDuration { 1203, "Duration must be a positive integer greater than or equal to 1." };
+	static const struct msg InvalidAccess { 1204, "Access must be 'allow' or 'deny'." };
 
 } // namespace OpenWifi::RESTAPI::Errors
 

--- a/src/framework/ow_constants.h
+++ b/src/framework/ow_constants.h
@@ -456,6 +456,10 @@ namespace OpenWifi::RESTAPI::Errors {
 	static const struct msg MacNotPresentInTopology { 1198, "MAC address is not present in subscriber topology." };
 	static const struct msg GatewayInventoryNotFound { 1199, "Gateway inventory record not found." };
 	static const struct msg VenueMissingBoardId { 1200, "Venue record does not contain a usable Board ID." };
+	static const struct msg ParentalControlDurationCrossesMidnight { 1201, "Duration crosses midnight. Duration-based client blocking is limited to the current block day." };
+	static const struct msg ParentalControlDurationNotAllowedForAllow { 1202, "Duration is not allowed when access is set to 'allow'." };
+	static const struct msg ParentalControlInvalidDuration { 1203, "Duration must be a positive integer greater than or equal to 1." };
+	static const struct msg ParentalControlInvalidAccess { 1204, "Access must be 'allow' or 'deny'." };
 
 } // namespace OpenWifi::RESTAPI::Errors
 

--- a/src/sdks/SDK_gw.cpp
+++ b/src/sdks/SDK_gw.cpp
@@ -503,6 +503,17 @@ namespace OpenWifi::SDK::GW {
 
 			Poco::JSON::Object::Ptr lastCallResponse;
 
+			struct ValidatedClientEntry {
+				std::string mac;
+				std::string formattedMac;
+				std::string access;
+				int64_t durationMinutes = 0;
+				bool hasDuration = false;
+			};
+			std::vector<ValidatedClientEntry> validatedEntries;
+			validatedEntries.reserve(clientList->size());
+
+			// Pass 1: Local validation with no side effects
 			for (std::size_t i = 0; i < clientList->size(); ++i) {
 				auto entry = clientList->getObject(i);
 				if (!entry || !entry->has("mac") || !entry->has("access")) {
@@ -579,18 +590,29 @@ namespace OpenWifi::SDK::GW {
 				std::string formattedMac = Utils::SerialToMAC(mac);
 				Poco::toLowerInPlace(formattedMac);
 
+				ValidatedClientEntry validatedEntry;
+				validatedEntry.mac = mac;
+				validatedEntry.formattedMac = formattedMac;
+				validatedEntry.access = access;
+				validatedEntry.durationMinutes = durationMinutes;
+				validatedEntry.hasDuration = hasDuration;
+				validatedEntries.push_back(validatedEntry);
+			}
+
+			// Pass 2: Execute REST calls downstream (guaranteed that all entries are locally valid)
+			for (const auto &entry : validatedEntries) {
 				Poco::Net::HTTPResponse::HTTPStatus callStatus = Poco::Net::HTTPResponse::HTTP_INTERNAL_SERVER_ERROR;
 				Poco::JSON::Object::Ptr callResponse;
 
-				if (access == "deny") {
+				if (entry.access == "deny") {
 					Poco::DateTime now;
 					std::string startDate = Poco::DateTimeFormatter::format(now, "%Y-%m-%d");
 					std::string startTime = Poco::DateTimeFormatter::format(now, "%H:%M:%S");
 
 					std::string stopDate;
 					std::string stopTime;
-					if (durationMinutes > 0) {
-						Poco::DateTime endDt = now + Poco::Timespan(durationMinutes * 60, 0);
+					if (entry.durationMinutes > 0) {
+						Poco::DateTime endDt = now + Poco::Timespan(entry.durationMinutes * 60, 0);
 						stopTime = Poco::DateTimeFormatter::format(endDt, "%H:%M:%S");
 
 						Poco::DateTime nextDay = endDt + Poco::Timespan(86400, 0);
@@ -602,7 +624,7 @@ namespace OpenWifi::SDK::GW {
 					}
 
 					Poco::JSON::Object reqBody;
-					reqBody.set("client_mac", formattedMac);
+					reqBody.set("client_mac", entry.formattedMac);
 					reqBody.set("start_date", startDate);
 					reqBody.set("stop_date", stopDate);
 					reqBody.set("start_time", startTime);
@@ -611,11 +633,11 @@ namespace OpenWifi::SDK::GW {
 					Poco::Logger::get("SDK_gw").information(fmt::format(
 						"Sending BLOCK request for client: [{}] subscriber: [{}] "
 						"(start_date={}, stop_date={}, start_time={}, stop_time={}) to parental-control",
-						formattedMac, SubscriberId, startDate, stopDate, startTime, stopTime));
+						entry.formattedMac, SubscriberId, startDate, stopDate, startTime, stopTime));
 
 					if (!SDK::ParentalControl::CreateClientAccess(client, SubscriberId, reqBody, callStatus, callResponse)) {
 						Poco::Logger::get("SDK_gw").error(fmt::format("CreateClientAccess failed for client: [{}] subscriber: [{}], Status={}",
-							formattedMac, SubscriberId, static_cast<int>(callStatus)));
+							entry.formattedMac, SubscriberId, static_cast<int>(callStatus)));
 						responseStatus = callStatus;
 						response = callResponse ? callResponse : Poco::makeShared<Poco::JSON::Object>();
 						return false;
@@ -624,11 +646,11 @@ namespace OpenWifi::SDK::GW {
 				} else {
 					std::string rawResponseBody;
 					Poco::Logger::get("SDK_gw").information(fmt::format("Sending UNBLOCK request for client: [{}] subscriber: [{}] to parental-control",
-									formattedMac, SubscriberId));
+									entry.formattedMac, SubscriberId));
 
-					if (!SDK::ParentalControl::DeleteClientAccess(client, SubscriberId, formattedMac, callStatus, callResponse, rawResponseBody)) {
+					if (!SDK::ParentalControl::DeleteClientAccess(client, SubscriberId, entry.formattedMac, callStatus, callResponse, rawResponseBody)) {
 						Poco::Logger::get("SDK_gw").error(fmt::format("DeleteClientAccess failed for client: [{}] subscriber: [{}], Status={}",
-							formattedMac, SubscriberId, static_cast<int>(callStatus)));
+							entry.formattedMac, SubscriberId, static_cast<int>(callStatus)));
 						responseStatus = callStatus;
 						response = callResponse ? callResponse : Poco::makeShared<Poco::JSON::Object>();
 						return false;

--- a/src/sdks/SDK_gw.cpp
+++ b/src/sdks/SDK_gw.cpp
@@ -516,12 +516,17 @@ namespace OpenWifi::SDK::GW {
 				std::string access;
 				int64_t durationMinutes = 0;
 				bool hasDuration = false;
+				bool durationIsNull = false;
 				try {
 					mac = entry->getValue<std::string>("mac");
 					access = entry->getValue<std::string>("access");
-					if (entry->has("duration") && !entry->isNull("duration")) {
+					if (entry->has("duration")) {
 						hasDuration = true;
-						durationMinutes = entry->getValue<int64_t>("duration");
+						if (entry->isNull("duration")) {
+							durationIsNull = true;
+						} else {
+							durationMinutes = entry->getValue<int64_t>("duration");
+						}
 					}
 				} catch (...) {
 					Poco::Logger::get("SDK_gw").error(fmt::format("Failed to parse fields for entry {}.", i));
@@ -531,11 +536,44 @@ namespace OpenWifi::SDK::GW {
 				}
 				Poco::trimInPlace(access);
 				Poco::toLowerInPlace(access);
-				if (!Utils::NormalizeMac(mac) || (access != "allow" && access != "deny") || (hasDuration && durationMinutes < 1)) {
-					Poco::Logger::get("SDK_gw").error(fmt::format("Invalid MAC [{}], access [{}], or duration minutes [{}] for entry {}.", mac, access, durationMinutes, i));
+
+				if (!Utils::NormalizeMac(mac)) {
+					Poco::Logger::get("SDK_gw").error(fmt::format("Invalid MAC address [{}] for entry {}.", mac, i));
 					return SetErrorResponse(Poco::Net::HTTPResponse::HTTP_BAD_REQUEST,
-											RESTAPI::Errors::MissingOrInvalidParameters, responseStatus,
+											RESTAPI::Errors::InvalidMacAddress, responseStatus,
 											response);
+				}
+
+				if (access != "allow" && access != "deny") {
+					Poco::Logger::get("SDK_gw").error(fmt::format("Invalid access value [{}] for client MAC [{}].", access, mac));
+					return SetErrorResponse(Poco::Net::HTTPResponse::HTTP_BAD_REQUEST,
+											RESTAPI::Errors::ParentalControlInvalidAccess, responseStatus,
+											response);
+				}
+
+				if (access == "allow" && hasDuration) {
+					Poco::Logger::get("SDK_gw").error(fmt::format("Duration specified with access 'allow' for client MAC [{}].", mac));
+					return SetErrorResponse(Poco::Net::HTTPResponse::HTTP_BAD_REQUEST,
+											RESTAPI::Errors::ParentalControlDurationNotAllowedForAllow, responseStatus,
+											response);
+				}
+
+				if (hasDuration && (durationIsNull || durationMinutes < 1)) {
+					Poco::Logger::get("SDK_gw").error(fmt::format("Invalid duration minutes [{}] for client MAC [{}].", durationMinutes, mac));
+					return SetErrorResponse(Poco::Net::HTTPResponse::HTTP_BAD_REQUEST,
+											RESTAPI::Errors::ParentalControlInvalidDuration, responseStatus,
+											response);
+				}
+
+				if (hasDuration && access == "deny") {
+					Poco::DateTime now;
+					Poco::DateTime endDt = now + Poco::Timespan(durationMinutes * 60, 0);
+					if (endDt.year() != now.year() || endDt.month() != now.month() || endDt.day() != now.day()) {
+						Poco::Logger::get("SDK_gw").error(fmt::format("Duration [{}] minutes crosses midnight for client MAC [{}].", durationMinutes, mac));
+						return SetErrorResponse(Poco::Net::HTTPResponse::HTTP_BAD_REQUEST,
+												RESTAPI::Errors::ParentalControlDurationCrossesMidnight, responseStatus,
+												response);
+					}
 				}
 
 				std::string formattedMac = Utils::SerialToMAC(mac);
@@ -549,15 +587,18 @@ namespace OpenWifi::SDK::GW {
 					std::string startDate = Poco::DateTimeFormatter::format(now, "%Y-%m-%d");
 					std::string startTime = Poco::DateTimeFormatter::format(now, "%H:%M:%S");
 
-					Poco::DateTime nextDay = now + Poco::Timespan(86400, 0);
-					std::string stopDate = Poco::DateTimeFormatter::format(nextDay, "%Y-%m-%d");
-
+					std::string stopDate;
 					std::string stopTime;
 					if (durationMinutes > 0) {
-						Poco::DateTime endDt = now + Poco::Timespan(std::chrono::minutes(durationMinutes));
+						Poco::DateTime endDt = now + Poco::Timespan(durationMinutes * 60, 0);
 						stopTime = Poco::DateTimeFormatter::format(endDt, "%H:%M:%S");
+
+						Poco::DateTime nextDay = endDt + Poco::Timespan(86400, 0);
+						stopDate = Poco::DateTimeFormatter::format(nextDay, "%Y-%m-%d");
 					} else {
 						stopTime = "23:59:59";
+						Poco::DateTime nextDay = now + Poco::Timespan(86400, 0);
+						stopDate = Poco::DateTimeFormatter::format(nextDay, "%Y-%m-%d");
 					}
 
 					Poco::JSON::Object reqBody;

--- a/src/sdks/SDK_gw.cpp
+++ b/src/sdks/SDK_gw.cpp
@@ -12,6 +12,7 @@
 #include <Poco/DateTime.h>
 #include <Poco/DateTimeFormatter.h>
 #include <Poco/Timespan.h>
+#include <chrono>
 #include <algorithm>
 #include <regex>
 #include <sstream>
@@ -472,7 +473,7 @@ namespace OpenWifi::SDK::GW {
 			ApplyClientAccessChanges():
 			1. Read and validate the request "client" array (each item needs "mac" + "access").
 			2. For each entry:
-			   - If access == "deny": compute start/stop date/time (with optional duration) and call
+			   - If access == "deny": compute start/stop date/time (with optional duration in minutes) and call
 				 SDK::ParentalControl::CreateClientAccess.
 			   - If access == "allow": call SDK::ParentalControl::DeleteClientAccess.
 			3. Extract config-raw snapshot from the PC response and update Config["config-raw"].
@@ -513,14 +514,14 @@ namespace OpenWifi::SDK::GW {
 
 				std::string mac;
 				std::string access;
-				int64_t durationSec = 0;
+				int64_t durationMinutes = 0;
 				bool hasDuration = false;
 				try {
 					mac = entry->getValue<std::string>("mac");
 					access = entry->getValue<std::string>("access");
 					if (entry->has("duration") && !entry->isNull("duration")) {
 						hasDuration = true;
-						durationSec = entry->getValue<int64_t>("duration");
+						durationMinutes = entry->getValue<int64_t>("duration");
 					}
 				} catch (...) {
 					Poco::Logger::get("SDK_gw").error(fmt::format("Failed to parse fields for entry {}.", i));
@@ -530,12 +531,13 @@ namespace OpenWifi::SDK::GW {
 				}
 				Poco::trimInPlace(access);
 				Poco::toLowerInPlace(access);
-				if (!Utils::NormalizeMac(mac) || (access != "allow" && access != "deny") || (hasDuration && durationSec < 1)) {
-					Poco::Logger::get("SDK_gw").error(fmt::format("Invalid MAC [{}], access [{}], or duration [{}] for entry {}.", mac, access, durationSec, i));
+				if (!Utils::NormalizeMac(mac) || (access != "allow" && access != "deny") || (hasDuration && durationMinutes < 1)) {
+					Poco::Logger::get("SDK_gw").error(fmt::format("Invalid MAC [{}], access [{}], or duration minutes [{}] for entry {}.", mac, access, durationMinutes, i));
 					return SetErrorResponse(Poco::Net::HTTPResponse::HTTP_BAD_REQUEST,
 											RESTAPI::Errors::MissingOrInvalidParameters, responseStatus,
 											response);
 				}
+
 				std::string formattedMac = Utils::SerialToMAC(mac);
 				Poco::toLowerInPlace(formattedMac);
 
@@ -551,8 +553,8 @@ namespace OpenWifi::SDK::GW {
 					std::string stopDate = Poco::DateTimeFormatter::format(nextDay, "%Y-%m-%d");
 
 					std::string stopTime;
-					if (durationSec > 0) {
-						Poco::DateTime endDt = now + Poco::Timespan(durationSec, 0);
+					if (durationMinutes > 0) {
+						Poco::DateTime endDt = now + Poco::Timespan(std::chrono::minutes(durationMinutes));
 						stopTime = Poco::DateTimeFormatter::format(endDt, "%H:%M:%S");
 					} else {
 						stopTime = "23:59:59";

--- a/src/sdks/SDK_gw.cpp
+++ b/src/sdks/SDK_gw.cpp
@@ -7,6 +7,11 @@
 //
 // Created by stephane bourque on 2022-01-11.
 //
+#include "RESTAPI/RESTAPI_parental_control_utils.h"
+#include "sdks/SDK_parental_control.h"
+#include <Poco/DateTime.h>
+#include <Poco/DateTimeFormatter.h>
+#include <Poco/Timespan.h>
 #include <algorithm>
 #include <regex>
 #include <sstream>
@@ -454,21 +459,6 @@ namespace OpenWifi::SDK::GW {
 			return true;
 		}
 
-		/*
-			MakeConfigRawCmd():
-			1. Build a single config-raw command array with 3 elements: [op, path, value].
-			2. Return it so callers can append it into a config-raw list.
-		*/
-		static Poco::JSON::Array::Ptr BuildConfigRawCommand(const std::string &op,
-															const std::string &path,
-															const std::string &value) {
-			auto cmd = Poco::makeShared<Poco::JSON::Array>();
-			cmd->add(op);
-			cmd->add(path);
-			cmd->add(value);
-			return cmd;
-		}
-
 		static std::string SerializeJson(const Poco::JSON::Object::Ptr &object) {
 			if (!object) {
 				return {};
@@ -479,47 +469,22 @@ namespace OpenWifi::SDK::GW {
 		}
 
 		/*
-			MakeBlockRuleRaw():
-			1. Build a config-raw array containing a single firewall rule named "Block_Clients".
-			2. Add one src_mac entry per blocked MAC (from blockedMacsNorm).
-			3. Return the constructed config-raw array so it can be saved into Config["config-raw"].
-		*/
-		static Poco::JSON::Array::Ptr BuildBlockClientsRule(
-			const std::list<std::string> &blockedMacsNorm) {
-			auto raw = Poco::makeShared<Poco::JSON::Array>();
-
-			raw->add(BuildConfigRawCommand("add", "firewall", "rule"));
-			raw->add(BuildConfigRawCommand("set", "firewall.@rule[-1].name", "Block_Clients"));
-			raw->add(BuildConfigRawCommand("set", "firewall.@rule[-1].src", "down1v0"));
-			raw->add(BuildConfigRawCommand("set", "firewall.@rule[-1].dest", "up0v0"));
-
-			for (const auto &macNorm : blockedMacsNorm) {
-				raw->add(BuildConfigRawCommand("add_list", "firewall.@rule[-1].src_mac",
-											   Utils::SerialToMAC(macNorm)));
-			}
-
-			raw->add(BuildConfigRawCommand("set", "firewall.@rule[-1].family", "any"));
-			raw->add(BuildConfigRawCommand("set", "firewall.@rule[-1].proto", "all"));
-			raw->add(BuildConfigRawCommand("set", "firewall.@rule[-1].target", "REJECT"));
-			raw->add(BuildConfigRawCommand("set", "firewall.@rule[-1].enabled", "1"));
-
-			return raw;
-		}
-
-		/*
 			ApplyClientAccessChanges():
 			1. Read and validate the request "client" array (each item needs "mac" + "access").
-			2. Normalize MAC addresses and validate access is either "allow" or "deny".
-			3. Load current blocked list from Config["config-raw"].
-			4. Apply request entries as a delta (deny adds, allow removes).
-			5. Remove existing Config["config-raw"] completely.
-			6. Write new block rule to Config["config-raw"] if blocked list is non-empty.
+			2. For each entry:
+			   - If access == "deny": compute start/stop date/time (with optional duration) and call
+				 SDK::ParentalControl::CreateClientAccess.
+			   - If access == "allow": call SDK::ParentalControl::DeleteClientAccess.
+			3. Extract config-raw snapshot from the PC response and update Config["config-raw"].
 		*/
-		static bool ApplyClientAccessChanges(
-			Poco::JSON::Object::Ptr &Config, const Poco::JSON::Object::Ptr &Body,
-			Poco::Net::HTTPResponse::HTTPStatus &responseStatus,
-			Poco::JSON::Object::Ptr &response) {
+		static bool ApplyClientAccessChanges(RESTAPIHandler *client,
+											 Poco::JSON::Object::Ptr &Config,
+											 const Poco::JSON::Object::Ptr &Body,
+											 const std::string &SubscriberId,
+											 Poco::Net::HTTPResponse::HTTPStatus &responseStatus,
+											 Poco::JSON::Object::Ptr &response) {
 			if (!Config || !Body || !Body->has("client") || !Body->isArray("client")) {
+				Poco::Logger::get("SDK_gw").error("Missing or invalid 'client' array in request body.");
 				return SetErrorResponse(Poco::Net::HTTPResponse::HTTP_BAD_REQUEST,
 										RESTAPI::Errors::MissingOrInvalidParameters, responseStatus,
 										response);
@@ -527,20 +492,20 @@ namespace OpenWifi::SDK::GW {
 
 			auto clientList = Body->getArray("client");
 			if (!clientList || clientList->size() == 0) {
+				Poco::Logger::get("SDK_gw").error("'client' array is empty.");
 				return SetErrorResponse(Poco::Net::HTTPResponse::HTTP_BAD_REQUEST,
 										RESTAPI::Errors::MissingOrInvalidParameters, responseStatus,
 										response);
 			}
 
-			std::list<std::string> blockedMacs;
-			if (!GetBlockedClients(Config, blockedMacs)) {
-				return SetErrorResponse(Poco::Net::HTTPResponse::HTTP_INTERNAL_SERVER_ERROR,
-										RESTAPI::Errors::InternalError, responseStatus, response);
-			}
+			Poco::Logger::get("SDK_gw").information(fmt::format("Processing {} client access entry(ies) for subscriber: [{}]", clientList->size(), SubscriberId));
+
+			Poco::JSON::Object::Ptr lastCallResponse;
 
 			for (std::size_t i = 0; i < clientList->size(); ++i) {
 				auto entry = clientList->getObject(i);
 				if (!entry || !entry->has("mac") || !entry->has("access")) {
+					Poco::Logger::get("SDK_gw").error(fmt::format("Entry {} missing required 'mac' or 'access' fields.", i));
 					return SetErrorResponse(Poco::Net::HTTPResponse::HTTP_BAD_REQUEST,
 											RESTAPI::Errors::MissingOrInvalidParameters, responseStatus,
 											response);
@@ -548,10 +513,15 @@ namespace OpenWifi::SDK::GW {
 
 				std::string mac;
 				std::string access;
+				int64_t durationSec = 0;
 				try {
 					mac = entry->getValue<std::string>("mac");
 					access = entry->getValue<std::string>("access");
+					if (entry->has("duration") && !entry->isNull("duration")) {
+						durationSec = entry->getValue<int64_t>("duration");
+					}
 				} catch (...) {
+					Poco::Logger::get("SDK_gw").error(fmt::format("Failed to parse fields for entry {}.", i));
 					return SetErrorResponse(Poco::Net::HTTPResponse::HTTP_BAD_REQUEST,
 											RESTAPI::Errors::MissingOrInvalidParameters, responseStatus,
 											response);
@@ -559,25 +529,78 @@ namespace OpenWifi::SDK::GW {
 				Poco::trimInPlace(access);
 				Poco::toLowerInPlace(access);
 				if (!Utils::NormalizeMac(mac) || (access != "allow" && access != "deny")) {
+					Poco::Logger::get("SDK_gw").error(fmt::format("Invalid MAC [{}] or access [{}] for entry {}.", mac, access, i));
 					return SetErrorResponse(Poco::Net::HTTPResponse::HTTP_BAD_REQUEST,
 											RESTAPI::Errors::MissingOrInvalidParameters, responseStatus,
 											response);
 				}
+				std::string formattedMac = Utils::SerialToMAC(mac);
+				Poco::toLowerInPlace(formattedMac);
+
+				Poco::Net::HTTPResponse::HTTPStatus callStatus = Poco::Net::HTTPResponse::HTTP_INTERNAL_SERVER_ERROR;
+				Poco::JSON::Object::Ptr callResponse;
 
 				if (access == "deny") {
-					if (std::find(blockedMacs.begin(), blockedMacs.end(), mac) == blockedMacs.end()) {
-						blockedMacs.push_back(mac);
+					Poco::DateTime now;
+					std::string startDate = Poco::DateTimeFormatter::format(now, "%Y-%m-%d");
+					std::string startTime = Poco::DateTimeFormatter::format(now, "%H:%M:%S");
+
+					Poco::DateTime nextDay = now + Poco::Timespan(86400, 0);
+					std::string stopDate = Poco::DateTimeFormatter::format(nextDay, "%Y-%m-%d");
+
+					std::string stopTime;
+					if (durationSec > 0) {
+						Poco::DateTime endDt = now + Poco::Timespan(durationSec, 0);
+						stopTime = Poco::DateTimeFormatter::format(endDt, "%H:%M:%S");
+					} else {
+						stopTime = "23:59:59";
 					}
+
+					Poco::JSON::Object reqBody;
+					reqBody.set("client_mac", formattedMac);
+					reqBody.set("start_date", startDate);
+					reqBody.set("stop_date", stopDate);
+					reqBody.set("start_time", startTime);
+					reqBody.set("stop_time", stopTime);
+
+					Poco::Logger::get("SDK_gw").information(fmt::format(
+						"Sending BLOCK request for client: [{}] subscriber: [{}] "
+						"(start_date={}, stop_date={}, start_time={}, stop_time={}) to parental-control",
+						formattedMac, SubscriberId, startDate, stopDate, startTime, stopTime));
+
+					if (!SDK::ParentalControl::CreateClientAccess(client, SubscriberId, reqBody, callStatus, callResponse)) {
+						Poco::Logger::get("SDK_gw").error(fmt::format("CreateClientAccess failed for client: [{}] subscriber: [{}], Status={}",
+							formattedMac, SubscriberId, static_cast<int>(callStatus)));
+						responseStatus = callStatus;
+						response = callResponse ? callResponse : Poco::makeShared<Poco::JSON::Object>();
+						return false;
+					}
+					lastCallResponse = callResponse;
 				} else {
-					blockedMacs.remove(mac);
+					std::string rawResponseBody;
+					Poco::Logger::get("SDK_gw").information(fmt::format("Sending UNBLOCK request for client: [{}] subscriber: [{}] to parental-control",
+									formattedMac, SubscriberId));
+
+					if (!SDK::ParentalControl::DeleteClientAccess(client, SubscriberId, formattedMac, callStatus, callResponse, rawResponseBody)) {
+						Poco::Logger::get("SDK_gw").error(fmt::format("DeleteClientAccess failed for client: [{}] subscriber: [{}], Status={}",
+							formattedMac, SubscriberId, static_cast<int>(callStatus)));
+						responseStatus = callStatus;
+						response = callResponse ? callResponse : Poco::makeShared<Poco::JSON::Object>();
+						return false;
+					}
+					lastCallResponse = callResponse;
 				}
 			}
 
-			if (Config->has("config-raw")) {
-				Config->remove("config-raw");
-			}
-			if (!blockedMacs.empty()) {
-				Config->set("config-raw", BuildBlockClientsRule(blockedMacs));
+			Poco::JSON::Array::Ptr configRaw;
+			if (lastCallResponse && RESTAPI::ParentalControl::ExtractConfigRawSnapshot(lastCallResponse, configRaw, false) && configRaw && configRaw->size() > 0) {
+				Poco::Logger::get("SDK_gw").information(fmt::format("Updated config-raw snapshot with {} rule(s) from parental-control", configRaw->size()));
+				Config->set("config-raw", configRaw);
+			} else {
+				Poco::Logger::get("SDK_gw").information("No active parental control rules remaining, clearing config-raw section");
+				if (Config->has("config-raw")) {
+					Config->remove("config-raw");
+				}
 			}
 			return true;
 		}
@@ -602,7 +625,7 @@ namespace OpenWifi::SDK::GW {
 
 		bool SetConfig(RESTAPIHandler *client, const Poco::JSON::Object::Ptr &Body,
 					   const ProvObjects::SubscriberDeviceList &SubscriberDevices,
-					   const std::string &GatewaySerial,
+					   const std::string &GatewaySerial, const std::string &SubscriberId,
 					   Poco::Net::HTTPResponse::HTTPStatus &ResponseStatus,
 					   Poco::JSON::Object::Ptr &Response) {
 			if (!Body) {
@@ -648,7 +671,7 @@ namespace OpenWifi::SDK::GW {
 			}
 
 			if (Body->has("client") &&
-				!ApplyClientAccessChanges(config, Body, ResponseStatus, Response)) {
+				!ApplyClientAccessChanges(client, config, Body, SubscriberId, ResponseStatus, Response)) {
 				return false;
 			}
 			const auto updatedConfigSnapshot = SerializeJson(config);

--- a/src/sdks/SDK_gw.cpp
+++ b/src/sdks/SDK_gw.cpp
@@ -558,21 +558,21 @@ namespace OpenWifi::SDK::GW {
 				if (access != "allow" && access != "deny") {
 					Poco::Logger::get("SDK_gw").error(fmt::format("Invalid access value [{}] for client MAC [{}].", access, mac));
 					return SetErrorResponse(Poco::Net::HTTPResponse::HTTP_BAD_REQUEST,
-											RESTAPI::Errors::ParentalControlInvalidAccess, responseStatus,
+											RESTAPI::Errors::InvalidAccess, responseStatus,
 											response);
 				}
 
 				if (access == "allow" && hasDuration) {
 					Poco::Logger::get("SDK_gw").error(fmt::format("Duration specified with access 'allow' for client MAC [{}].", mac));
 					return SetErrorResponse(Poco::Net::HTTPResponse::HTTP_BAD_REQUEST,
-											RESTAPI::Errors::ParentalControlDurationNotAllowedForAllow, responseStatus,
+											RESTAPI::Errors::DurationNotAllowedForAllow, responseStatus,
 											response);
 				}
 
 				if (hasDuration && (durationIsNull || durationMinutes < 1)) {
 					Poco::Logger::get("SDK_gw").error(fmt::format("Invalid duration minutes [{}] for client MAC [{}].", durationMinutes, mac));
 					return SetErrorResponse(Poco::Net::HTTPResponse::HTTP_BAD_REQUEST,
-											RESTAPI::Errors::ParentalControlInvalidDuration, responseStatus,
+											RESTAPI::Errors::InvalidDuration, responseStatus,
 											response);
 				}
 
@@ -582,7 +582,7 @@ namespace OpenWifi::SDK::GW {
 					if (endDt.year() != now.year() || endDt.month() != now.month() || endDt.day() != now.day()) {
 						Poco::Logger::get("SDK_gw").error(fmt::format("Duration [{}] minutes crosses midnight for client MAC [{}].", durationMinutes, mac));
 						return SetErrorResponse(Poco::Net::HTTPResponse::HTTP_BAD_REQUEST,
-												RESTAPI::Errors::ParentalControlDurationCrossesMidnight, responseStatus,
+												RESTAPI::Errors::DurationCrossesMidnight, responseStatus,
 												response);
 					}
 				}

--- a/src/sdks/SDK_gw.cpp
+++ b/src/sdks/SDK_gw.cpp
@@ -514,10 +514,12 @@ namespace OpenWifi::SDK::GW {
 				std::string mac;
 				std::string access;
 				int64_t durationSec = 0;
+				bool hasDuration = false;
 				try {
 					mac = entry->getValue<std::string>("mac");
 					access = entry->getValue<std::string>("access");
 					if (entry->has("duration") && !entry->isNull("duration")) {
+						hasDuration = true;
 						durationSec = entry->getValue<int64_t>("duration");
 					}
 				} catch (...) {
@@ -528,8 +530,8 @@ namespace OpenWifi::SDK::GW {
 				}
 				Poco::trimInPlace(access);
 				Poco::toLowerInPlace(access);
-				if (!Utils::NormalizeMac(mac) || (access != "allow" && access != "deny")) {
-					Poco::Logger::get("SDK_gw").error(fmt::format("Invalid MAC [{}] or access [{}] for entry {}.", mac, access, i));
+				if (!Utils::NormalizeMac(mac) || (access != "allow" && access != "deny") || (hasDuration && durationSec < 1)) {
+					Poco::Logger::get("SDK_gw").error(fmt::format("Invalid MAC [{}], access [{}], or duration [{}] for entry {}.", mac, access, durationSec, i));
 					return SetErrorResponse(Poco::Net::HTTPResponse::HTTP_BAD_REQUEST,
 											RESTAPI::Errors::MissingOrInvalidParameters, responseStatus,
 											response);

--- a/src/sdks/SDK_gw.h
+++ b/src/sdks/SDK_gw.h
@@ -42,6 +42,7 @@ namespace OpenWifi::SDK::GW {
 		bool SetConfig(RESTAPIHandler *client, const Poco::JSON::Object::Ptr &Body,
 					   const ProvObjects::SubscriberDeviceList &SubscriberDevices,
 					   const std::string &GatewaySerial,
+					   const std::string &SubscriberId,
 					   Poco::Net::HTTPResponse::HTTPStatus &ResponseStatus,
 					   Poco::JSON::Object::Ptr &Response);
 		bool GetLastStats(RESTAPIHandler *client, const std::string &Mac,

--- a/src/sdks/SDK_parental_control.cpp
+++ b/src/sdks/SDK_parental_control.cpp
@@ -259,4 +259,30 @@ namespace OpenWifi::SDK::ParentalControl {
 		return ExecutePutObject(client, endpoint, Body, 120000, CallStatus, CallResponse);
 	}
 
+	// =========================================================================
+	// Client Access
+	// =========================================================================
+
+	bool CreateClientAccess(RESTAPIHandler *client, const std::string &SubscriberId,
+							const Poco::JSON::Object &Body,
+							Poco::Net::HTTPResponse::HTTPStatus &CallStatus,
+							Poco::JSON::Object::Ptr &CallResponse) {
+		std::string endpoint = "/api/v1/subscribers/" + SubscriberId + "/client-access";
+		return ExecutePostObject(client, endpoint, Body, 120000, CallStatus, CallResponse);
+	}
+
+	bool DeleteClientAccess(RESTAPIHandler *client, const std::string &SubscriberId,
+							const std::string &ClientMac,
+							Poco::Net::HTTPResponse::HTTPStatus &CallStatus,
+							Poco::JSON::Object::Ptr &CallResponse, std::string &RawResponseBody) {
+		std::string endpoint = "/api/v1/subscribers/" + SubscriberId + "/client-access/" + ClientMac;
+		if (!ExecuteDelete(client, endpoint, 120000, CallStatus, CallResponse, RawResponseBody)) {
+			return false;
+		}
+		if (RawResponseBody.empty() || !CallResponse || !CallResponse->has("config-raw")) {
+			return false;
+		}
+		return true;
+	}
+
 } // namespace OpenWifi::SDK::ParentalControl

--- a/src/sdks/SDK_parental_control.h
+++ b/src/sdks/SDK_parental_control.h
@@ -129,4 +129,18 @@ namespace OpenWifi::SDK::ParentalControl {
 							   Poco::Net::HTTPResponse::HTTPStatus &CallStatus,
 							   Poco::JSON::Object::Ptr &CallResponse);
 
+	// =========================================================================
+	// Client Access
+	// =========================================================================
+
+	bool CreateClientAccess(RESTAPIHandler *client, const std::string &SubscriberId,
+							const Poco::JSON::Object &Body,
+							Poco::Net::HTTPResponse::HTTPStatus &CallStatus,
+							Poco::JSON::Object::Ptr &CallResponse);
+
+	bool DeleteClientAccess(RESTAPIHandler *client, const std::string &SubscriberId,
+							const std::string &ClientMac,
+							Poco::Net::HTTPResponse::HTTPStatus &CallStatus,
+							Poco::JSON::Object::Ptr &CallResponse, std::string &RawResponseBody);
+
 } // namespace OpenWifi::SDK::ParentalControl

--- a/tests/unit/test_parental_control_utils.cpp
+++ b/tests/unit/test_parental_control_utils.cpp
@@ -1456,7 +1456,211 @@ void TestGetBlockedClientsClientAccessOvernightExpiredWindowInactive() {
     Expect(blockedMacs.empty(), "Expired overnight client-access window should not block client");
 }
 
+void TestGetBlockedClientsIncompleteRuleMissingEnabled() {
+    auto config = Poco::JSON::Object::Ptr(new Poco::JSON::Object());
+    auto configRaw = Poco::JSON::Array::Ptr(new Poco::JSON::Array());
+    configRaw->add(MakeStringArray({"set", "firewall.pc_client_access_5A_F8_57_CA_A5_3E", "rule"}));
+    configRaw->add(MakeStringArray({"set", "firewall.pc_client_access_5A_F8_57_CA_A5_3E.start_date", "2026-07-21"}));
+    configRaw->add(MakeStringArray({"set", "firewall.pc_client_access_5A_F8_57_CA_A5_3E.stop_date", "2026-07-22"}));
+    configRaw->add(MakeStringArray({"set", "firewall.pc_client_access_5A_F8_57_CA_A5_3E.start_time", "08:00:00"}));
+    configRaw->add(MakeStringArray({"set", "firewall.pc_client_access_5A_F8_57_CA_A5_3E.stop_time", "18:00:00"}));
+    configRaw->add(MakeStringArray({"add_list", "firewall.pc_client_access_5A_F8_57_CA_A5_3E.src_mac", "5a:f8:57:ca:a5:3e"}));
+    config->set("config-raw", configRaw);
+
+    std::list<std::string> blockedMacs;
+    Expect(OpenWifi::RESTAPI::ParentalControl::GetBlockedClients(config, blockedMacs), "GetBlockedClients should return true");
+    Expect(blockedMacs.empty(), "Rule missing enabled should be ignored");
+}
+
+void TestGetBlockedClientsIncompleteRuleMissingSectionDeclaration() {
+    auto config = Poco::JSON::Object::Ptr(new Poco::JSON::Object());
+    auto configRaw = Poco::JSON::Array::Ptr(new Poco::JSON::Array());
+    configRaw->add(MakeStringArray({"set", "firewall.pc_client_access_5A_F8_57_CA_A5_3E.enabled", "1"}));
+    configRaw->add(MakeStringArray({"set", "firewall.pc_client_access_5A_F8_57_CA_A5_3E.start_date", "2026-07-21"}));
+    configRaw->add(MakeStringArray({"set", "firewall.pc_client_access_5A_F8_57_CA_A5_3E.stop_date", "2026-07-22"}));
+    configRaw->add(MakeStringArray({"set", "firewall.pc_client_access_5A_F8_57_CA_A5_3E.start_time", "08:00:00"}));
+    configRaw->add(MakeStringArray({"set", "firewall.pc_client_access_5A_F8_57_CA_A5_3E.stop_time", "18:00:00"}));
+    configRaw->add(MakeStringArray({"add_list", "firewall.pc_client_access_5A_F8_57_CA_A5_3E.src_mac", "5a:f8:57:ca:a5:3e"}));
+    config->set("config-raw", configRaw);
+
+    std::list<std::string> blockedMacs;
+    Expect(OpenWifi::RESTAPI::ParentalControl::GetBlockedClients(config, blockedMacs), "GetBlockedClients should return true");
+    Expect(blockedMacs.empty(), "Rule missing section declaration should be ignored");
+}
+
+void TestGetBlockedClientsIncompleteRuleMissingDates() {
+    auto config = Poco::JSON::Object::Ptr(new Poco::JSON::Object());
+    auto configRaw = Poco::JSON::Array::Ptr(new Poco::JSON::Array());
+    configRaw->add(MakeStringArray({"set", "firewall.pc_client_access_5A_F8_57_CA_A5_3E", "rule"}));
+    configRaw->add(MakeStringArray({"set", "firewall.pc_client_access_5A_F8_57_CA_A5_3E.enabled", "1"}));
+    configRaw->add(MakeStringArray({"set", "firewall.pc_client_access_5A_F8_57_CA_A5_3E.start_time", "08:00:00"}));
+    configRaw->add(MakeStringArray({"set", "firewall.pc_client_access_5A_F8_57_CA_A5_3E.stop_time", "18:00:00"}));
+    configRaw->add(MakeStringArray({"add_list", "firewall.pc_client_access_5A_F8_57_CA_A5_3E.src_mac", "5a:f8:57:ca:a5:3e"}));
+    config->set("config-raw", configRaw);
+
+    std::list<std::string> blockedMacs;
+    Expect(OpenWifi::RESTAPI::ParentalControl::GetBlockedClients(config, blockedMacs), "GetBlockedClients should return true");
+    Expect(blockedMacs.empty(), "Rule missing start/stop date should be ignored");
+}
+
+void TestGetBlockedClientsIncompleteRuleMissingStopTime() {
+    auto config = Poco::JSON::Object::Ptr(new Poco::JSON::Object());
+    auto configRaw = Poco::JSON::Array::Ptr(new Poco::JSON::Array());
+    configRaw->add(MakeStringArray({"set", "firewall.pc_client_access_5A_F8_57_CA_A5_3E", "rule"}));
+    configRaw->add(MakeStringArray({"set", "firewall.pc_client_access_5A_F8_57_CA_A5_3E.enabled", "1"}));
+    configRaw->add(MakeStringArray({"set", "firewall.pc_client_access_5A_F8_57_CA_A5_3E.start_date", "2026-07-21"}));
+    configRaw->add(MakeStringArray({"set", "firewall.pc_client_access_5A_F8_57_CA_A5_3E.stop_date", "2026-07-22"}));
+    configRaw->add(MakeStringArray({"set", "firewall.pc_client_access_5A_F8_57_CA_A5_3E.start_time", "08:00:00"}));
+    configRaw->add(MakeStringArray({"add_list", "firewall.pc_client_access_5A_F8_57_CA_A5_3E.src_mac", "5a:f8:57:ca:a5:3e"}));
+    config->set("config-raw", configRaw);
+
+    std::list<std::string> blockedMacs;
+    Expect(OpenWifi::RESTAPI::ParentalControl::GetBlockedClients(config, blockedMacs), "GetBlockedClients should return true");
+    Expect(blockedMacs.empty(), "Rule missing stop time should be ignored");
+}
+
+void TestGetBlockedClientsMalformedDatesOrTimes() {
+    // 1. Invalid date (Feb 31)
+    {
+        auto config = Poco::JSON::Object::Ptr(new Poco::JSON::Object());
+        auto configRaw = Poco::JSON::Array::Ptr(new Poco::JSON::Array());
+        configRaw->add(MakeStringArray({"set", "firewall.pc_client_access_5A_F8_57_CA_A5_3E", "rule"}));
+        configRaw->add(MakeStringArray({"set", "firewall.pc_client_access_5A_F8_57_CA_A5_3E.enabled", "1"}));
+        configRaw->add(MakeStringArray({"set", "firewall.pc_client_access_5A_F8_57_CA_A5_3E.start_date", "2026-02-31"}));
+        configRaw->add(MakeStringArray({"set", "firewall.pc_client_access_5A_F8_57_CA_A5_3E.stop_date", "2026-07-22"}));
+        configRaw->add(MakeStringArray({"set", "firewall.pc_client_access_5A_F8_57_CA_A5_3E.start_time", "08:00:00"}));
+        configRaw->add(MakeStringArray({"set", "firewall.pc_client_access_5A_F8_57_CA_A5_3E.stop_time", "18:00:00"}));
+        configRaw->add(MakeStringArray({"add_list", "firewall.pc_client_access_5A_F8_57_CA_A5_3E.src_mac", "5a:f8:57:ca:a5:3e"}));
+        config->set("config-raw", configRaw);
+        std::list<std::string> blockedMacs;
+        Expect(OpenWifi::RESTAPI::ParentalControl::GetBlockedClients(config, blockedMacs), "GetBlockedClients should return true");
+        Expect(blockedMacs.empty(), "Rule with 2026-02-31 should be ignored");
+    }
+
+    // 2. Invalid date (April 31)
+    {
+        auto config = Poco::JSON::Object::Ptr(new Poco::JSON::Object());
+        auto configRaw = Poco::JSON::Array::Ptr(new Poco::JSON::Array());
+        configRaw->add(MakeStringArray({"set", "firewall.pc_client_access_5A_F8_57_CA_A5_3E", "rule"}));
+        configRaw->add(MakeStringArray({"set", "firewall.pc_client_access_5A_F8_57_CA_A5_3E.enabled", "1"}));
+        configRaw->add(MakeStringArray({"set", "firewall.pc_client_access_5A_F8_57_CA_A5_3E.start_date", "2026-04-31"}));
+        configRaw->add(MakeStringArray({"set", "firewall.pc_client_access_5A_F8_57_CA_A5_3E.stop_date", "2026-07-22"}));
+        configRaw->add(MakeStringArray({"set", "firewall.pc_client_access_5A_F8_57_CA_A5_3E.start_time", "08:00:00"}));
+        configRaw->add(MakeStringArray({"set", "firewall.pc_client_access_5A_F8_57_CA_A5_3E.stop_time", "18:00:00"}));
+        configRaw->add(MakeStringArray({"add_list", "firewall.pc_client_access_5A_F8_57_CA_A5_3E.src_mac", "5a:f8:57:ca:a5:3e"}));
+        config->set("config-raw", configRaw);
+        std::list<std::string> blockedMacs;
+        Expect(OpenWifi::RESTAPI::ParentalControl::GetBlockedClients(config, blockedMacs), "GetBlockedClients should return true");
+        Expect(blockedMacs.empty(), "Rule with 2026-04-31 should be ignored");
+    }
+
+    // 3. Invalid hour (25:00:00)
+    {
+        auto config = Poco::JSON::Object::Ptr(new Poco::JSON::Object());
+        auto configRaw = Poco::JSON::Array::Ptr(new Poco::JSON::Array());
+        configRaw->add(MakeStringArray({"set", "firewall.pc_client_access_5A_F8_57_CA_A5_3E", "rule"}));
+        configRaw->add(MakeStringArray({"set", "firewall.pc_client_access_5A_F8_57_CA_A5_3E.enabled", "1"}));
+        configRaw->add(MakeStringArray({"set", "firewall.pc_client_access_5A_F8_57_CA_A5_3E.start_date", "2026-07-21"}));
+        configRaw->add(MakeStringArray({"set", "firewall.pc_client_access_5A_F8_57_CA_A5_3E.stop_date", "2026-07-22"}));
+        configRaw->add(MakeStringArray({"set", "firewall.pc_client_access_5A_F8_57_CA_A5_3E.start_time", "25:00:00"}));
+        configRaw->add(MakeStringArray({"set", "firewall.pc_client_access_5A_F8_57_CA_A5_3E.stop_time", "18:00:00"}));
+        configRaw->add(MakeStringArray({"add_list", "firewall.pc_client_access_5A_F8_57_CA_A5_3E.src_mac", "5a:f8:57:ca:a5:3e"}));
+        config->set("config-raw", configRaw);
+        std::list<std::string> blockedMacs;
+        Expect(OpenWifi::RESTAPI::ParentalControl::GetBlockedClients(config, blockedMacs), "GetBlockedClients should return true");
+        Expect(blockedMacs.empty(), "Rule with 25:00:00 should be ignored");
+    }
+
+    // 4. Invalid time format (12:00)
+    {
+        auto config = Poco::JSON::Object::Ptr(new Poco::JSON::Object());
+        auto configRaw = Poco::JSON::Array::Ptr(new Poco::JSON::Array());
+        configRaw->add(MakeStringArray({"set", "firewall.pc_client_access_5A_F8_57_CA_A5_3E", "rule"}));
+        configRaw->add(MakeStringArray({"set", "firewall.pc_client_access_5A_F8_57_CA_A5_3E.enabled", "1"}));
+        configRaw->add(MakeStringArray({"set", "firewall.pc_client_access_5A_F8_57_CA_A5_3E.start_date", "2026-07-21"}));
+        configRaw->add(MakeStringArray({"set", "firewall.pc_client_access_5A_F8_57_CA_A5_3E.stop_date", "2026-07-22"}));
+        configRaw->add(MakeStringArray({"set", "firewall.pc_client_access_5A_F8_57_CA_A5_3E.start_time", "12:00"}));
+        configRaw->add(MakeStringArray({"set", "firewall.pc_client_access_5A_F8_57_CA_A5_3E.stop_time", "18:00:00"}));
+        configRaw->add(MakeStringArray({"add_list", "firewall.pc_client_access_5A_F8_57_CA_A5_3E.src_mac", "5a:f8:57:ca:a5:3e"}));
+        config->set("config-raw", configRaw);
+        std::list<std::string> blockedMacs;
+        Expect(OpenWifi::RESTAPI::ParentalControl::GetBlockedClients(config, blockedMacs), "GetBlockedClients should return true");
+        Expect(blockedMacs.empty(), "Rule with 12:00 should be ignored");
+    }
+}
+
+void TestGetBlockedClientsIncorrectOperationTypes() {
+    auto config = Poco::JSON::Object::Ptr(new Poco::JSON::Object());
+    auto configRaw = Poco::JSON::Array::Ptr(new Poco::JSON::Array());
+    configRaw->add(MakeStringArray({"add_list", "firewall.pc_client_access_5A_F8_57_CA_A5_3E", "rule"}));
+    configRaw->add(MakeStringArray({"set", "firewall.pc_client_access_5A_F8_57_CA_A5_3E.enabled", "1"}));
+    configRaw->add(MakeStringArray({"set", "firewall.pc_client_access_5A_F8_57_CA_A5_3E.start_date", "2026-07-21"}));
+    configRaw->add(MakeStringArray({"set", "firewall.pc_client_access_5A_F8_57_CA_A5_3E.stop_date", "2026-07-22"}));
+    configRaw->add(MakeStringArray({"set", "firewall.pc_client_access_5A_F8_57_CA_A5_3E.start_time", "08:00:00"}));
+    configRaw->add(MakeStringArray({"set", "firewall.pc_client_access_5A_F8_57_CA_A5_3E.stop_time", "18:00:00"}));
+    configRaw->add(MakeStringArray({"add_list", "firewall.pc_client_access_5A_F8_57_CA_A5_3E.src_mac", "5a:f8:57:ca:a5:3e"}));
+    config->set("config-raw", configRaw);
+
+    std::list<std::string> blockedMacs;
+    Expect(OpenWifi::RESTAPI::ParentalControl::GetBlockedClients(config, blockedMacs), "GetBlockedClients should return true");
+    Expect(blockedMacs.empty(), "Rule with incorrect section op should be ignored");
+
+    auto config2 = Poco::JSON::Object::Ptr(new Poco::JSON::Object());
+    auto configRaw2 = Poco::JSON::Array::Ptr(new Poco::JSON::Array());
+    configRaw2->add(MakeStringArray({"set", "firewall.pc_client_access_5A_F8_57_CA_A5_3E", "rule"}));
+    configRaw2->add(MakeStringArray({"add_list", "firewall.pc_client_access_5A_F8_57_CA_A5_3E.enabled", "1"}));
+    configRaw2->add(MakeStringArray({"set", "firewall.pc_client_access_5A_F8_57_CA_A5_3E.start_date", "2026-07-21"}));
+    configRaw2->add(MakeStringArray({"set", "firewall.pc_client_access_5A_F8_57_CA_A5_3E.stop_date", "2026-07-22"}));
+    configRaw2->add(MakeStringArray({"set", "firewall.pc_client_access_5A_F8_57_CA_A5_3E.start_time", "08:00:00"}));
+    configRaw2->add(MakeStringArray({"set", "firewall.pc_client_access_5A_F8_57_CA_A5_3E.stop_time", "18:00:00"}));
+    configRaw2->add(MakeStringArray({"add_list", "firewall.pc_client_access_5A_F8_57_CA_A5_3E.src_mac", "5a:f8:57:ca:a5:3e"}));
+    config2->set("config-raw", configRaw2);
+
+    blockedMacs.clear();
+    Expect(OpenWifi::RESTAPI::ParentalControl::GetBlockedClients(config2, blockedMacs), "GetBlockedClients should return true");
+    Expect(blockedMacs.empty(), "Rule with incorrect scalar field op should be ignored");
+
+    auto config3 = Poco::JSON::Object::Ptr(new Poco::JSON::Object());
+    auto configRaw3 = Poco::JSON::Array::Ptr(new Poco::JSON::Array());
+    configRaw3->add(MakeStringArray({"set", "firewall.pc_client_access_5A_F8_57_CA_A5_3E", "rule"}));
+    configRaw3->add(MakeStringArray({"set", "firewall.pc_client_access_5A_F8_57_CA_A5_3E.enabled", "1"}));
+    configRaw3->add(MakeStringArray({"set", "firewall.pc_client_access_5A_F8_57_CA_A5_3E.start_date", "2026-07-21"}));
+    configRaw3->add(MakeStringArray({"set", "firewall.pc_client_access_5A_F8_57_CA_A5_3E.stop_date", "2026-07-22"}));
+    configRaw3->add(MakeStringArray({"set", "firewall.pc_client_access_5A_F8_57_CA_A5_3E.start_time", "08:00:00"}));
+    configRaw3->add(MakeStringArray({"set", "firewall.pc_client_access_5A_F8_57_CA_A5_3E.stop_time", "18:00:00"}));
+    configRaw3->add(MakeStringArray({"set", "firewall.pc_client_access_5A_F8_57_CA_A5_3E.src_mac", "5a:f8:57:ca:a5:3e"}));
+    config3->set("config-raw", configRaw3);
+
+    blockedMacs.clear();
+    Expect(OpenWifi::RESTAPI::ParentalControl::GetBlockedClients(config3, blockedMacs), "GetBlockedClients should return true");
+    Expect(blockedMacs.empty(), "Rule with incorrect MAC list op should be ignored");
+}
+
+void TestGetBlockedClientsIncompleteRuleMissingMacs() {
+    auto config = Poco::JSON::Object::Ptr(new Poco::JSON::Object());
+    auto configRaw = Poco::JSON::Array::Ptr(new Poco::JSON::Array());
+    configRaw->add(MakeStringArray({"set", "firewall.pc_client_access_5A_F8_57_CA_A5_3E", "rule"}));
+    configRaw->add(MakeStringArray({"set", "firewall.pc_client_access_5A_F8_57_CA_A5_3E.enabled", "1"}));
+    configRaw->add(MakeStringArray({"set", "firewall.pc_client_access_5A_F8_57_CA_A5_3E.start_date", "2026-07-21"}));
+    configRaw->add(MakeStringArray({"set", "firewall.pc_client_access_5A_F8_57_CA_A5_3E.stop_date", "2026-07-22"}));
+    configRaw->add(MakeStringArray({"set", "firewall.pc_client_access_5A_F8_57_CA_A5_3E.start_time", "08:00:00"}));
+    configRaw->add(MakeStringArray({"set", "firewall.pc_client_access_5A_F8_57_CA_A5_3E.stop_time", "18:00:00"}));
+    configRaw->add(MakeStringArray({"add_list", "firewall.pc_client_access_5A_F8_57_CA_A5_3E.src_mac", "invalid_mac"}));
+    config->set("config-raw", configRaw);
+
+    std::list<std::string> blockedMacs;
+    Expect(OpenWifi::RESTAPI::ParentalControl::GetBlockedClients(config, blockedMacs), "GetBlockedClients should return true");
+    Expect(blockedMacs.empty(), "Rule without valid MACs should be ignored");
+}
+
 const std::vector<std::pair<std::string, std::function<void()>>> kTests = {
+    {"GetBlockedClientsIncompleteRuleMissingEnabled", TestGetBlockedClientsIncompleteRuleMissingEnabled},
+    {"GetBlockedClientsIncompleteRuleMissingSectionDeclaration", TestGetBlockedClientsIncompleteRuleMissingSectionDeclaration},
+    {"GetBlockedClientsIncompleteRuleMissingDates", TestGetBlockedClientsIncompleteRuleMissingDates},
+    {"GetBlockedClientsIncompleteRuleMissingStopTime", TestGetBlockedClientsIncompleteRuleMissingStopTime},
+    {"GetBlockedClientsMalformedDatesOrTimes", TestGetBlockedClientsMalformedDatesOrTimes},
+    {"GetBlockedClientsIncorrectOperationTypes", TestGetBlockedClientsIncorrectOperationTypes},
+    {"GetBlockedClientsIncompleteRuleMissingMacs", TestGetBlockedClientsIncompleteRuleMissingMacs},
     {"ValidateMacInTopologySuccessHistoricalClient", TestValidateMacInTopologySuccessHistoricalClient},
     {"ValidateMacInTopologySuccessHistoricalDevice", TestValidateMacInTopologySuccessHistoricalDevice},
     {"ValidateMacInTopologySuccessNodesClient", TestValidateMacInTopologySuccessNodesClient},

--- a/tests/unit/test_parental_control_utils.cpp
+++ b/tests/unit/test_parental_control_utils.cpp
@@ -17,6 +17,8 @@
 #include "Poco/JSON/Object.h"
 #include "Poco/JSON/Parser.h"
 #include "Poco/Logger.h"
+#include "Poco/Timespan.h"
+#include "Poco/Timestamp.h"
 #include "Poco/Net/HTTPServerParams.h"
 #include "Poco/Net/SocketAddress.h"
 #include "RESTAPI/RESTAPI_parental_control_utils.h"
@@ -92,6 +94,16 @@ std::string MacWithColons(const std::string &value) {
         os << value.substr(i, 2);
     }
     return os.str();
+}
+
+std::string FormatDate(const Poco::DateTime &value) {
+    return Poco::DateTimeFormatter::format(value, "%Y-%m-%d");
+}
+
+Poco::DateTime ShiftDateTime(const Poco::DateTime &value, int days, int hours = 0, int minutes = 0, int seconds = 0) {
+    Poco::Timestamp ts = value.timestamp();
+    ts += Poco::Timespan(days, hours, minutes, seconds, 0);
+    return Poco::DateTime(ts);
 }
 
 class FakeHTTPServerParams final : public Poco::Net::HTTPServerParams {
@@ -1265,14 +1277,15 @@ void TestHandleValidateMacResult() {
 
 void TestGetBlockedClientsClientAccessExpiredRuleSameDay() {
     Poco::DateTime now;
-    std::string todayDate = Poco::DateTimeFormatter::format(now, "%Y-%m-%d");
+    std::string todayDate = FormatDate(now);
+    std::string tomorrowDate = FormatDate(ShiftDateTime(now, 1));
 
     auto config = Poco::JSON::Object::Ptr(new Poco::JSON::Object());
     auto configRaw = Poco::JSON::Array::Ptr(new Poco::JSON::Array());
     configRaw->add(MakeStringArray({"set", "firewall.pc_client_access_6C_C7_EC_DE_10_65", "rule"}));
     configRaw->add(MakeStringArray({"set", "firewall.pc_client_access_6C_C7_EC_DE_10_65.enabled", "1"}));
     configRaw->add(MakeStringArray({"set", "firewall.pc_client_access_6C_C7_EC_DE_10_65.start_date", todayDate}));
-    configRaw->add(MakeStringArray({"set", "firewall.pc_client_access_6C_C7_EC_DE_10_65.stop_date", "2099-12-31"}));
+    configRaw->add(MakeStringArray({"set", "firewall.pc_client_access_6C_C7_EC_DE_10_65.stop_date", tomorrowDate}));
     configRaw->add(MakeStringArray({"set", "firewall.pc_client_access_6C_C7_EC_DE_10_65.start_time", "00:00:00"}));
     configRaw->add(MakeStringArray({"set", "firewall.pc_client_access_6C_C7_EC_DE_10_65.stop_time", "00:00:01"}));
     configRaw->add(MakeStringArray({"add_list", "firewall.pc_client_access_6C_C7_EC_DE_10_65.src_mac", "6c:c7:ec:de:10:65"}));
@@ -1285,14 +1298,15 @@ void TestGetBlockedClientsClientAccessExpiredRuleSameDay() {
 
 void TestGetBlockedClientsClientAccessActiveRule() {
     Poco::DateTime now;
-    std::string todayDate = Poco::DateTimeFormatter::format(now, "%Y-%m-%d");
+    std::string todayDate = FormatDate(now);
+    std::string tomorrowDate = FormatDate(ShiftDateTime(now, 1));
 
     auto config = Poco::JSON::Object::Ptr(new Poco::JSON::Object());
     auto configRaw = Poco::JSON::Array::Ptr(new Poco::JSON::Array());
     configRaw->add(MakeStringArray({"set", "firewall.pc_client_access_10_F1_F2_86_11_DC", "rule"}));
     configRaw->add(MakeStringArray({"set", "firewall.pc_client_access_10_F1_F2_86_11_DC.enabled", "1"}));
     configRaw->add(MakeStringArray({"set", "firewall.pc_client_access_10_F1_F2_86_11_DC.start_date", todayDate}));
-    configRaw->add(MakeStringArray({"set", "firewall.pc_client_access_10_F1_F2_86_11_DC.stop_date", "2099-12-31"}));
+    configRaw->add(MakeStringArray({"set", "firewall.pc_client_access_10_F1_F2_86_11_DC.stop_date", tomorrowDate}));
     configRaw->add(MakeStringArray({"set", "firewall.pc_client_access_10_F1_F2_86_11_DC.start_time", "00:00:00"}));
     configRaw->add(MakeStringArray({"set", "firewall.pc_client_access_10_F1_F2_86_11_DC.stop_time", "23:59:59"}));
     configRaw->add(MakeStringArray({"add_list", "firewall.pc_client_access_10_F1_F2_86_11_DC.src_mac", "10:f1:f2:86:11:dc"}));
@@ -1303,7 +1317,7 @@ void TestGetBlockedClientsClientAccessActiveRule() {
     ExpectEq(blockedMacs.size(), static_cast<std::size_t>(1), "Active rule should produce 1 blocked MAC");
 }
 
-void TestGetBlockedClientsGroupScheduleRuleWeekdayMatch() {
+void TestGetBlockedClientsGroupScheduleRuleIgnored() {
     Poco::DateTime now;
     static const std::vector<std::string> names = {"Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"};
     std::string todayWeekday = names[now.dayOfWeek()];
@@ -1320,48 +1334,26 @@ void TestGetBlockedClientsGroupScheduleRuleWeekdayMatch() {
 
     std::list<std::string> blockedMacs;
     Expect(OpenWifi::RESTAPI::ParentalControl::GetBlockedClients(config, blockedMacs), "GetBlockedClients should return true");
-    ExpectEq(blockedMacs.size(), static_cast<std::size_t>(1), "Group schedule active today should block client");
+    Expect(blockedMacs.empty(), "Topology blocked clients should ignore active group schedule rules");
 }
 
-void TestGetBlockedClientsGroupScheduleRuleWeekdayMismatch() {
+void TestGetBlockedClientsMixedRulesOnlyClientAccessBlocks() {
     Poco::DateTime now;
-    static const std::vector<std::string> names = {"Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"};
-    std::string notTodayWeekday = names[(now.dayOfWeek() + 1) % 7];
-
-    auto config = Poco::JSON::Object::Ptr(new Poco::JSON::Object());
-    auto configRaw = Poco::JSON::Array::Ptr(new Poco::JSON::Array());
-    configRaw->add(MakeStringArray({"set", "firewall.pc_rule_g1_s1_5a_f8_57_ca_a5_3e", "rule"}));
-    configRaw->add(MakeStringArray({"set", "firewall.pc_rule_g1_s1_5a_f8_57_ca_a5_3e.enabled", "1"}));
-    configRaw->add(MakeStringArray({"set", "firewall.pc_rule_g1_s1_5a_f8_57_ca_a5_3e.weekdays", notTodayWeekday}));
-    configRaw->add(MakeStringArray({"set", "firewall.pc_rule_g1_s1_5a_f8_57_ca_a5_3e.start_time", "00:00:00"}));
-    configRaw->add(MakeStringArray({"set", "firewall.pc_rule_g1_s1_5a_f8_57_ca_a5_3e.stop_time", "23:59:59"}));
-    configRaw->add(MakeStringArray({"add_list", "firewall.pc_rule_g1_s1_5a_f8_57_ca_a5_3e.src_mac", "5a:f8:57:ca:a5:3e"}));
-    config->set("config-raw", configRaw);
-
-    std::list<std::string> blockedMacs;
-    Expect(OpenWifi::RESTAPI::ParentalControl::GetBlockedClients(config, blockedMacs), "GetBlockedClients should return true");
-    Expect(blockedMacs.empty(), "Group schedule for another weekday should not block client today");
-}
-
-void TestGetBlockedClientsOverlappingActiveRules() {
-    Poco::DateTime now;
-    std::string todayDate = Poco::DateTimeFormatter::format(now, "%Y-%m-%d");
+    std::string todayDate = FormatDate(now);
+    std::string tomorrowDate = FormatDate(ShiftDateTime(now, 1));
     static const std::vector<std::string> names = {"Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"};
     std::string todayWeekday = names[now.dayOfWeek()];
 
     auto config = Poco::JSON::Object::Ptr(new Poco::JSON::Object());
     auto configRaw = Poco::JSON::Array::Ptr(new Poco::JSON::Array());
-
-    // Active client-access rule for MAC 1
     configRaw->add(MakeStringArray({"set", "firewall.pc_client_access_10_F1_F2_86_11_DC", "rule"}));
     configRaw->add(MakeStringArray({"set", "firewall.pc_client_access_10_F1_F2_86_11_DC.enabled", "1"}));
     configRaw->add(MakeStringArray({"set", "firewall.pc_client_access_10_F1_F2_86_11_DC.start_date", todayDate}));
-    configRaw->add(MakeStringArray({"set", "firewall.pc_client_access_10_F1_F2_86_11_DC.stop_date", "2099-12-31"}));
+    configRaw->add(MakeStringArray({"set", "firewall.pc_client_access_10_F1_F2_86_11_DC.stop_date", tomorrowDate}));
     configRaw->add(MakeStringArray({"set", "firewall.pc_client_access_10_F1_F2_86_11_DC.start_time", "00:00:00"}));
     configRaw->add(MakeStringArray({"set", "firewall.pc_client_access_10_F1_F2_86_11_DC.stop_time", "23:59:59"}));
     configRaw->add(MakeStringArray({"add_list", "firewall.pc_client_access_10_F1_F2_86_11_DC.src_mac", "10:f1:f2:86:11:dc"}));
 
-    // Active group-schedule rule for MAC 2
     configRaw->add(MakeStringArray({"set", "firewall.pc_rule_g1_s1_5a_f8_57_ca_a5_3e", "rule"}));
     configRaw->add(MakeStringArray({"set", "firewall.pc_rule_g1_s1_5a_f8_57_ca_a5_3e.enabled", "1"}));
     configRaw->add(MakeStringArray({"set", "firewall.pc_rule_g1_s1_5a_f8_57_ca_a5_3e.weekdays", todayWeekday}));
@@ -1373,19 +1365,20 @@ void TestGetBlockedClientsOverlappingActiveRules() {
 
     std::list<std::string> blockedMacs;
     Expect(OpenWifi::RESTAPI::ParentalControl::GetBlockedClients(config, blockedMacs), "GetBlockedClients should return true");
-    ExpectEq(blockedMacs.size(), static_cast<std::size_t>(2), "Overlapping rules for MAC 1 & MAC 2 should produce 2 blocked MACs");
+    ExpectEq(blockedMacs.size(), static_cast<std::size_t>(1), "Only active client-access rules should affect topology blocked clients");
 }
 
 void TestGetBlockedClientsDisabledRulesIgnored() {
     Poco::DateTime now;
-    std::string todayDate = Poco::DateTimeFormatter::format(now, "%Y-%m-%d");
+    std::string todayDate = FormatDate(now);
+    std::string tomorrowDate = FormatDate(ShiftDateTime(now, 1));
 
     auto config = Poco::JSON::Object::Ptr(new Poco::JSON::Object());
     auto configRaw = Poco::JSON::Array::Ptr(new Poco::JSON::Array());
     configRaw->add(MakeStringArray({"set", "firewall.pc_client_access_10_F1_F2_86_11_DC", "rule"}));
     configRaw->add(MakeStringArray({"set", "firewall.pc_client_access_10_F1_F2_86_11_DC.enabled", "0"}));
     configRaw->add(MakeStringArray({"set", "firewall.pc_client_access_10_F1_F2_86_11_DC.start_date", todayDate}));
-    configRaw->add(MakeStringArray({"set", "firewall.pc_client_access_10_F1_F2_86_11_DC.stop_date", "2099-12-31"}));
+    configRaw->add(MakeStringArray({"set", "firewall.pc_client_access_10_F1_F2_86_11_DC.stop_date", tomorrowDate}));
     configRaw->add(MakeStringArray({"set", "firewall.pc_client_access_10_F1_F2_86_11_DC.start_time", "00:00:00"}));
     configRaw->add(MakeStringArray({"set", "firewall.pc_client_access_10_F1_F2_86_11_DC.stop_time", "23:59:59"}));
     configRaw->add(MakeStringArray({"add_list", "firewall.pc_client_access_10_F1_F2_86_11_DC.src_mac", "10:f1:f2:86:11:dc"}));
@@ -1394,6 +1387,73 @@ void TestGetBlockedClientsDisabledRulesIgnored() {
     std::list<std::string> blockedMacs;
     Expect(OpenWifi::RESTAPI::ParentalControl::GetBlockedClients(config, blockedMacs), "GetBlockedClients should return true");
     Expect(blockedMacs.empty(), "Disabled rule (enabled=0) should be ignored");
+}
+
+// =========================================================================
+// Client-access time window tests
+// =========================================================================
+
+void TestGetBlockedClientsClientAccessOvernightWindowActive() {
+    Poco::DateTime now;
+    std::string yesterdayDate = FormatDate(ShiftDateTime(now, -1));
+    std::string tomorrowDate = FormatDate(ShiftDateTime(now, 1));
+
+    auto config = Poco::JSON::Object::Ptr(new Poco::JSON::Object());
+    auto configRaw = Poco::JSON::Array::Ptr(new Poco::JSON::Array());
+    configRaw->add(MakeStringArray({"set", "firewall.pc_client_access_5A_F8_57_CA_A5_3E", "rule"}));
+    configRaw->add(MakeStringArray({"set", "firewall.pc_client_access_5A_F8_57_CA_A5_3E.enabled", "1"}));
+    configRaw->add(MakeStringArray({"set", "firewall.pc_client_access_5A_F8_57_CA_A5_3E.start_date", yesterdayDate}));
+    configRaw->add(MakeStringArray({"set", "firewall.pc_client_access_5A_F8_57_CA_A5_3E.stop_date", tomorrowDate}));
+    configRaw->add(MakeStringArray({"set", "firewall.pc_client_access_5A_F8_57_CA_A5_3E.start_time", "23:59:59"}));
+    configRaw->add(MakeStringArray({"set", "firewall.pc_client_access_5A_F8_57_CA_A5_3E.stop_time", "00:00:00"}));
+    configRaw->add(MakeStringArray({"add_list", "firewall.pc_client_access_5A_F8_57_CA_A5_3E.src_mac", "5a:f8:57:ca:a5:3e"}));
+    config->set("config-raw", configRaw);
+
+    std::list<std::string> blockedMacs;
+    Expect(OpenWifi::RESTAPI::ParentalControl::GetBlockedClients(config, blockedMacs), "GetBlockedClients should return true");
+    ExpectEq(blockedMacs.size(), static_cast<std::size_t>(1), "Active overnight client-access window should block client");
+}
+
+void TestGetBlockedClientsClientAccessOvernightFutureWindowInactive() {
+    Poco::DateTime now;
+    std::string tomorrowDate = FormatDate(ShiftDateTime(now, 1));
+    std::string dayAfterTomorrowDate = FormatDate(ShiftDateTime(now, 2));
+
+    auto config = Poco::JSON::Object::Ptr(new Poco::JSON::Object());
+    auto configRaw = Poco::JSON::Array::Ptr(new Poco::JSON::Array());
+    configRaw->add(MakeStringArray({"set", "firewall.pc_client_access_5A_F8_57_CA_A5_3E", "rule"}));
+    configRaw->add(MakeStringArray({"set", "firewall.pc_client_access_5A_F8_57_CA_A5_3E.enabled", "1"}));
+    configRaw->add(MakeStringArray({"set", "firewall.pc_client_access_5A_F8_57_CA_A5_3E.start_date", tomorrowDate}));
+    configRaw->add(MakeStringArray({"set", "firewall.pc_client_access_5A_F8_57_CA_A5_3E.stop_date", dayAfterTomorrowDate}));
+    configRaw->add(MakeStringArray({"set", "firewall.pc_client_access_5A_F8_57_CA_A5_3E.start_time", "23:59:59"}));
+    configRaw->add(MakeStringArray({"set", "firewall.pc_client_access_5A_F8_57_CA_A5_3E.stop_time", "00:00:00"}));
+    configRaw->add(MakeStringArray({"add_list", "firewall.pc_client_access_5A_F8_57_CA_A5_3E.src_mac", "5a:f8:57:ca:a5:3e"}));
+    config->set("config-raw", configRaw);
+
+    std::list<std::string> blockedMacs;
+    Expect(OpenWifi::RESTAPI::ParentalControl::GetBlockedClients(config, blockedMacs), "GetBlockedClients should return true");
+    Expect(blockedMacs.empty(), "Future overnight client-access window should not block client yet");
+}
+
+void TestGetBlockedClientsClientAccessOvernightExpiredWindowInactive() {
+    Poco::DateTime now;
+    std::string twoDaysAgoDate = FormatDate(ShiftDateTime(now, -2));
+    std::string yesterdayDate = FormatDate(ShiftDateTime(now, -1));
+
+    auto config = Poco::JSON::Object::Ptr(new Poco::JSON::Object());
+    auto configRaw = Poco::JSON::Array::Ptr(new Poco::JSON::Array());
+    configRaw->add(MakeStringArray({"set", "firewall.pc_client_access_5A_F8_57_CA_A5_3E", "rule"}));
+    configRaw->add(MakeStringArray({"set", "firewall.pc_client_access_5A_F8_57_CA_A5_3E.enabled", "1"}));
+    configRaw->add(MakeStringArray({"set", "firewall.pc_client_access_5A_F8_57_CA_A5_3E.start_date", twoDaysAgoDate}));
+    configRaw->add(MakeStringArray({"set", "firewall.pc_client_access_5A_F8_57_CA_A5_3E.stop_date", yesterdayDate}));
+    configRaw->add(MakeStringArray({"set", "firewall.pc_client_access_5A_F8_57_CA_A5_3E.start_time", "23:59:59"}));
+    configRaw->add(MakeStringArray({"set", "firewall.pc_client_access_5A_F8_57_CA_A5_3E.stop_time", "00:00:00"}));
+    configRaw->add(MakeStringArray({"add_list", "firewall.pc_client_access_5A_F8_57_CA_A5_3E.src_mac", "5a:f8:57:ca:a5:3e"}));
+    config->set("config-raw", configRaw);
+
+    std::list<std::string> blockedMacs;
+    Expect(OpenWifi::RESTAPI::ParentalControl::GetBlockedClients(config, blockedMacs), "GetBlockedClients should return true");
+    Expect(blockedMacs.empty(), "Expired overnight client-access window should not block client");
 }
 
 const std::vector<std::pair<std::string, std::function<void()>>> kTests = {
@@ -1447,10 +1507,12 @@ const std::vector<std::pair<std::string, std::function<void()>>> kTests = {
     {"ExtractConfigRawSnapshotRejectsNonStringCommandEntry", TestExtractConfigRawSnapshotRejectsNonStringCommandEntry},
     {"GetBlockedClientsClientAccessExpiredRuleSameDay", TestGetBlockedClientsClientAccessExpiredRuleSameDay},
     {"GetBlockedClientsClientAccessActiveRule", TestGetBlockedClientsClientAccessActiveRule},
-    {"GetBlockedClientsGroupScheduleRuleWeekdayMatch", TestGetBlockedClientsGroupScheduleRuleWeekdayMatch},
-    {"GetBlockedClientsGroupScheduleRuleWeekdayMismatch", TestGetBlockedClientsGroupScheduleRuleWeekdayMismatch},
-    {"GetBlockedClientsOverlappingActiveRules", TestGetBlockedClientsOverlappingActiveRules},
+    {"GetBlockedClientsGroupScheduleRuleIgnored", TestGetBlockedClientsGroupScheduleRuleIgnored},
+    {"GetBlockedClientsMixedRulesOnlyClientAccessBlocks", TestGetBlockedClientsMixedRulesOnlyClientAccessBlocks},
     {"GetBlockedClientsDisabledRulesIgnored", TestGetBlockedClientsDisabledRulesIgnored},
+    {"GetBlockedClientsClientAccessOvernightWindowActive", TestGetBlockedClientsClientAccessOvernightWindowActive},
+    {"GetBlockedClientsClientAccessOvernightFutureWindowInactive", TestGetBlockedClientsClientAccessOvernightFutureWindowInactive},
+    {"GetBlockedClientsClientAccessOvernightExpiredWindowInactive", TestGetBlockedClientsClientAccessOvernightExpiredWindowInactive},
 };
 
 } // namespace

--- a/tests/unit/test_parental_control_utils.cpp
+++ b/tests/unit/test_parental_control_utils.cpp
@@ -1263,6 +1263,139 @@ void TestHandleValidateMacResult() {
     verifyMapping(ValidateMacResult::TopologyUnusable, Poco::Net::HTTPResponse::HTTP_INTERNAL_SERVER_ERROR, 1002);
 }
 
+void TestGetBlockedClientsClientAccessExpiredRuleSameDay() {
+    Poco::DateTime now;
+    std::string todayDate = Poco::DateTimeFormatter::format(now, "%Y-%m-%d");
+
+    auto config = Poco::JSON::Object::Ptr(new Poco::JSON::Object());
+    auto configRaw = Poco::JSON::Array::Ptr(new Poco::JSON::Array());
+    configRaw->add(MakeStringArray({"set", "firewall.pc_client_access_6C_C7_EC_DE_10_65", "rule"}));
+    configRaw->add(MakeStringArray({"set", "firewall.pc_client_access_6C_C7_EC_DE_10_65.enabled", "1"}));
+    configRaw->add(MakeStringArray({"set", "firewall.pc_client_access_6C_C7_EC_DE_10_65.start_date", todayDate}));
+    configRaw->add(MakeStringArray({"set", "firewall.pc_client_access_6C_C7_EC_DE_10_65.stop_date", "2099-12-31"}));
+    configRaw->add(MakeStringArray({"set", "firewall.pc_client_access_6C_C7_EC_DE_10_65.start_time", "00:00:00"}));
+    configRaw->add(MakeStringArray({"set", "firewall.pc_client_access_6C_C7_EC_DE_10_65.stop_time", "00:00:01"}));
+    configRaw->add(MakeStringArray({"add_list", "firewall.pc_client_access_6C_C7_EC_DE_10_65.src_mac", "6c:c7:ec:de:10:65"}));
+    config->set("config-raw", configRaw);
+
+    std::list<std::string> blockedMacs;
+    Expect(OpenWifi::RESTAPI::ParentalControl::GetBlockedClients(config, blockedMacs), "GetBlockedClients should return true");
+    Expect(blockedMacs.empty(), "Expired client access rule (00:00:01) should not block client");
+}
+
+void TestGetBlockedClientsClientAccessActiveRule() {
+    Poco::DateTime now;
+    std::string todayDate = Poco::DateTimeFormatter::format(now, "%Y-%m-%d");
+
+    auto config = Poco::JSON::Object::Ptr(new Poco::JSON::Object());
+    auto configRaw = Poco::JSON::Array::Ptr(new Poco::JSON::Array());
+    configRaw->add(MakeStringArray({"set", "firewall.pc_client_access_10_F1_F2_86_11_DC", "rule"}));
+    configRaw->add(MakeStringArray({"set", "firewall.pc_client_access_10_F1_F2_86_11_DC.enabled", "1"}));
+    configRaw->add(MakeStringArray({"set", "firewall.pc_client_access_10_F1_F2_86_11_DC.start_date", todayDate}));
+    configRaw->add(MakeStringArray({"set", "firewall.pc_client_access_10_F1_F2_86_11_DC.stop_date", "2099-12-31"}));
+    configRaw->add(MakeStringArray({"set", "firewall.pc_client_access_10_F1_F2_86_11_DC.start_time", "00:00:00"}));
+    configRaw->add(MakeStringArray({"set", "firewall.pc_client_access_10_F1_F2_86_11_DC.stop_time", "23:59:59"}));
+    configRaw->add(MakeStringArray({"add_list", "firewall.pc_client_access_10_F1_F2_86_11_DC.src_mac", "10:f1:f2:86:11:dc"}));
+    config->set("config-raw", configRaw);
+
+    std::list<std::string> blockedMacs;
+    Expect(OpenWifi::RESTAPI::ParentalControl::GetBlockedClients(config, blockedMacs), "GetBlockedClients should return true");
+    ExpectEq(blockedMacs.size(), static_cast<std::size_t>(1), "Active rule should produce 1 blocked MAC");
+}
+
+void TestGetBlockedClientsGroupScheduleRuleWeekdayMatch() {
+    Poco::DateTime now;
+    static const std::vector<std::string> names = {"Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"};
+    std::string todayWeekday = names[now.dayOfWeek()];
+
+    auto config = Poco::JSON::Object::Ptr(new Poco::JSON::Object());
+    auto configRaw = Poco::JSON::Array::Ptr(new Poco::JSON::Array());
+    configRaw->add(MakeStringArray({"set", "firewall.pc_rule_g1_s1_5a_f8_57_ca_a5_3e", "rule"}));
+    configRaw->add(MakeStringArray({"set", "firewall.pc_rule_g1_s1_5a_f8_57_ca_a5_3e.enabled", "1"}));
+    configRaw->add(MakeStringArray({"set", "firewall.pc_rule_g1_s1_5a_f8_57_ca_a5_3e.weekdays", todayWeekday}));
+    configRaw->add(MakeStringArray({"set", "firewall.pc_rule_g1_s1_5a_f8_57_ca_a5_3e.start_time", "00:00:00"}));
+    configRaw->add(MakeStringArray({"set", "firewall.pc_rule_g1_s1_5a_f8_57_ca_a5_3e.stop_time", "23:59:59"}));
+    configRaw->add(MakeStringArray({"add_list", "firewall.pc_rule_g1_s1_5a_f8_57_ca_a5_3e.src_mac", "5a:f8:57:ca:a5:3e"}));
+    config->set("config-raw", configRaw);
+
+    std::list<std::string> blockedMacs;
+    Expect(OpenWifi::RESTAPI::ParentalControl::GetBlockedClients(config, blockedMacs), "GetBlockedClients should return true");
+    ExpectEq(blockedMacs.size(), static_cast<std::size_t>(1), "Group schedule active today should block client");
+}
+
+void TestGetBlockedClientsGroupScheduleRuleWeekdayMismatch() {
+    Poco::DateTime now;
+    static const std::vector<std::string> names = {"Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"};
+    std::string notTodayWeekday = names[(now.dayOfWeek() + 1) % 7];
+
+    auto config = Poco::JSON::Object::Ptr(new Poco::JSON::Object());
+    auto configRaw = Poco::JSON::Array::Ptr(new Poco::JSON::Array());
+    configRaw->add(MakeStringArray({"set", "firewall.pc_rule_g1_s1_5a_f8_57_ca_a5_3e", "rule"}));
+    configRaw->add(MakeStringArray({"set", "firewall.pc_rule_g1_s1_5a_f8_57_ca_a5_3e.enabled", "1"}));
+    configRaw->add(MakeStringArray({"set", "firewall.pc_rule_g1_s1_5a_f8_57_ca_a5_3e.weekdays", notTodayWeekday}));
+    configRaw->add(MakeStringArray({"set", "firewall.pc_rule_g1_s1_5a_f8_57_ca_a5_3e.start_time", "00:00:00"}));
+    configRaw->add(MakeStringArray({"set", "firewall.pc_rule_g1_s1_5a_f8_57_ca_a5_3e.stop_time", "23:59:59"}));
+    configRaw->add(MakeStringArray({"add_list", "firewall.pc_rule_g1_s1_5a_f8_57_ca_a5_3e.src_mac", "5a:f8:57:ca:a5:3e"}));
+    config->set("config-raw", configRaw);
+
+    std::list<std::string> blockedMacs;
+    Expect(OpenWifi::RESTAPI::ParentalControl::GetBlockedClients(config, blockedMacs), "GetBlockedClients should return true");
+    Expect(blockedMacs.empty(), "Group schedule for another weekday should not block client today");
+}
+
+void TestGetBlockedClientsOverlappingActiveRules() {
+    Poco::DateTime now;
+    std::string todayDate = Poco::DateTimeFormatter::format(now, "%Y-%m-%d");
+    static const std::vector<std::string> names = {"Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"};
+    std::string todayWeekday = names[now.dayOfWeek()];
+
+    auto config = Poco::JSON::Object::Ptr(new Poco::JSON::Object());
+    auto configRaw = Poco::JSON::Array::Ptr(new Poco::JSON::Array());
+
+    // Active client-access rule for MAC 1
+    configRaw->add(MakeStringArray({"set", "firewall.pc_client_access_10_F1_F2_86_11_DC", "rule"}));
+    configRaw->add(MakeStringArray({"set", "firewall.pc_client_access_10_F1_F2_86_11_DC.enabled", "1"}));
+    configRaw->add(MakeStringArray({"set", "firewall.pc_client_access_10_F1_F2_86_11_DC.start_date", todayDate}));
+    configRaw->add(MakeStringArray({"set", "firewall.pc_client_access_10_F1_F2_86_11_DC.stop_date", "2099-12-31"}));
+    configRaw->add(MakeStringArray({"set", "firewall.pc_client_access_10_F1_F2_86_11_DC.start_time", "00:00:00"}));
+    configRaw->add(MakeStringArray({"set", "firewall.pc_client_access_10_F1_F2_86_11_DC.stop_time", "23:59:59"}));
+    configRaw->add(MakeStringArray({"add_list", "firewall.pc_client_access_10_F1_F2_86_11_DC.src_mac", "10:f1:f2:86:11:dc"}));
+
+    // Active group-schedule rule for MAC 2
+    configRaw->add(MakeStringArray({"set", "firewall.pc_rule_g1_s1_5a_f8_57_ca_a5_3e", "rule"}));
+    configRaw->add(MakeStringArray({"set", "firewall.pc_rule_g1_s1_5a_f8_57_ca_a5_3e.enabled", "1"}));
+    configRaw->add(MakeStringArray({"set", "firewall.pc_rule_g1_s1_5a_f8_57_ca_a5_3e.weekdays", todayWeekday}));
+    configRaw->add(MakeStringArray({"set", "firewall.pc_rule_g1_s1_5a_f8_57_ca_a5_3e.start_time", "00:00:00"}));
+    configRaw->add(MakeStringArray({"set", "firewall.pc_rule_g1_s1_5a_f8_57_ca_a5_3e.stop_time", "23:59:59"}));
+    configRaw->add(MakeStringArray({"add_list", "firewall.pc_rule_g1_s1_5a_f8_57_ca_a5_3e.src_mac", "5a:f8:57:ca:a5:3e"}));
+
+    config->set("config-raw", configRaw);
+
+    std::list<std::string> blockedMacs;
+    Expect(OpenWifi::RESTAPI::ParentalControl::GetBlockedClients(config, blockedMacs), "GetBlockedClients should return true");
+    ExpectEq(blockedMacs.size(), static_cast<std::size_t>(2), "Overlapping rules for MAC 1 & MAC 2 should produce 2 blocked MACs");
+}
+
+void TestGetBlockedClientsDisabledRulesIgnored() {
+    Poco::DateTime now;
+    std::string todayDate = Poco::DateTimeFormatter::format(now, "%Y-%m-%d");
+
+    auto config = Poco::JSON::Object::Ptr(new Poco::JSON::Object());
+    auto configRaw = Poco::JSON::Array::Ptr(new Poco::JSON::Array());
+    configRaw->add(MakeStringArray({"set", "firewall.pc_client_access_10_F1_F2_86_11_DC", "rule"}));
+    configRaw->add(MakeStringArray({"set", "firewall.pc_client_access_10_F1_F2_86_11_DC.enabled", "0"}));
+    configRaw->add(MakeStringArray({"set", "firewall.pc_client_access_10_F1_F2_86_11_DC.start_date", todayDate}));
+    configRaw->add(MakeStringArray({"set", "firewall.pc_client_access_10_F1_F2_86_11_DC.stop_date", "2099-12-31"}));
+    configRaw->add(MakeStringArray({"set", "firewall.pc_client_access_10_F1_F2_86_11_DC.start_time", "00:00:00"}));
+    configRaw->add(MakeStringArray({"set", "firewall.pc_client_access_10_F1_F2_86_11_DC.stop_time", "23:59:59"}));
+    configRaw->add(MakeStringArray({"add_list", "firewall.pc_client_access_10_F1_F2_86_11_DC.src_mac", "10:f1:f2:86:11:dc"}));
+    config->set("config-raw", configRaw);
+
+    std::list<std::string> blockedMacs;
+    Expect(OpenWifi::RESTAPI::ParentalControl::GetBlockedClients(config, blockedMacs), "GetBlockedClients should return true");
+    Expect(blockedMacs.empty(), "Disabled rule (enabled=0) should be ignored");
+}
+
 const std::vector<std::pair<std::string, std::function<void()>>> kTests = {
     {"ValidateMacInTopologySuccessHistoricalClient", TestValidateMacInTopologySuccessHistoricalClient},
     {"ValidateMacInTopologySuccessHistoricalDevice", TestValidateMacInTopologySuccessHistoricalDevice},
@@ -1312,6 +1445,12 @@ const std::vector<std::pair<std::string, std::function<void()>>> kTests = {
     {"ExtractConfigRawSnapshotAcceptsValidCommands", TestExtractConfigRawSnapshotAcceptsValidCommands},
     {"ExtractConfigRawSnapshotRejectsInvalidCommandLength", TestExtractConfigRawSnapshotRejectsInvalidCommandLength},
     {"ExtractConfigRawSnapshotRejectsNonStringCommandEntry", TestExtractConfigRawSnapshotRejectsNonStringCommandEntry},
+    {"GetBlockedClientsClientAccessExpiredRuleSameDay", TestGetBlockedClientsClientAccessExpiredRuleSameDay},
+    {"GetBlockedClientsClientAccessActiveRule", TestGetBlockedClientsClientAccessActiveRule},
+    {"GetBlockedClientsGroupScheduleRuleWeekdayMatch", TestGetBlockedClientsGroupScheduleRuleWeekdayMatch},
+    {"GetBlockedClientsGroupScheduleRuleWeekdayMismatch", TestGetBlockedClientsGroupScheduleRuleWeekdayMismatch},
+    {"GetBlockedClientsOverlappingActiveRules", TestGetBlockedClientsOverlappingActiveRules},
+    {"GetBlockedClientsDisabledRulesIgnored", TestGetBlockedClientsDisabledRulesIgnored},
 };
 
 } // namespace

--- a/tests/unit/test_sdk_parental_control.cpp
+++ b/tests/unit/test_sdk_parental_control.cpp
@@ -411,7 +411,7 @@ void TestSetConfigDurationValidation() {
         Expect(response && response->has("ErrorDescription"), "response must contain ErrorDescription");
         ExpectEq(response->getValue<std::string>("ErrorDescription"),
                  std::string("1201: Duration crosses midnight. Duration-based client blocking is limited to the current block day."),
-                 "error text must match ParentalControlDurationCrossesMidnight");
+                 "error text must match DurationCrossesMidnight");
     }
 
     // 3. Invalid MAC address must be rejected with HTTP 400 Bad Request (Error 1019)
@@ -481,7 +481,7 @@ void TestSetConfigDurationValidation() {
         Expect(response && response->has("ErrorDescription"), "response must contain ErrorDescription");
         ExpectEq(response->getValue<std::string>("ErrorDescription"),
                  std::string("1204: Access must be 'allow' or 'deny'."),
-                 "error text must match ParentalControlInvalidAccess");
+                 "error text must match InvalidAccess");
     }
 
     // 5. Duration on 'allow' must be rejected with HTTP 400 Bad Request (Error 1202)
@@ -517,7 +517,7 @@ void TestSetConfigDurationValidation() {
         Expect(response && response->has("ErrorDescription"), "response must contain ErrorDescription");
         ExpectEq(response->getValue<std::string>("ErrorDescription"),
                  std::string("1202: Duration is not allowed when access is set to 'allow'."),
-                 "error text must match ParentalControlDurationNotAllowedForAllow");
+                 "error text must match DurationNotAllowedForAllow");
     }
 
     // 6. Invalid duration minutes (< 1) must be rejected with HTTP 400 Bad Request (Error 1203)
@@ -553,7 +553,7 @@ void TestSetConfigDurationValidation() {
         Expect(response && response->has("ErrorDescription"), "response must contain ErrorDescription");
         ExpectEq(response->getValue<std::string>("ErrorDescription"),
                  std::string("1203: Duration must be a positive integer greater than or equal to 1."),
-                 "error text must match ParentalControlInvalidDuration");
+                 "error text must match InvalidDuration");
      }
 
     // 7. Access 'allow' with duration: null must be rejected with HTTP 400 (Error 1202)
@@ -589,7 +589,7 @@ void TestSetConfigDurationValidation() {
         Expect(response && response->has("ErrorDescription"), "response must contain ErrorDescription");
         ExpectEq(response->getValue<std::string>("ErrorDescription"),
                  std::string("1202: Duration is not allowed when access is set to 'allow'."),
-                 "error text must match ParentalControlDurationNotAllowedForAllow");
+                 "error text must match DurationNotAllowedForAllow");
     }
 }
 

--- a/tests/unit/test_sdk_parental_control.cpp
+++ b/tests/unit/test_sdk_parental_control.cpp
@@ -593,6 +593,107 @@ void TestSetConfigDurationValidation() {
     }
 }
 
+void TestSetConfigTwoPassValidation() {
+    // Case 1: Send multiple clients where the last client has an invalid MAC.
+    // Assert response is 400, and assert no downstream parental-control client-access calls are made.
+    {
+        ResetState();
+        auto deviceObj = Poco::makeShared<Poco::JSON::Object>();
+        auto configObj = Poco::makeShared<Poco::JSON::Object>();
+        deviceObj->set("configuration", configObj);
+        deviceObj->set("config-raw", Poco::makeShared<Poco::JSON::Array>());
+        g_state.nextObject = deviceObj;
+        g_state.nextStatus = Poco::Net::HTTPResponse::HTTP_OK;
+
+        OpenWifi::ProvObjects::SubscriberDeviceList subDevices;
+        OpenWifi::ProvObjects::SubscriberDevice dev;
+        dev.deviceGroup = "olg";
+        dev.serialNumber = "112233445566";
+        subDevices.subscriberDevices.push_back(dev);
+
+        auto body = Poco::makeShared<Poco::JSON::Object>();
+        auto clientArr = Poco::makeShared<Poco::JSON::Array>();
+        
+        // Client 1: Valid MAC
+        auto entry1 = Poco::makeShared<Poco::JSON::Object>();
+        entry1->set("mac", "11:22:33:44:55:66");
+        entry1->set("access", "deny");
+        clientArr->add(entry1);
+
+        // Client 2: Invalid MAC
+        auto entry2 = Poco::makeShared<Poco::JSON::Object>();
+        entry2->set("mac", "invalid-mac-address");
+        entry2->set("access", "deny");
+        clientArr->add(entry2);
+
+        body->set("client", clientArr);
+
+        Poco::Net::HTTPResponse::HTTPStatus status = Poco::Net::HTTPResponse::HTTP_INTERNAL_SERVER_ERROR;
+        Poco::JSON::Object::Ptr response;
+        bool success = OpenWifi::SDK::GW::Device::SetConfig(nullptr, body, subDevices, "112233445566", "sub-123", status, response);
+        
+        Expect(!success, "SetConfig should fail because of the invalid MAC in the second client");
+        ExpectEq(status, Poco::Net::HTTPResponse::HTTP_BAD_REQUEST, "status should be 400");
+        Expect(response && response->has("ErrorDescription"), "response must contain ErrorDescription");
+        ExpectEq(response->getValue<std::string>("ErrorDescription"),
+                 std::string("1019: Invalid MAC address."),
+                 "error text must match InvalidMacAddress");
+        
+        // Since GetConfig sets the endpoint to /api/v1/device/...
+        // If any client-access POST or DELETE call had been made, lastEndpoint would contain "client-access".
+        // Assert that lastEndpoint does NOT contain "client-access", verifying no calls were made.
+        Expect(g_state.lastEndpoint.find("client-access") == std::string::npos, 
+               "No downstream client-access calls should have been made due to early validation failure");
+    }
+
+    // Case 2: Success case confirming valid multi-client input still executes calls normally.
+    {
+        ResetState();
+        auto deviceObj = Poco::makeShared<Poco::JSON::Object>();
+        auto configObj = Poco::makeShared<Poco::JSON::Object>();
+        deviceObj->set("configuration", configObj);
+        deviceObj->set("config-raw", Poco::makeShared<Poco::JSON::Array>());
+        g_state.nextObject = deviceObj;
+        g_state.nextStatus = Poco::Net::HTTPResponse::HTTP_OK;
+
+        OpenWifi::ProvObjects::SubscriberDeviceList subDevices;
+        OpenWifi::ProvObjects::SubscriberDevice dev;
+        dev.deviceGroup = "olg";
+        dev.serialNumber = "112233445566";
+        subDevices.subscriberDevices.push_back(dev);
+
+        auto body = Poco::makeShared<Poco::JSON::Object>();
+        auto clientArr = Poco::makeShared<Poco::JSON::Array>();
+        
+        // Client 1: Valid MAC
+        auto entry1 = Poco::makeShared<Poco::JSON::Object>();
+        entry1->set("mac", "11:22:33:44:55:66");
+        entry1->set("access", "deny");
+        clientArr->add(entry1);
+
+        // Client 2: Valid MAC
+        auto entry2 = Poco::makeShared<Poco::JSON::Object>();
+        entry2->set("mac", "aa:bb:cc:dd:ee:ff");
+        entry2->set("access", "deny");
+        clientArr->add(entry2);
+
+        body->set("client", clientArr);
+
+        Poco::Net::HTTPResponse::HTTPStatus status = Poco::Net::HTTPResponse::HTTP_INTERNAL_SERVER_ERROR;
+        Poco::JSON::Object::Ptr response;
+        bool success = OpenWifi::SDK::GW::Device::SetConfig(nullptr, body, subDevices, "112233445566", "sub-123", status, response);
+        
+        Expect(success, "SetConfig with multiple valid clients should succeed");
+        ExpectEq(status, Poco::Net::HTTPResponse::HTTP_OK, "status should be 200");
+        
+        // Verify that downstream client-access calls were actually executed.
+        // The last endpoint processed should be the client-access endpoint for aa:bb:cc:dd:ee:ff (Client 2).
+        Expect(g_state.lastEndpoint.find("client-access") != std::string::npos,
+               "Downstream client-access calls should have been executed");
+        ExpectEq(g_state.lastMethod, std::string("POST"), "Last call should have been a POST to client-access");
+    }
+}
+
 const std::vector<std::pair<std::string, std::function<void()>>> kTests = {
     {"GetGroupDevicesSuccess", TestGetGroupDevicesSuccess},
     {"CreateGroupDeviceSuccess", TestCreateGroupDeviceSuccess},
@@ -608,6 +709,7 @@ const std::vector<std::pair<std::string, std::function<void()>>> kTests = {
     {"Non200StatusFailsWrapper", TestNon200StatusFailsWrapper},
     {"BearerTokenIsNotForwardedFromClient", TestBearerTokenIsNotForwardedFromClient},
     {"SetConfigDurationValidation", TestSetConfigDurationValidation},
+    {"SetConfigTwoPassValidation", TestSetConfigTwoPassValidation},
 };
 
 

--- a/tests/unit/test_sdk_parental_control.cpp
+++ b/tests/unit/test_sdk_parental_control.cpp
@@ -17,6 +17,7 @@
 #include "Poco/Logger.h"
 #include "framework/RESTAPI_GenericServerAccounting.h"
 #include "sdks/SDK_parental_control.h"
+#include "sdks/SDK_gw.h"
 #include "framework/OpenAPIRequests.h"
 
 namespace {
@@ -151,6 +152,7 @@ OpenAPIRequestDelete::Do(Poco::JSON::Object::Ptr &responseObject, std::string &r
 } // namespace OpenWifi
 
 #include "../../src/sdks/SDK_parental_control.cpp"
+#include "../../src/sdks/SDK_gw.cpp"
 
 namespace {
 
@@ -339,6 +341,258 @@ void TestBearerTokenIsNotForwardedFromClient() {
     ExpectEq(g_state.lastBearerToken, std::string(""), "bearer token should not be forwarded");
 }
 
+void TestSetConfigDurationValidation() {
+    // 1. Same-day duration is allowed if it does not cross midnight (safeDuration minutes)
+    {
+        ResetState();
+        Poco::DateTime now;
+        int remainingMinutes = (23 - now.hour()) * 60 + (59 - now.minute());
+        if (remainingMinutes > 5) {
+            auto deviceObj = Poco::makeShared<Poco::JSON::Object>();
+            auto configObj = Poco::makeShared<Poco::JSON::Object>();
+            deviceObj->set("configuration", configObj);
+            deviceObj->set("config-raw", Poco::makeShared<Poco::JSON::Array>());
+            g_state.nextObject = deviceObj;
+            g_state.nextStatus = Poco::Net::HTTPResponse::HTTP_OK;
+
+            OpenWifi::ProvObjects::SubscriberDeviceList subDevices;
+            OpenWifi::ProvObjects::SubscriberDevice dev;
+            dev.deviceGroup = "olg";
+            dev.serialNumber = "112233445566";
+            subDevices.subscriberDevices.push_back(dev);
+
+            auto body = Poco::makeShared<Poco::JSON::Object>();
+            auto clientArr = Poco::makeShared<Poco::JSON::Array>();
+            auto entry = Poco::makeShared<Poco::JSON::Object>();
+            entry->set("mac", "aa:bb:cc:dd:ee:ff");
+            entry->set("access", "deny");
+            entry->set("duration", 2); // 2 minutes (safely less than remainingMinutes)
+            clientArr->add(entry);
+            body->set("client", clientArr);
+
+            Poco::Net::HTTPResponse::HTTPStatus status = Poco::Net::HTTPResponse::HTTP_INTERNAL_SERVER_ERROR;
+            Poco::JSON::Object::Ptr response;
+            bool success = OpenWifi::SDK::GW::Device::SetConfig(nullptr, body, subDevices, "112233445566", "sub-123", status, response);
+            Expect(success, "SetConfig with same-day duration should succeed");
+            ExpectEq(status, Poco::Net::HTTPResponse::HTTP_OK, "status should be 200");
+        }
+    }
+
+    // 2. Overnight / >24h duration (1500 mins) must be rejected with HTTP 400 Bad Request (Error 1201)
+    {
+        ResetState();
+        auto deviceObj = Poco::makeShared<Poco::JSON::Object>();
+        auto configObj = Poco::makeShared<Poco::JSON::Object>();
+        deviceObj->set("configuration", configObj);
+        deviceObj->set("config-raw", Poco::makeShared<Poco::JSON::Array>());
+        g_state.nextObject = deviceObj;
+        g_state.nextStatus = Poco::Net::HTTPResponse::HTTP_OK;
+
+        OpenWifi::ProvObjects::SubscriberDeviceList subDevices;
+        OpenWifi::ProvObjects::SubscriberDevice dev;
+        dev.deviceGroup = "olg";
+        dev.serialNumber = "112233445566";
+        subDevices.subscriberDevices.push_back(dev);
+
+        auto body = Poco::makeShared<Poco::JSON::Object>();
+        auto clientArr = Poco::makeShared<Poco::JSON::Array>();
+        auto entry = Poco::makeShared<Poco::JSON::Object>();
+        entry->set("mac", "aa:bb:cc:dd:ee:ff");
+        entry->set("access", "deny");
+        entry->set("duration", 1500); // 1500 minutes (25 hours) - always crosses midnight
+        clientArr->add(entry);
+        body->set("client", clientArr);
+
+        Poco::Net::HTTPResponse::HTTPStatus status = Poco::Net::HTTPResponse::HTTP_INTERNAL_SERVER_ERROR;
+        Poco::JSON::Object::Ptr response;
+        bool success = OpenWifi::SDK::GW::Device::SetConfig(nullptr, body, subDevices, "112233445566", "sub-123", status, response);
+        Expect(!success, "SetConfig with overnight/24h+ duration should fail");
+        ExpectEq(status, Poco::Net::HTTPResponse::HTTP_BAD_REQUEST, "status should be 400");
+        Expect(response && response->has("ErrorDescription"), "response must contain ErrorDescription");
+        ExpectEq(response->getValue<std::string>("ErrorDescription"),
+                 std::string("1201: Duration crosses midnight. Duration-based client blocking is limited to the current block day."),
+                 "error text must match ParentalControlDurationCrossesMidnight");
+    }
+
+    // 3. Invalid MAC address must be rejected with HTTP 400 Bad Request (Error 1019)
+    {
+        ResetState();
+        auto deviceObj = Poco::makeShared<Poco::JSON::Object>();
+        auto configObj = Poco::makeShared<Poco::JSON::Object>();
+        deviceObj->set("configuration", configObj);
+        deviceObj->set("config-raw", Poco::makeShared<Poco::JSON::Array>());
+        g_state.nextObject = deviceObj;
+        g_state.nextStatus = Poco::Net::HTTPResponse::HTTP_OK;
+
+        OpenWifi::ProvObjects::SubscriberDeviceList subDevices;
+        OpenWifi::ProvObjects::SubscriberDevice dev;
+        dev.deviceGroup = "olg";
+        dev.serialNumber = "112233445566";
+        subDevices.subscriberDevices.push_back(dev);
+
+        auto body = Poco::makeShared<Poco::JSON::Object>();
+        auto clientArr = Poco::makeShared<Poco::JSON::Array>();
+        auto entry = Poco::makeShared<Poco::JSON::Object>();
+        entry->set("mac", "invalid-mac-address-here");
+        entry->set("access", "deny");
+        clientArr->add(entry);
+        body->set("client", clientArr);
+
+        Poco::Net::HTTPResponse::HTTPStatus status = Poco::Net::HTTPResponse::HTTP_INTERNAL_SERVER_ERROR;
+        Poco::JSON::Object::Ptr response;
+        bool success = OpenWifi::SDK::GW::Device::SetConfig(nullptr, body, subDevices, "112233445566", "sub-123", status, response);
+        Expect(!success, "SetConfig with invalid mac should fail");
+        ExpectEq(status, Poco::Net::HTTPResponse::HTTP_BAD_REQUEST, "status should be 400");
+        Expect(response && response->has("ErrorDescription"), "response must contain ErrorDescription");
+        ExpectEq(response->getValue<std::string>("ErrorDescription"),
+                 std::string("1019: Invalid MAC address."),
+                 "error text must match InvalidMacAddress");
+    }
+
+    // 4. Invalid access mode must be rejected with HTTP 400 Bad Request (Error 1204)
+    {
+        ResetState();
+        auto deviceObj = Poco::makeShared<Poco::JSON::Object>();
+        auto configObj = Poco::makeShared<Poco::JSON::Object>();
+        deviceObj->set("configuration", configObj);
+        deviceObj->set("config-raw", Poco::makeShared<Poco::JSON::Array>());
+        g_state.nextObject = deviceObj;
+        g_state.nextStatus = Poco::Net::HTTPResponse::HTTP_OK;
+
+        OpenWifi::ProvObjects::SubscriberDeviceList subDevices;
+        OpenWifi::ProvObjects::SubscriberDevice dev;
+        dev.deviceGroup = "olg";
+        dev.serialNumber = "112233445566";
+        subDevices.subscriberDevices.push_back(dev);
+
+        auto body = Poco::makeShared<Poco::JSON::Object>();
+        auto clientArr = Poco::makeShared<Poco::JSON::Array>();
+        auto entry = Poco::makeShared<Poco::JSON::Object>();
+        entry->set("mac", "aa:bb:cc:dd:ee:ff");
+        entry->set("access", "invalid_mode");
+        clientArr->add(entry);
+        body->set("client", clientArr);
+
+        Poco::Net::HTTPResponse::HTTPStatus status = Poco::Net::HTTPResponse::HTTP_INTERNAL_SERVER_ERROR;
+        Poco::JSON::Object::Ptr response;
+        bool success = OpenWifi::SDK::GW::Device::SetConfig(nullptr, body, subDevices, "112233445566", "sub-123", status, response);
+        Expect(!success, "SetConfig with invalid access should fail");
+        ExpectEq(status, Poco::Net::HTTPResponse::HTTP_BAD_REQUEST, "status should be 400");
+        Expect(response && response->has("ErrorDescription"), "response must contain ErrorDescription");
+        ExpectEq(response->getValue<std::string>("ErrorDescription"),
+                 std::string("1204: Access must be 'allow' or 'deny'."),
+                 "error text must match ParentalControlInvalidAccess");
+    }
+
+    // 5. Duration on 'allow' must be rejected with HTTP 400 Bad Request (Error 1202)
+    {
+        ResetState();
+        auto deviceObj = Poco::makeShared<Poco::JSON::Object>();
+        auto configObj = Poco::makeShared<Poco::JSON::Object>();
+        deviceObj->set("configuration", configObj);
+        deviceObj->set("config-raw", Poco::makeShared<Poco::JSON::Array>());
+        g_state.nextObject = deviceObj;
+        g_state.nextStatus = Poco::Net::HTTPResponse::HTTP_OK;
+
+        OpenWifi::ProvObjects::SubscriberDeviceList subDevices;
+        OpenWifi::ProvObjects::SubscriberDevice dev;
+        dev.deviceGroup = "olg";
+        dev.serialNumber = "112233445566";
+        subDevices.subscriberDevices.push_back(dev);
+
+        auto body = Poco::makeShared<Poco::JSON::Object>();
+        auto clientArr = Poco::makeShared<Poco::JSON::Array>();
+        auto entry = Poco::makeShared<Poco::JSON::Object>();
+        entry->set("mac", "aa:bb:cc:dd:ee:ff");
+        entry->set("access", "allow");
+        entry->set("duration", 30);
+        clientArr->add(entry);
+        body->set("client", clientArr);
+
+        Poco::Net::HTTPResponse::HTTPStatus status = Poco::Net::HTTPResponse::HTTP_INTERNAL_SERVER_ERROR;
+        Poco::JSON::Object::Ptr response;
+        bool success = OpenWifi::SDK::GW::Device::SetConfig(nullptr, body, subDevices, "112233445566", "sub-123", status, response);
+        Expect(!success, "SetConfig with duration on allow should fail");
+        ExpectEq(status, Poco::Net::HTTPResponse::HTTP_BAD_REQUEST, "status should be 400");
+        Expect(response && response->has("ErrorDescription"), "response must contain ErrorDescription");
+        ExpectEq(response->getValue<std::string>("ErrorDescription"),
+                 std::string("1202: Duration is not allowed when access is set to 'allow'."),
+                 "error text must match ParentalControlDurationNotAllowedForAllow");
+    }
+
+    // 6. Invalid duration minutes (< 1) must be rejected with HTTP 400 Bad Request (Error 1203)
+    {
+        ResetState();
+        auto deviceObj = Poco::makeShared<Poco::JSON::Object>();
+        auto configObj = Poco::makeShared<Poco::JSON::Object>();
+        deviceObj->set("configuration", configObj);
+        deviceObj->set("config-raw", Poco::makeShared<Poco::JSON::Array>());
+        g_state.nextObject = deviceObj;
+        g_state.nextStatus = Poco::Net::HTTPResponse::HTTP_OK;
+
+        OpenWifi::ProvObjects::SubscriberDeviceList subDevices;
+        OpenWifi::ProvObjects::SubscriberDevice dev;
+        dev.deviceGroup = "olg";
+        dev.serialNumber = "112233445566";
+        subDevices.subscriberDevices.push_back(dev);
+
+        auto body = Poco::makeShared<Poco::JSON::Object>();
+        auto clientArr = Poco::makeShared<Poco::JSON::Array>();
+        auto entry = Poco::makeShared<Poco::JSON::Object>();
+        entry->set("mac", "aa:bb:cc:dd:ee:ff");
+        entry->set("access", "deny");
+        entry->set("duration", 0);
+        clientArr->add(entry);
+        body->set("client", clientArr);
+
+        Poco::Net::HTTPResponse::HTTPStatus status = Poco::Net::HTTPResponse::HTTP_INTERNAL_SERVER_ERROR;
+        Poco::JSON::Object::Ptr response;
+        bool success = OpenWifi::SDK::GW::Device::SetConfig(nullptr, body, subDevices, "112233445566", "sub-123", status, response);
+        Expect(!success, "SetConfig with invalid duration should fail");
+        ExpectEq(status, Poco::Net::HTTPResponse::HTTP_BAD_REQUEST, "status should be 400");
+        Expect(response && response->has("ErrorDescription"), "response must contain ErrorDescription");
+        ExpectEq(response->getValue<std::string>("ErrorDescription"),
+                 std::string("1203: Duration must be a positive integer greater than or equal to 1."),
+                 "error text must match ParentalControlInvalidDuration");
+     }
+
+    // 7. Access 'allow' with duration: null must be rejected with HTTP 400 (Error 1202)
+    {
+        ResetState();
+        auto deviceObj = Poco::makeShared<Poco::JSON::Object>();
+        auto configObj = Poco::makeShared<Poco::JSON::Object>();
+        deviceObj->set("configuration", configObj);
+        deviceObj->set("config-raw", Poco::makeShared<Poco::JSON::Array>());
+        g_state.nextObject = deviceObj;
+        g_state.nextStatus = Poco::Net::HTTPResponse::HTTP_OK;
+
+        OpenWifi::ProvObjects::SubscriberDeviceList subDevices;
+        OpenWifi::ProvObjects::SubscriberDevice dev;
+        dev.deviceGroup = "olg";
+        dev.serialNumber = "112233445566";
+        subDevices.subscriberDevices.push_back(dev);
+
+        auto body = Poco::makeShared<Poco::JSON::Object>();
+        auto clientArr = Poco::makeShared<Poco::JSON::Array>();
+        auto entry = Poco::makeShared<Poco::JSON::Object>();
+        entry->set("mac", "aa:bb:cc:dd:ee:ff");
+        entry->set("access", "allow");
+        entry->set("duration", Poco::Dynamic::Var());
+        clientArr->add(entry);
+        body->set("client", clientArr);
+
+        Poco::Net::HTTPResponse::HTTPStatus status = Poco::Net::HTTPResponse::HTTP_INTERNAL_SERVER_ERROR;
+        Poco::JSON::Object::Ptr response;
+        bool success = OpenWifi::SDK::GW::Device::SetConfig(nullptr, body, subDevices, "112233445566", "sub-123", status, response);
+        Expect(!success, "SetConfig with duration: null on allow should fail");
+        ExpectEq(status, Poco::Net::HTTPResponse::HTTP_BAD_REQUEST, "status should be 400");
+        Expect(response && response->has("ErrorDescription"), "response must contain ErrorDescription");
+        ExpectEq(response->getValue<std::string>("ErrorDescription"),
+                 std::string("1202: Duration is not allowed when access is set to 'allow'."),
+                 "error text must match ParentalControlDurationNotAllowedForAllow");
+    }
+}
+
 const std::vector<std::pair<std::string, std::function<void()>>> kTests = {
     {"GetGroupDevicesSuccess", TestGetGroupDevicesSuccess},
     {"CreateGroupDeviceSuccess", TestCreateGroupDeviceSuccess},
@@ -353,6 +607,7 @@ const std::vector<std::pair<std::string, std::function<void()>>> kTests = {
     {"ReplaceGroupSchedulesSuccess", TestReplaceGroupSchedulesSuccess},
     {"Non200StatusFailsWrapper", TestNon200StatusFailsWrapper},
     {"BearerTokenIsNotForwardedFromClient", TestBearerTokenIsNotForwardedFromClient},
+    {"SetConfigDurationValidation", TestSetConfigDurationValidation},
 };
 
 
@@ -407,4 +662,64 @@ namespace OpenWifi {
 
 namespace OpenWifi::Utils {
     std::string FormatIPv6(const std::string &addr) { return addr; }
+
+    std::string StripMac(const std::string &value) {
+        std::string result;
+        for (char c : value) {
+            if (c == ':' || c == '-' || c == '.') {
+                continue;
+            }
+            result.push_back(static_cast<char>(std::toupper(static_cast<unsigned char>(c))));
+        }
+        return result;
+    }
+
+    bool IsNormalizedMac(const std::string &value) {
+        if (value.size() != 12) {
+            return false;
+        }
+        return std::all_of(value.begin(), value.end(), [](unsigned char c) { return std::isxdigit(c) != 0; });
+    }
+
+    std::string MacWithColons(const std::string &value) {
+        if (!IsNormalizedMac(value)) {
+            return value;
+        }
+        std::ostringstream os;
+        for (std::size_t i = 0; i < value.size(); i += 2) {
+            if (i != 0) {
+                os << ':';
+            }
+            os << value.substr(i, 2);
+        }
+        return os.str();
+    }
+
+    bool NormalizeMac(std::string &mac) {
+        std::string normalized = StripMac(mac);
+        if (!IsNormalizedMac(normalized)) {
+            return false;
+        }
+        mac = normalized;
+        return true;
+    }
+
+    std::string SerialToMAC(const std::string &serial) { return MacWithColons(StripMac(serial)); }
+}
+
+namespace OpenWifi {
+    bool ConfigMaker::BuildMeshConfig(const Poco::JSON::Object::Ptr &inputConfig, Poco::JSON::Object::Ptr &meshConfig) {
+        meshConfig = inputConfig;
+        return true;
+    }
+}
+
+namespace OpenWifi::RESTAPI::ParentalControl {
+    bool ExtractConfigRawSnapshot(const Poco::JSON::Object::Ptr &response, Poco::JSON::Array::Ptr &configRaw, bool required) {
+        if (response && response->has("config-raw")) {
+            configRaw = response->getArray("config-raw");
+            return true;
+        }
+        return !required;
+    }
 }


### PR DESCRIPTION
#63 
### Problem Fixed

UserPortal did not yet support the new client-access pause/unpause flow through the subscriber `action=configure` endpoint, nor did it evaluate active client rules in real time within topology responses.

Before this change:

- **Missing `action=configure` integration:** subscriber client block/unblock requests could not be translated into downstream `mango-parental-control` client-access API calls.
- **Unaligned firewall configuration:** UserPortal attempted to build local firewall rules instead of synchronizing the downstream parental-control service’s merged `config-raw` snapshot onto the gateway device.
- **Incomplete topology `blocked` tagging:** topology evaluation did not account for active date-bounded client-access rules reflected in gateway parental-control `config-raw`.

This PR resolves those integration gaps and aligns UserPortal with the current `mango-parental-control` architecture.

## Key Changes

### 1. Configure action support for client-access pause/unpause

Updates `POST /api/v1/action?action=configure` in `RESTAPI_action_handler.cpp` and `SDK_gw.cpp` (`ApplyClientAccessChanges`):

- `access=deny`: converts subscriber duration (in minutes) into `start_date`, `stop_date`, `start_time`, and `stop_time` strings and calls downstream `CreateClientAccess`.
- If `duration` is omitted, this PR keeps the current-phase behavior of blocking until the end of the current block day (`23:59:59`). Forever-block behavior for omitted `duration` is intentionally not included in this PR and is planned for a follow-up phase.
- `access=allow`: calls downstream `DeleteClientAccess` to remove the client block rule.
- For `access=deny` with `duration`, UserPortal follows the current downstream `mango-parental-control` single-intended-block-day contract: `stop_time` is derived from `now + duration`, `stop_date` is set to the next calendar date as required by the firewall request shape, and any duration that crosses midnight is rejected with `400 Bad Request`.

### 2. Downstream `config-raw` synchronization

UserPortal now relies on downstream `mango-parental-control` as the source of truth for gateway parental-control firewall rules.

The flow now:

- extracts the returned `config-raw` snapshot from the downstream response
- overwrites the `config-raw` section of the gateway device configuration with that returned snapshot
- clears `config-raw` if no active parental-control rules remain

### 3. Inter-service microservice auth fix

Updates `FetchBoardTopology` in `RESTAPI_parental_control_utils.cpp` to pass `nullptr` for the client REST API handler when calling `SDK::Topology::Get`.

This ensures internal requests send microservice `X-API-KEY` authentication headers instead of forwarding client Bearer tokens.

### 4. Real-time topology blocked-state evaluation

Implements shared evaluation logic in `RESTAPI_parental_control_utils.cpp` and `RESTAPI_topology_handler.cpp` for active client-access firewall rules reflected in gateway parental-control `config-raw`.

This includes:
- active-window evaluation for date-bounded client-access rules using the current server timestamp
- case-insensitive client tagging so `"blocked": "1"` / `"0"` is set consistently for both connected clients and historical clients

This updates topology blocked-state handling for:
- `nodes[].aps[].clients[]`
- `historicalClients` (created by converting and tagging the legacy `historicalDevices` list returned by the topology service)


This PR intentionally limits topology `blocked` evaluation to active date-bounded client-access rules. Group-schedule-derived topology blocking is planned for next phase.

### 5. Mesh-device config separation

Updates `ConfigMaker.cpp` to strip gateway-only `config-raw` parental-control sections when building configuration payloads for mesh AP devices.

### 6. OpenAPI specification and unit test sync

- `openapi/userportal.yaml`:
  - documents the optional `duration` field in `ClientAccessChange`
  - updates `/action?action=configure` description
  - updates `/topology` description to reflect blocked-state evaluation
  - adds the optional `config-raw` field to the `Group` schema to align with Go microservice responses
  - defines the `EmptySuccess` response schema and migrates all six `DELETE` endpoints to use it, accurately reflecting that successful `DELETE` operations return an empty response body on the wire rather than a `Success` JSON object


- `tests/unit/test_parental_control_utils.cpp`:
  - adds unit coverage for active/expired client-access rules
  - adds unit coverage for overlapping rules and disabled rules

### 7. CORS and API schema consistency improvements
- **Framework CORS fix (`src/framework/RESTAPI_Handler.h`)**: Refactored `ForwardErrorResponse` to use `PrepareResponse(callStatus)`. This fixes browser/Swagger CORS blocks when proxying non-200 error responses from downstream microservices, while standardizing on chunked encoding.


## Current Phase Scope

This PR is limited to the UserPortal side of the current client-access pause/unpause integration.

Included in this PR:

- `action=configure` mapping for client `access=deny` / `access=allow`
- downstream `mango-parental-control` client-access API calls
- downstream parental-control `config-raw` snapshot synchronization
- topology `"blocked"` status for active date-bounded client-access rules (evaluated for connected clients and converted legacy historical devices)
- same-day duration validation and crossing-midnight rejection
- specific subscriber-facing validation errors for invalid client-access configure inputs

Not included in this PR:

- topology `blocked` status derived from group-schedule rules
- forever-block behavior when `duration` is omitted
- updated parental-control/UserPortal design for no-duration forever blocks
- multi-day duration support or automatic splitting of blocks across midnight

Those items are planned for the next phase.

## Test Evidence

Validated through local testing of the subscriber configure flow and topology behavior.

Validation confirmed:
- the new configure client block/unblock flow successfully calls the downstream parental-control client-access API
- downstream parental-control `config-raw` snapshots are synchronized correctly into the gateway config path
- topology returns updated `blocked` status (`"0"` / `"1"`) for clients based on active client-access rules reflected in gateway parental-control `config-raw`
- topology blocked-state evaluation works for active, expired, disabled, and overnight client-access windows
- topology blocked-state evaluation intentionally ignores group-schedule-shaped rules in this PR; mixed-rule coverage confirms only active client-access rules mark clients blocked
- configure validation returns specific `400 Bad Request` errors for invalid MAC, invalid access, invalid duration, duration with `access=allow`, and crossing-midnight duration

## Reviewer Guidance

Please review this PR against the intended UserPortal integration behavior for the downstream parental-control client-access flow.

Primary review focus areas:
- verify that `action=configure` correctly maps subscriber client block/unblock requests to downstream client-access API calls
- verify that duration handling matches the current single-intended-block-day client-access contract
- verify that crossing-midnight duration requests are rejected instead of converted into invalid downstream windows
- verify that gateway `config-raw` synchronization now uses the downstream parental-control snapshot as intended
- verify that topology blocked-state evaluation correctly reflects active client-access rules from gateway parental-control `config-raw`
- note that group-schedule topology blocking and `blocked_until` are intentionally deferred to the next phase/PR
- verify that mesh-device config generation does not propagate gateway-only parental-control `config-raw`
- verify that the OpenAPI updates match the implemented configure and topology behavior

Closes #34